### PR TITLE
initial commit for geo commands

### DIFF
--- a/lib/valkey/commands.rb
+++ b/lib/valkey/commands.rb
@@ -6,6 +6,7 @@ require "valkey/commands/server_commands"
 require "valkey/commands/generic_commands"
 require "valkey/commands/bitmap_commands"
 require "valkey/commands/list_commands"
+require "valkey/commands/geo_commands"
 
 class Valkey
   # Valkey commands module
@@ -27,6 +28,7 @@ class Valkey
     include GenericCommands
     include BitmapCommands
     include ListCommands
+    include GeoCommands
 
     # there are a few commands that are not implemented by design
     #

--- a/lib/valkey/commands/geo_commands.rb
+++ b/lib/valkey/commands/geo_commands.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class Valkey
+  module Commands
+    # This module contains commands on geospatial operations.
+    #
+    # @see https://valkey.io/commands/#geo
+    #
+    module GeoCommands
+      # Add one or more geospatial items (longitude, latitude, name) to a key.
+      #
+      # @example
+      #   valkey.geoadd("locations", 13.361389, 38.115556, "Palermo", 15.087269, 37.502669, "Catania")
+      #     # => Integer (number of elements added)
+      #
+      # @param [String] key the name of the key
+      # @param [Array<String, Float>] members one or more longitude, latitude, and name triplets
+      # @return [Integer] the number of elements added
+      def geoadd(key, *members)
+        send_command(RequestType::GEO_ADD, [key, *members])
+      end
+
+      # Retrieve the positions (longitude, latitude) of one or more elements.
+      #
+      # @example
+      #   valkey.geopos("locations", "Palermo", "Catania")
+      #     # => [[13.361389, 38.115556], [15.087269, 37.502669]]
+      #
+      # @param [String] key the name of the key
+      # @param [Array<String>] members one or more member names to get positions for
+      # @return [Array<Array<Float, Float>, nil>] list of positions or nil for missing members
+      def geopos(key, *members)
+        send_command(RequestType::GEO_POS, [key, *members])
+      end
+    end
+  end
+end

--- a/test/lint/geo_commands.rb
+++ b/test/lint/geo_commands.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Lint
+  module GeoCommands
+    def test_geoadd_and_geopos
+      r.geoadd("geo_key", 13.361389, 38.115556, "Palermo")
+      r.geoadd("geo_key", 15.087269, 37.502669, "Catania")
+
+      positions = r.geopos("geo_key", "Palermo", "Catania")
+
+      expected = [[13.361389, 38.115556], [15.087269, 37.502669]]
+
+      assert_equal 2, positions.length
+      positions.each_with_index do |pos, i|
+        pos.each_with_index do |coord, j|
+          assert_in_delta expected[i][j], coord, 0.00001
+        end
+      end
+    end
+  end
+end

--- a/test/valkey/geo_commands_test.rb
+++ b/test/valkey/geo_commands_test.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestCommandsOnString < Minitest::Test
+  include Helper::Client
+  include Lint::GeoCommands
+end


### PR DESCRIPTION
# Add Initial Support for GEO Commands

## Summary

This PR introduces the initial implementation of `geoadd` and `geopos` commands in the `Valkey::Commands::GeoCommands` module.

These commands allow interaction with Redis-style geospatial data types.

## Details

- ✅ Added `Valkey::Commands::GeoCommands` module
- ✅ Implemented:
  - `geoadd`: Add longitude, latitude, and member triplets to a geospatial key
  - `geopos`: Retrieve the positions of specified members
- ✅ Each method includes YARD-style documentation
- ✅ Followed the same documentation/comment format as `StringCommands`

## Example usage

```ruby
valkey.geoadd("locations", 13.361389, 38.115556, "Palermo", 15.087269, 37.502669, "Catania")
# => 2

valkey.geopos("locations", "Palermo", "Catania")
# => [[13.361389, 38.115556], [15.087269, 37.502669]]