### PR TITLE
Add sorted set commands

### DIFF
--- a/lib/valkey/commands/sorted_set_commands.rb
+++ b/lib/valkey/commands/sorted_set_commands.rb
@@ -120,6 +120,48 @@ class Valkey
         end
       end
 
+      # Removes and returns up to count members with the highest scores in the sorted set stored at keys,
+      #   or block until one is available.
+      #
+      # @example Popping a member from a sorted set
+      #   valkey.bzpopmax('zset', 1)
+      #   #=> ['zset', 'b', 2.0]
+      # @example Popping a member from multiple sorted sets
+      #   valkey.bzpopmax('zset1', 'zset2', 1)
+      #   #=> ['zset1', 'b', 2.0]
+      #
+      # @params keys [Array<String>] one or multiple keys of the sorted sets
+      # @params timeout [Integer] the maximum number of seconds to block
+      #
+      # @return [Array<String, String, Float>] a touple of key, member and score
+      # @return [nil] when no element could be popped and the timeout expired
+      def bzpopmax(*args)
+        _bpop(:bzpopmax, args) do |reply|
+          reply.is_a?(Array) ? [reply[0], reply[1], Floatify.call(reply[2])] : reply
+        end
+      end
+
+      # Removes and returns up to count members with the lowest scores in the sorted set stored at keys,
+      #   or block until one is available.
+      #
+      # @example Popping a member from a sorted set
+      #   valkey.bzpopmin('zset', 1)
+      #   #=> ['zset', 'a', 1.0]
+      # @example Popping a member from multiple sorted sets
+      #   valkey.bzpopmin('zset1', 'zset2', 1)
+      #   #=> ['zset1', 'a', 1.0]
+      #
+      # @params keys [Array<String>] one or multiple keys of the sorted sets
+      # @params timeout [Integer] the maximum number of seconds to block
+      #
+      # @return [Array<String, String, Float>] a touple of key, member and score
+      # @return [nil] when no element could be popped and the timeout expired
+      def bzpopmin(*args)
+        _bpop(:bzpopmin, args) do |reply|
+          reply.is_a?(Array) ? [reply[0], reply[1], Floatify.call(reply[2])] : reply
+        end
+      end
+
       # Get the score associated with the given member in a sorted set.
       #
       # @example Get the score for member "a"
@@ -131,6 +173,55 @@ class Valkey
       # @return [Float] score of the member
       def zscore(key, member)
         send_command(RequestType::Z_SCORE, [key, member], &Utils::Floatify)
+      end
+
+      # Get the scores associated with the given members in a sorted set.
+      #
+      # @example Get the scores for members "a" and "b"
+      #   valkey.zmscore("zset", "a", "b")
+      #     # => [32.0, 48.0]
+      #
+      # @param [String] key
+      # @param [String, Array<String>] members
+      # @return [Array<Float>] scores of the members
+      def zmscore(key, *members)
+        send_command(RequestType::Z_MSCORE, [key, *members]) do |reply|
+          reply.map(&Utils::Floatify)
+        end
+      end
+
+      # Select a range of members in a sorted set, by index, score or lexicographical ordering
+      # and store the resulting sorted set in a new key.
+      #
+      # @example
+      #   valkey.zadd("foo", [[1.0, "s1"], [2.0, "s2"], [3.0, "s3"]])
+      #   valkey.zrangestore("bar", "foo", 0, 1)
+      #     # => 2
+      #   valkey.zrange("bar", 0, -1)
+      #     # => ["s1", "s2"]
+      #
+      # @return [Integer] the number of elements in the resulting sorted set
+      # @see #zrange
+      def zrangestore(dest_key, src_key, start, stop, byscore: false, by_score: byscore,
+                      bylex: false, by_lex: bylex, rev: false, limit: nil)
+        raise ArgumentError, "only one of :by_score or :by_lex can be specified" if by_score && by_lex
+
+        args = [dest_key, src_key, start, stop]
+
+        if by_score
+          args << "BYSCORE"
+        elsif by_lex
+          args << "BYLEX"
+        end
+
+        args << "REV" if rev
+
+        if limit
+          args << "LIMIT"
+          args.concat(limit.map { |l| Integer(l) })
+        end
+
+        send_command(RequestType::Z_RANGE_STORE, args)
       end
 
       # Determine the index of a member in a sorted set.
@@ -184,6 +275,196 @@ class Valkey
         end
 
         send_command(RequestType::Z_REV_RANK, args, &block)
