### PR TITLE
geo commands - geodist

### DIFF
--- a/lib/valkey/commands/geo_commands.rb
+++ b/lib/valkey/commands/geo_commands.rb
@@ -41,6 +41,16 @@ class Valkey
       def geohash(key, *member)
         send_command(RequestType::GEO_HASH, [key, *member])
       end
+
+      # Returns the distance between two members of a geospatial index
+      #
+      # @param [String] key
+      # @param [Array<String>] members
+      # @param ['m', 'km', 'mi', 'ft'] unit
+      # @return [String, nil] returns distance in specified unit if both members present, nil otherwise.
+      def geodist(key, member1, member2, unit = 'm')
+        send_command(RequestType::GEO_DIST, [key, member1, member2, unit])
+      end
     end
   end
 end

--- a/test/lint/geo_commands.rb
+++ b/test/lint/geo_commands.rb
@@ -33,5 +33,18 @@ module Lint
       geohashes = r.geohash("Sicily", "Palermo", "Rome")
       assert_equal ["sqc8b49rny0", nil], geohashes
     end
+
+    def test_geodist
+      distination_in_meters = r.geodist("Sicily", "Palermo", "Catania")
+      assert_equal 166_274.1516, distination_in_meters
+
+      distination_in_feet = r.geodist("Sicily", "Palermo", "Catania", 'ft')
+      assert_equal 545_518.8700, distination_in_feet
+    end
+
+    def test_geodist_with_nonexistant_location
+      distination = r.geodist("Sicily", "Palermo", "Rome")
+      assert_nil distination
+    end
   end
 end


### PR DESCRIPTION
# Add `geodist` in GEO Commands

## Summary

This PR introduces the implementation of `geodist`  commands in the `Valkey::Commands::GeoCommands` module.

This command allows interaction with Redis-style geospatial data types.

This function returns the distance in the specified unit if both members are present; otherwise, it returns nil.

## Example usage

```ruby
valkey.geodist("Sicily", "Palermo", "Catania")
# => 166274.1516
```