+      end
+
+      # Remove all members in a sorted set within the given indexes.
+      #
+      # @example Remove first 5 members
+      #   valkey.zremrangebyrank("zset", 0, 4)
+      #     # => 5
+      # @example Remove last 5 members
+      #   valkey.zremrangebyrank("zset", -5, -1)
+      #     # => 5
+      #
+      # @param [String] key
+      # @param [Integer] start start index
+      # @param [Integer] stop stop index
+      # @return [Integer] number of members that were removed
+      def zremrangebyrank(key, start, stop)
+        send_command(RequestType::Z_REM_RANGE_BY_RANK, [key, start, stop])
+      end
+
+      # Count the members, with the same score in a sorted set, within the given lexicographical range.
+      #
+      # @example Count members matching a
+      #   valkey.zlexcount("zset", "[a", "[a\xff")
+      #     # => 1
+      # @example Count members matching a-z
+      #   valkey.zlexcount("zset", "[a", "[z\xff")
+      #     # => 26
+      #
+      # @param [String] key
+      # @param [String] min
+      #   - inclusive minimum is specified by prefixing `(`
+      #   - exclusive minimum is specified by prefixing `[`
+      # @param [String] max
+      #   - inclusive maximum is specified by prefixing `(`
+      #   - exclusive maximum is specified by prefixing `[`
+      #
+      # @return [Integer] number of members within the specified lexicographical range
+      def zlexcount(key, min, max)
+        send_command(RequestType::Z_LEX_COUNT, [key, min, max])
+      end
+
+      # Remove all members in a sorted set within the given scores.
+      #
+      # @example Remove members with score `>= 5` and `< 100`
+      #   valkey.zremrangebyscore("zset", "5", "(100")
+      #     # => 2
+      # @example Remove members with scores `> 5`
+      #   valkey.zremrangebyscore("zset", "(5", "+inf")
+      #     # => 2
+      #
+      # @param [String] key
+      # @param [String] min
+      #   - inclusive minimum score is specified verbatim
+      #   - exclusive minimum score is specified by prefixing `(`
+      # @param [String] max
+      #   - inclusive maximum score is specified verbatim
+      #   - exclusive maximum score is specified by prefixing `(`
+      # @return [Integer] number of members that were removed
+      def zremrangebyscore(key, min, max)
+        send_command(RequestType::Z_REM_RANGE_BY_SCORE, [key, min, max])
+      end
+
+      # Count the members in a sorted set with scores within the given values.
+      #
+      # @example Count members with score `>= 5` and `< 100`
+      #   valkey.zcount("zset", "5", "(100")
+      #     # => 2
+      # @example Count members with scores `> 5`
+      #   valkey.zcount("zset", "(5", "+inf")
+      #     # => 2
+      #
+      # @param [String] key
+      # @param [String] min
+      #   - inclusive minimum score is specified verbatim
+      #   - exclusive minimum score is specified by prefixing `(`
+      # @param [String] max
+      #   - inclusive maximum score is specified verbatim
+      #   - exclusive maximum score is specified by prefixing `(`
+      # @return [Integer] number of members in within the specified range
+      def zcount(key, min, max)
+        send_command(RequestType::Z_COUNT, [key, min, max])
+      end
+
+      # Intersect multiple sorted sets and store the resulting sorted set in a new
+      # key.
+      #
+      # @example Compute the intersection of `2*zsetA` with `1*zsetB`, summing their scores
+      #   valkey.zinterstore("zsetC", ["zsetA", "zsetB"], :weights => [2.0, 1.0], :aggregate => "sum")
+      #     # => 4
+      #
+      # @param [String] destination destination key
+      # @param [Array<String>] keys source keys
+      # @param [Hash] options
+      #   - `:weights => [Array<Float>]`: weights to associate with source
+      #   sorted sets
+      #   - `:aggregate => String`: aggregate function to use (sum, min, max)
+      # @return [Integer] number of elements in the resulting sorted set
+      def zinterstore(*args)
+        _zsets_operation_store(RequestType::Z_INTER_STORE, *args)
+      end
+      ruby2_keywords(:zinterstore) if respond_to?(:ruby2_keywords, true)
+
+      # Add multiple sorted sets and store the resulting sorted set in a new key.
+      #
+      # @example Compute the union of `2*zsetA` with `1*zsetB`, summing their scores
+      #   valkey.zunionstore("zsetC", ["zsetA", "zsetB"], :weights => [2.0, 1.0], :aggregate => "sum")
+      #     # => 8
+      #
+      # @param [String] destination destination key
+      # @param [Array<String>] keys source keys
+      # @param [Hash] options
+      #   - `:weights => [Float, Float, ...]`: weights to associate with source
+      #   sorted sets
+      #   - `:aggregate => String`: aggregate function to use (sum, min, max, ...)
+      # @return [Integer] number of elements in the resulting sorted set
+      def zunionstore(*args)
+        _zsets_operation_store(RequestType::Z_UNION_STORE, *args)
+      end
+      ruby2_keywords(:zunionstore) if respond_to?(:ruby2_keywords, true)
+
+      # Compute the difference between the first and all successive input sorted sets
+      # and store the resulting sorted set in a new key
+      #
+      # @example
+      #   valkey.zadd("zsetA", [[1.0, "v1"], [2.0, "v2"]])
+      #   valkey.zadd("zsetB", [[3.0, "v2"], [2.0, "v3"]])
+      #   valkey.zdiffstore("zsetA", "zsetB")
+      #     # => 1
+      #
+      # @param [String] destination destination key
+      # @param [Array<String>] keys source keys
+      # @return [Integer] number of elements in the resulting sorted set
+      def zdiffstore(*args)
+        _zsets_operation_store(RequestType::Z_DIFF_STORE, *args)
+      end
+      ruby2_keywords(:zdiffstore) if respond_to?(:ruby2_keywords, true)
+
+      # Scan a sorted set
+      #
+      # @example Retrieve the first batch of key/value pairs in a hash
+      #   valkey.zscan("zset", 0)
+      #
+      # @param [String, Integer] cursor the cursor of the iteration
+      # @param [Hash] options
+      #   - `:match => String`: only return keys matching the pattern
+      #   - `:count => Integer`: return count keys at most per iteration
+      #
+      # @return [String, Array<[String, Float]>] the next cursor and all found
+      #   members and scores
+      #
+      # See the [Valkey Server ZSCAN documentation](https://valkey.io/docs/latest/commands/zscan/) for further details
+      def zscan(key, cursor, **options)
+        _scan(RequestType::Z_SCAN, cursor, [key], **options) do |reply|
+          [reply[0], Utils::FloatifyPairs.call(reply[1])]
+        end
+      end
+
+      private
+
+      def _zsets_operation(cmd, *keys, weights: nil, aggregate: nil, with_scores: false)
+        keys.flatten!(1)
+        command_args = [keys.size].concat(keys)
+
+        if weights
+          command_args << "WEIGHTS"
+          command_args.concat(weights)
+        end
+
+        command_args << "AGGREGATE" << aggregate if aggregate
+
+        if with_scores
+          command_args << "WITHSCORES"
+          block = Utils::FloatifyPairs
+        end
+
+        send_command(cmd, command_args, &block)
+      end
+
+      def _zsets_operation_store(cmd, destination, keys, weights: nil, aggregate: nil)
+        keys.flatten!(1)
+        command_args = [destination, keys.size].concat(keys)
+
+        if weights
+          command_args << "WEIGHTS"
+          command_args.concat(weights)
+        end
+
+        command_args << "AGGREGATE" << aggregate if aggregate
+
+        send_command(cmd, command_args)
       end
     end
   end

--- a/lib/valkey/commands/sorted_set_commands.rb
+++ b/lib/valkey/commands/sorted_set_commands.rb
@@ -120,45 +120,49 @@ class Valkey
         end
       end
 
-      # Removes and returns up to count members with the highest scores in the sorted set stored at keys,
-      #   or block until one is available.
+      # Removes and returns up to count members with the highest scores in the sorted set stored at key.
       #
-      # @example Popping a member from a sorted set
-      #   valkey.bzpopmax('zset', 1)
-      #   #=> ['zset', 'b', 2.0]
-      # @example Popping a member from multiple sorted sets
-      #   valkey.bzpopmax('zset1', 'zset2', 1)
-      #   #=> ['zset1', 'b', 2.0]
+      # @example Popping a member
+      #   valkey.zpopmax('zset')
+      #   #=> ['b', 2.0]
+      # @example With count option
+      #   valkey.zpopmax('zset', 2)
+      #   #=> [['b', 2.0], ['a', 1.0]]
       #
-      # @params keys [Array<String>] one or multiple keys of the sorted sets
-      # @params timeout [Integer] the maximum number of seconds to block
+      # @params key [String] a key of the sorted set
+      # @params count [Integer] a number of members
       #
-      # @return [Array<String, String, Float>] a touple of key, member and score
-      # @return [nil] when no element could be popped and the timeout expired
-      def bzpopmax(*args)
-        _bpop(:bzpopmax, args) do |reply|
-          reply.is_a?(Array) ? [reply[0], reply[1], Floatify.call(reply[2])] : reply
+      # @return [Array<String, Float>] element and score pair if count is not specified
+      # @return [Array<Array<String, Float>>] list of popped elements and scores
+      def zpopmax(key, count = nil)
+        command_args = [key]
+        command_args << Integer(count) if count
+        send_command(RequestType::Z_POP_MAX, command_args) do |members|
+          members = Utils::FloatifyPairs.call(members)
+          count.to_i > 1 ? members : members.first
         end
       end
 
-      # Removes and returns up to count members with the lowest scores in the sorted set stored at keys,
-      #   or block until one is available.
+      # Removes and returns up to count members with the lowest scores in the sorted set stored at key.
       #
-      # @example Popping a member from a sorted set
-      #   valkey.bzpopmin('zset', 1)
-      #   #=> ['zset', 'a', 1.0]
-      # @example Popping a member from multiple sorted sets
-      #   valkey.bzpopmin('zset1', 'zset2', 1)
-      #   #=> ['zset1', 'a', 1.0]
+      # @example Popping a member
+      #   valkey.zpopmin('zset')
+      #   #=> ['a', 1.0]
+      # @example With count option
+      #   valkey.zpopmin('zset', 2)
+      #   #=> [['a', 1.0], ['b', 2.0]]
       #
-      # @params keys [Array<String>] one or multiple keys of the sorted sets
-      # @params timeout [Integer] the maximum number of seconds to block
+      # @params key [String] a key of the sorted set
+      # @params count [Integer] a number of members
       #
-      # @return [Array<String, String, Float>] a touple of key, member and score
-      # @return [nil] when no element could be popped and the timeout expired
-      def bzpopmin(*args)
-        _bpop(:bzpopmin, args) do |reply|
-          reply.is_a?(Array) ? [reply[0], reply[1], Floatify.call(reply[2])] : reply
+      # @return [Array<String, Float>] element and score pair if count is not specified
+      # @return [Array<Array<String, Float>>] list of popped elements and scores
+      def zpopmin(key, count = nil)
+        command_args = [key]
+        command_args << Integer(count) if count
+        send_command(RequestType::Z_POP_MIN, command_args) do |members|
+          members = Utils::FloatifyPairs.call(members)
+          count.to_i > 1 ? members : members.first
         end
       end
 
@@ -188,6 +192,56 @@ class Valkey
         send_command(RequestType::Z_MSCORE, [key, *members]) do |reply|
           reply.map(&Utils::Floatify)
         end
+      end
+
+      # Return a range of members in a sorted set, by index, score or lexicographical ordering.
+      #
+      # @example Retrieve all members from a sorted set, by index
+      #   valkey.zrange("zset", 0, -1)
+      #     # => ["a", "b"]
+      # @example Retrieve all members and their scores from a sorted set
+      #   valkey.zrange("zset", 0, -1, :with_scores => true)
+      #     # => [["a", 32.0], ["b", 64.0]]
+      #
+      # @param [String] key
+      # @param [Integer] start start index
+      # @param [Integer] stop stop index
+      # @param [Hash] options
+      #   - `:by_score => false`: return members by score
+      #   - `:by_lex => false`: return members by lexicographical ordering
+      #   - `:rev => false`: reverse the ordering, from highest to lowest
+      #   - `:limit => [offset, count]`: skip `offset` members, return a maximum of
+      #   `count` members
+      #   - `:with_scores => true`: include scores in output
+      #
+      # @return [Array<String>, Array<[String, Float]>]
+      #   - when `:with_scores` is not specified, an array of members
+      #   - when `:with_scores` is specified, an array with `[member, score]` pairs
+      def zrange(key, start, stop, byscore: false, by_score: byscore, bylex: false, by_lex: bylex,
+                 rev: false, limit: nil, withscores: false, with_scores: withscores)
+        raise ArgumentError, "only one of :by_score or :by_lex can be specified" if by_score && by_lex
+
+        args = [key, start, stop]
+
+        if by_score
+          args << "BYSCORE"
+        elsif by_lex
+          args << "BYLEX"
+        end
+
+        args << "REV" if rev
+
+        if limit
+          args << "LIMIT"
+          args.concat(limit.map { |l| Integer(l) })
+        end
+
+        if with_scores
+          args << "WITHSCORES"
+          block = Utils::FloatifyPairs
+        end
+
+        send_command(RequestType::Z_RANGE, args, &block)
       end
 
       # Select a range of members in a sorted set, by index, score or lexicographical ordering
@@ -358,6 +412,30 @@ class Valkey
         send_command(RequestType::Z_COUNT, [key, min, max])
       end
 
+      # Return the intersection of multiple sorted sets
+      #
+      # @example Retrieve the intersection of `2*zsetA` and `1*zsetB`
+      #   valkey.zinter("zsetA", "zsetB", :weights => [2.0, 1.0])
+      #     # => ["v1", "v2"]
+      # @example Retrieve the intersection of `2*zsetA` and `1*zsetB`, and their scores
+      #   valkey.zinter("zsetA", "zsetB", :weights => [2.0, 1.0], :with_scores => true)
+      #     # => [["v1", 3.0], ["v2", 6.0]]
+      #
+      # @param [String, Array<String>] keys one or more keys to intersect
+      # @param [Hash] options
+      #   - `:weights => [Float, Float, ...]`: weights to associate with source
+      #   sorted sets
+      #   - `:aggregate => String`: aggregate function to use (sum, min, max, ...)
+      #   - `:with_scores => true`: include scores in output
+      #
+      # @return [Array<String>, Array<[String, Float]>]
+      #   - when `:with_scores` is not specified, an array of members
+      #   - when `:with_scores` is specified, an array with `[member, score]` pairs
+      def zinter(*args)
+        _zsets_operation(RequestType::Z_INTER, *args)
+      end
+      ruby2_keywords(:zinter) if respond_to?(:ruby2_keywords, true)
+
       # Intersect multiple sorted sets and store the resulting sorted set in a new
       # key.
       #
@@ -377,6 +455,30 @@ class Valkey
       end
       ruby2_keywords(:zinterstore) if respond_to?(:ruby2_keywords, true)
 
+      # Return the union of multiple sorted sets
+      #
+      # @example Retrieve the union of `2*zsetA` and `1*zsetB`
+      #   valkey.zunion("zsetA", "zsetB", :weights => [2.0, 1.0])
+      #     # => ["v1", "v2"]
+      # @example Retrieve the union of `2*zsetA` and `1*zsetB`, and their scores
+      #   valkey.zunion("zsetA", "zsetB", :weights => [2.0, 1.0], :with_scores => true)
+      #     # => [["v1", 3.0], ["v2", 6.0]]
+      #
+      # @param [String, Array<String>] keys one or more keys to union
+      # @param [Hash] options
+      #   - `:weights => [Array<Float>]`: weights to associate with source
+      #   sorted sets
+      #   - `:aggregate => String`: aggregate function to use (sum, min, max)
+      #   - `:with_scores => true`: include scores in output
+      #
+      # @return [Array<String>, Array<[String, Float]>]
+      #   - when `:with_scores` is not specified, an array of members
+      #   - when `:with_scores` is specified, an array with `[member, score]` pairs
+      def zunion(*args)
+        _zsets_operation(RequestType::Z_UNION, *args)
+      end
+      ruby2_keywords(:zunion) if respond_to?(:ruby2_keywords, true)
+
       # Add multiple sorted sets and store the resulting sorted set in a new key.
       #
       # @example Compute the union of `2*zsetA` with `1*zsetB`, summing their scores
@@ -394,6 +496,30 @@ class Valkey
         _zsets_operation_store(RequestType::Z_UNION_STORE, *args)
       end
       ruby2_keywords(:zunionstore) if respond_to?(:ruby2_keywords, true)
+
+      # Return the difference between the first and all successive input sorted sets
+      #
+      # @example
+      #   valkey.zadd("zsetA", [[1.0, "v1"], [2.0, "v2"]])
+      #   valkey.zadd("zsetB", [[3.0, "v2"], [2.0, "v3"]])
+      #   valkey.zdiff("zsetA", "zsetB")
+      #     => ["v1"]
+      # @example With scores
+      #   valkey.zadd("zsetA", [[1.0, "v1"], [2.0, "v2"]])
+      #   valkey.zadd("zsetB", [[3.0, "v2"], [2.0, "v3"]])
+      #   valkey.zdiff("zsetA", "zsetB", :with_scores => true)
+      #     => [["v1", 1.0]]
+      #
+      # @param [String, Array<String>] keys one or more keys to compute the difference
+      # @param [Hash] options
+      #   - `:with_scores => true`: include scores in output
+      #
+      # @return [Array<String>, Array<[String, Float]>]
+      #   - when `:with_scores` is not specified, an array of members
+      #   - when `:with_scores` is specified, an array with `[member, score]` pairs
+      def zdiff(*keys, with_scores: false)
+        _zsets_operation(RequestType::Z_DIFF, *keys, with_scores: with_scores)
+      end
 
       # Compute the difference between the first and all successive input sorted sets
       # and store the resulting sorted set in a new key

--- a/test/lint/sorted_set_commands.rb
+++ b/test/lint/sorted_set_commands.rb
@@ -243,5 +243,80 @@ module Lint
         assert_equal [0, 3], r.zrevrank("foo", "s3", withscore: true)
       end
     end
+
+    def test_zcard
+      assert_equal 0, r.zcard("foo")
+
+      r.zadd "foo", 1, "s1"
+
+      assert_equal 1, r.zcard("foo")
+    end
+
+    def test_zscore
+      r.zadd "foo", 1, "s1"
+
+      assert_equal 1.0, r.zscore("foo", "s1")
+
+      assert_nil r.zscore("foo", "s2")
+      assert_nil r.zscore("bar", "s1")
+
+      r.zadd "bar", "-inf", "s1"
+      r.zadd "bar", "+inf", "s2"
+      assert_equal(-Float::INFINITY, r.zscore("bar", "s1"))
+      assert_equal(+Float::INFINITY, r.zscore("bar", "s2"))
+    end
+
+    def test_zmscore
+      target_version("6.2") do
+        r.zadd "foo", 1, "s1"
+
+        assert_equal [1.0], r.zmscore("foo", "s1")
+        assert_equal [nil], r.zmscore("foo", "s2")
+
+        r.zadd "foo", "-inf", "s2"
+        r.zadd "foo", "+inf", "s3"
+        assert_equal [1.0, nil], r.zmscore("foo", "s1", "s4")
+        assert_equal [-Float::INFINITY, +Float::INFINITY], r.zmscore("foo", "s2", "s3")
+      end
+    end
+
+    def test_zlexcount
+      r.zadd 'foo', 0, 'aaren'
+      r.zadd 'foo', 0, 'abagael'
+      r.zadd 'foo', 0, 'abby'
+      r.zadd 'foo', 0, 'abbygail'
+
+      assert_equal 4, r.zlexcount('foo', '[a', "[a\xff")
+      assert_equal 4, r.zlexcount('foo', '[aa', "[ab\xff")
+      assert_equal 3, r.zlexcount('foo', '(aaren', "[ab\xff")
+      assert_equal 2, r.zlexcount('foo', '[aba', '(abbygail')
+      assert_equal 1, r.zlexcount('foo', '(aaren', '(abby')
+    end
+
+    def test_zcount
+      r.zadd 'foo', 1, 's1'
+      r.zadd 'foo', 2, 's2'
+      r.zadd 'foo', 3, 's3'
+
+      assert_equal 2, r.zcount('foo', 2, 3)
+    end
+
+    def test_zunionstore_expand
+      r.zadd('{1}foo', %w[0 a 1 b 2 c])
+      r.zadd('{1}bar', %w[0 c 1 d 2 e])
+      assert_equal 5, r.zunionstore('{1}baz', %w[{1}foo {1}bar])
+    end
+
+    def test_zinterstore_expand
+      r.zadd '{1}foo', %w[0 s1 1 s2 2 s3]
+      r.zadd '{1}bar', %w[0 s3 1 s4 2 s5]
+      assert_equal 1, r.zinterstore('{1}baz', %w[{1}foo {1}bar], weights: [2.0, 3.0])
+    end
+
+    def test_zscan
+      r.zadd('foo', %w[0 a 1 b 2 c])
+      expected = ['0', [['a', 0.0], ['b', 1.0], ['c', 2.0]]]
+      assert_equal expected, r.zscan('foo', 0)
+    end
   end
 end

--- a/test/lint/sorted_set_commands.rb
+++ b/test/lint/sorted_set_commands.rb
@@ -244,6 +244,60 @@ module Lint
       end
     end
 
+    def test_zrange
+      r.zadd "foo", 1, "s1"
+      r.zadd "foo", 2, "s2"
+      r.zadd "foo", 3, "s3"
+
+      assert_equal %w[s1 s2], r.zrange("foo", 0, 1)
+      assert_equal [["s1", 1.0], ["s2", 2.0]], r.zrange("foo", 0, 1, with_scores: true)
+      assert_equal [["s1", 1.0], ["s2", 2.0]], r.zrange("foo", 0, 1, withscores: true)
+
+      r.zadd "bar", "-inf", "s1"
+      r.zadd "bar", "+inf", "s2"
+      assert_equal [["s1", -Float::INFINITY], ["s2", +Float::INFINITY]], r.zrange("bar", 0, 1, with_scores: true)
+      assert_equal [["s1", -Float::INFINITY], ["s2", +Float::INFINITY]], r.zrange("bar", 0, 1, withscores: true)
+    end
+
+    def test_zrange_with_byscore
+      target_version("6.2") do
+        r.zadd "foo", 1, "s1"
+        r.zadd "foo", 2, "s2"
+        r.zadd "foo", 3, "s3"
+
+        assert_equal %w[s2 s3], r.zrange("foo", 2, 3, byscore: true)
+        assert_equal %w[s2 s1], r.zrange("foo", 2, 1, byscore: true, rev: true)
+      end
+    end
+
+    def test_zrange_with_bylex
+      target_version("6.2") do
+        r.zadd "foo", 0, "aaren"
+        r.zadd "foo", 0, "abagael"
+        r.zadd "foo", 0, "abby"
+        r.zadd "foo", 0, "abbygail"
+
+        assert_equal %w[aaren abagael abby abbygail], r.zrange("foo", "[a", "[a\xff", bylex: true)
+        assert_equal %w[aaren abagael], r.zrange("foo", "[a", "[a\xff", bylex: true, limit: [0, 2])
+        assert_equal %w[abby abbygail], r.zrange("foo", "(abb", "(abb\xff", bylex: true)
+        assert_equal %w[abbygail], r.zrange("foo", "(abby", "(abby\xff", bylex: true)
+      end
+    end
+
+    def test_zrangestore
+      target_version("6.2") do
+        r.zadd "foo", 1, "s1"
+        r.zadd "foo", 2, "s2"
+        r.zadd "foo", 3, "s3"
+
+        assert_equal 2, r.zrangestore("bar", "foo", 0, 1)
+        assert_equal %w[s1 s2], r.zrange("bar", 0, -1)
+
+        assert_equal 2, r.zrangestore("baz", "foo", 2, 3, by_score: true)
+        assert_equal %w[s2 s3], r.zrange("baz", 0, -1)
+      end
+    end
+
     def test_zcard
       assert_equal 0, r.zcard("foo")
 
@@ -280,6 +334,40 @@ module Lint
       end
     end
 
+    def test_zremrangebyrank
+      r.zadd "foo", 10, "s1"
+      r.zadd "foo", 20, "s2"
+      r.zadd "foo", 30, "s3"
+      r.zadd "foo", 40, "s4"
+
+      assert_equal 3, r.zremrangebyrank("foo", 1, 3)
+      assert_equal ["s1"], r.zrange("foo", 0, -1)
+    end
+
+    def test_zremrangebyscore
+      r.zadd "foo", 1, "s1"
+      r.zadd "foo", 2, "s2"
+      r.zadd "foo", 3, "s3"
+      r.zadd "foo", 4, "s4"
+
+      assert_equal 3, r.zremrangebyscore("foo", 2, 4)
+      assert_equal ["s1"], r.zrange("foo", 0, -1)
+    end
+
+    def test_zpopmax
+      r.zadd('foo', %w[0 a 1 b 2 c 3 d])
+      assert_equal ['d', 3.0], r.zpopmax('foo')
+      assert_equal [['c', 2.0], ['b', 1.0]], r.zpopmax('foo', 2)
+      assert_equal [['a', 0.0]], r.zrange('foo', 0, -1, with_scores: true)
+    end
+
+    def test_zpopmin
+      r.zadd('foo', %w[0 a 1 b 2 c 3 d])
+      assert_equal ['a', 0.0], r.zpopmin('foo')
+      assert_equal [['b', 1.0], ['c', 2.0]], r.zpopmin('foo', 2)
+      assert_equal [['d', 3.0]], r.zrange('foo', 0, -1, with_scores: true)
+    end
+
     def test_zlexcount
       r.zadd 'foo', 0, 'aaren'
       r.zadd 'foo', 0, 'abagael'
@@ -301,10 +389,230 @@ module Lint
       assert_equal 2, r.zcount('foo', 2, 3)
     end
 
+    def test_zunion
+      target_version("6.2") do
+        r.zadd 'foo', 1, 's1'
+        r.zadd 'foo', 2, 's2'
+        r.zadd 'bar', 3, 's1'
+        r.zadd 'bar', 5, 's3'
+
+        assert_equal %w[s2 s1 s3], r.zunion('foo', 'bar')
+        assert_equal [['s2', 2.0], ['s1', 4.0], ['s3', 5.0]], r.zunion('foo', 'bar', with_scores: true)
+      end
+    end
+
+    def test_zunion_with_weights
+      target_version("6.2") do
+        r.zadd 'foo', 1, 's1'
+        r.zadd 'foo', 2, 's2'
+        r.zadd 'foo', 3, 's3'
+        r.zadd 'bar', 20, 's2'
+        r.zadd 'bar', 30, 's3'
+        r.zadd 'bar', 100, 's4'
+
+        assert_equal %w[s1 s2 s3 s4], r.zunion('foo', 'bar')
+        assert_equal [['s1', 1.0], ['s2', 22.0], ['s3', 33.0], ['s4', 100.0]], r.zunion('foo', 'bar', with_scores: true)
+
+        assert_equal %w[s1 s2 s3 s4], r.zunion('foo', 'bar', weights: [10, 1])
+        assert_equal [['s1', 10.0], ['s2', 40.0], ['s3', 60.0], ['s4', 100.0]],
+                     r.zunion('foo', 'bar', weights: [10, 1], with_scores: true)
+      end
+    end
+
+    def test_zunion_with_aggregate
+      target_version("6.2") do
+        r.zadd 'foo', 1, 's1'
+        r.zadd 'foo', 20, 's2'
+        r.zadd 'foo', 3, 's3'
+        r.zadd 'bar', 2, 's2'
+        r.zadd 'bar', 30, 's3'
+        r.zadd 'bar', 100, 's4'
+
+        assert_equal %w[s1 s2 s3 s4], r.zunion('foo', 'bar', aggregate: :min)
+        assert_equal [['s1', 1.0], ['s2', 2.0], ['s3', 3.0], ['s4', 100.0]],
+                     r.zunion('foo', 'bar', aggregate: :min, with_scores: true)
+
+        assert_equal %w[s1 s2 s3 s4], r.zunion('foo', 'bar', aggregate: :max)
+        assert_equal [['s1', 1.0], ['s2', 20.0], ['s3', 30.0], ['s4', 100.0]],
+                     r.zunion('foo', 'bar', aggregate: :max, with_scores: true)
+      end
+    end
+
+    def test_zunionstore
+      r.zadd 'foo', 1, 's1'
+      r.zadd 'bar', 2, 's2'
+      r.zadd 'foo', 3, 's3'
+      r.zadd 'bar', 4, 's4'
+
+      assert_equal 4, r.zunionstore('foobar', %w[foo bar])
+      assert_equal %w[s1 s2 s3 s4], r.zrange('foobar', 0, -1)
+    end
+
+    def test_zunionstore_with_weights
+      r.zadd 'foo', 1, 's1'
+      r.zadd 'foo', 3, 's3'
+      r.zadd 'bar', 20, 's2'
+      r.zadd 'bar', 40, 's4'
+
+      assert_equal 4, r.zunionstore('foobar', %w[foo bar])
+      assert_equal %w[s1 s3 s2 s4], r.zrange('foobar', 0, -1)
+
+      assert_equal 4, r.zunionstore('foobar', %w[foo bar], weights: [10, 1])
+      assert_equal %w[s1 s2 s3 s4], r.zrange('foobar', 0, -1)
+    end
+
+    def test_zunionstore_with_aggregate
+      r.zadd 'foo', 1, 's1'
+      r.zadd 'foo', 2, 's2'
+      r.zadd 'bar', 4, 's2'
+      r.zadd 'bar', 3, 's3'
+
+      assert_equal 3, r.zunionstore('foobar', %w[foo bar])
+      assert_equal %w[s1 s3 s2], r.zrange('foobar', 0, -1)
+
+      assert_equal 3, r.zunionstore('foobar', %w[foo bar], aggregate: :min)
+      assert_equal %w[s1 s2 s3], r.zrange('foobar', 0, -1)
+
+      assert_equal 3, r.zunionstore('foobar', %w[foo bar], aggregate: :max)
+      assert_equal %w[s1 s3 s2], r.zrange('foobar', 0, -1)
+    end
+
     def test_zunionstore_expand
       r.zadd('{1}foo', %w[0 a 1 b 2 c])
       r.zadd('{1}bar', %w[0 c 1 d 2 e])
       assert_equal 5, r.zunionstore('{1}baz', %w[{1}foo {1}bar])
+    end
+
+    def test_zdiff
+      target_version("6.2") do
+        r.zadd 'foo', 1, 's1'
+        r.zadd 'foo', 2, 's2'
+        r.zadd 'bar', 3, 's1'
+        r.zadd 'bar', 5, 's3'
+
+        assert_equal [], r.zdiff('foo', 'foo')
+        assert_equal %w[s1 s2], r.zdiff('foo')
+
+        assert_equal ['s2'], r.zdiff('foo', 'bar')
+        assert_equal [['s2', 2.0]], r.zdiff('foo', 'bar', with_scores: true)
+      end
+    end
+
+    def test_zdiffstore
+      target_version("6.2") do
+        r.zadd 'foo', 1, 's1'
+        r.zadd 'foo', 2, 's2'
+        r.zadd 'bar', 3, 's1'
+        r.zadd 'bar', 5, 's3'
+
+        assert_equal 0, r.zdiffstore('baz', %w[foo foo])
+        assert_equal 2, r.zdiffstore('baz', ['foo'])
+        assert_equal %w[s1 s2], r.zrange('baz', 0, -1)
+
+        assert_equal 1, r.zdiffstore('baz', %w[foo bar])
+        assert_equal ['s2'], r.zrange('baz', 0, -1)
+      end
+    end
+
+    def test_zinter
+      target_version("6.2") do
+        r.zadd 'foo', 1, 's1'
+        r.zadd 'bar', 2, 's1'
+        r.zadd 'foo', 3, 's3'
+        r.zadd 'bar', 4, 's4'
+
+        assert_equal ['s1'], r.zinter('foo', 'bar')
+        assert_equal [['s1', 3.0]], r.zinter('foo', 'bar', with_scores: true)
+      end
+    end
+
+    def test_zinter_with_weights
+      target_version("6.2") do
+        r.zadd 'foo', 1, 's1'
+        r.zadd 'foo', 2, 's2'
+        r.zadd 'foo', 3, 's3'
+        r.zadd 'bar', 20, 's2'
+        r.zadd 'bar', 30, 's3'
+        r.zadd 'bar', 40, 's4'
+
+        assert_equal %w[s2 s3], r.zinter('foo', 'bar')
+        assert_equal [['s2', 22.0], ['s3', 33.0]], r.zinter('foo', 'bar', with_scores: true)
+
+        assert_equal %w[s2 s3], r.zinter('foo', 'bar', weights: [10, 1])
+        assert_equal [['s2', 40.0], ['s3', 60.0]], r.zinter('foo', 'bar', weights: [10, 1], with_scores: true)
+      end
+    end
+
+    def test_zinter_with_aggregate
+      target_version("6.2") do
+        r.zadd 'foo', 1, 's1'
+        r.zadd 'foo', 2, 's2'
+        r.zadd 'foo', 3, 's3'
+        r.zadd 'bar', 20, 's2'
+        r.zadd 'bar', 30, 's3'
+        r.zadd 'bar', 40, 's4'
+
+        assert_equal %w[s2 s3], r.zinter('foo', 'bar')
+        assert_equal [['s2', 22.0], ['s3', 33.0]], r.zinter('foo', 'bar', with_scores: true)
+
+        assert_equal %w[s2 s3], r.zinter('foo', 'bar', aggregate: :min)
+        assert_equal [['s2', 2.0], ['s3', 3.0]], r.zinter('foo', 'bar', aggregate: :min, with_scores: true)
+
+        assert_equal %w[s2 s3], r.zinter('foo', 'bar', aggregate: :max)
+        assert_equal [['s2', 20.0], ['s3', 30.0]], r.zinter('foo', 'bar', aggregate: :max, with_scores: true)
+      end
+    end
+
+    def test_zinterstore
+      r.zadd 'foo', 1, 's1'
+      r.zadd 'bar', 2, 's1'
+      r.zadd 'foo', 3, 's3'
+      r.zadd 'bar', 4, 's4'
+
+      assert_equal 1, r.zinterstore('foobar', %w[foo bar])
+      assert_equal ['s1'], r.zrange('foobar', 0, -1)
+    end
+
+    def test_zinterstore_with_weights
+      r.zadd 'foo', 1, 's1'
+      r.zadd 'foo', 2, 's2'
+      r.zadd 'foo', 3, 's3'
+      r.zadd 'bar', 20, 's2'
+      r.zadd 'bar', 30, 's3'
+      r.zadd 'bar', 40, 's4'
+
+      assert_equal 2, r.zinterstore('foobar', %w[foo bar])
+      assert_equal %w[s2 s3], r.zrange('foobar', 0, -1)
+
+      assert_equal 2, r.zinterstore('foobar', %w[foo bar], weights: [10, 1])
+      assert_equal %w[s2 s3], r.zrange('foobar', 0, -1)
+
+      assert_equal 40.0, r.zscore('foobar', 's2')
+      assert_equal 60.0, r.zscore('foobar', 's3')
+    end
+
+    def test_zinterstore_with_aggregate
+      r.zadd 'foo', 1, 's1'
+      r.zadd 'foo', 2, 's2'
+      r.zadd 'foo', 3, 's3'
+      r.zadd 'bar', 20, 's2'
+      r.zadd 'bar', 30, 's3'
+      r.zadd 'bar', 40, 's4'
+
+      assert_equal 2, r.zinterstore('foobar', %w[foo bar])
+      assert_equal %w[s2 s3], r.zrange('foobar', 0, -1)
+      assert_equal 22.0, r.zscore('foobar', 's2')
+      assert_equal 33.0, r.zscore('foobar', 's3')
+
+      assert_equal 2, r.zinterstore('foobar', %w[foo bar], aggregate: :min)
+      assert_equal %w[s2 s3], r.zrange('foobar', 0, -1)
+      assert_equal 2.0, r.zscore('foobar', 's2')
+      assert_equal 3.0, r.zscore('foobar', 's3')
+
+      assert_equal 2, r.zinterstore('foobar', %w[foo bar], aggregate: :max)
+      assert_equal %w[s2 s3], r.zrange('foobar', 0, -1)
+      assert_equal 20.0, r.zscore('foobar', 's2')
+      assert_equal 30.0, r.zscore('foobar', 's3')
     end
 
     def test_zinterstore_expand


### PR DESCRIPTION
This PR implements the following commands:

* Z_POP_MAX
* Z_POP_MIN
* Z_RANGE
* Z_INTER
* Z_UNION
* Z_DIFF
* Z_MSCORE
* Z_RANGE_STORE
* Z_REM_RANGE_BY_RANK
* Z_LEX_COUNT
* Z_REM_RANGE_BY_SCORE
* Z_COUNT
* Z_INTER_STORE
* Z_UNION_STORE
* Z_DIFF_STORE
* Z_SCAN