### PR TITLE
Add stream commands

### DIFF
--- a/lib/valkey/bindings.rb
+++ b/lib/valkey/bindings.rb
@@ -130,7 +130,10 @@ class Valkey
       :pointer,     # route_bytes
       :ulong,       # route_bytes_len
       :ulong        # span_ptr (u64)
-    ], :pointer     # returns *mut CommandResult
+    ], :pointer, blocking: true # returns *mut CommandResult
+    # Note: :blocking => true is required for proper multi-threading support
+    # and blocking commands (BLPOP, XREAD, etc.). This releases the GIL
+    # during FFI calls, allowing other Ruby threads to execute.
 
     attach_function :batch, [
       :pointer,        # client_ptr

--- a/lib/valkey/commands.rb
+++ b/lib/valkey/commands.rb
@@ -12,6 +12,7 @@ require "valkey/commands/sorted_set_commands"
 require "valkey/commands/set_commands"
 require "valkey/commands/scripting_commands"
 require "valkey/commands/cluster_commands"
+require "valkey/commands/stream_commands"
 
 class Valkey
   # Valkey commands module
@@ -39,6 +40,7 @@ class Valkey
     include SetCommands
     include ScriptingCommands
     include ClusterCommands
+    include StreamCommands
 
     # there are a few commands that are not implemented by design
     #

--- a/lib/valkey/commands/list_commands.rb
+++ b/lib/valkey/commands/list_commands.rb
@@ -216,7 +216,7 @@ class Valkey
         args = [timeout, keys.size, *keys, modifier]
         args << "COUNT" << Integer(count) if count
 
-        send_command(RequestType::BLMPOP, args)
+        send_command(RequestType::BLMPOP, args, &Utils::Arrayify)
       end
 
       # Pops one or more elements from the first non-empty list key from the list
@@ -244,7 +244,7 @@ class Valkey
 
         # pp args
 
-        send_command(RequestType::LMPOP, args)
+        send_command(RequestType::LMPOP, args, &Utils::Arrayify)
       end
 
       # Get an element from a list by its index.

--- a/lib/valkey/commands/stream_commands.rb
+++ b/lib/valkey/commands/stream_commands.rb
@@ -1,0 +1,455 @@
+# frozen_string_literal: true
+
+class Valkey
+  module Commands
+    # This module contains commands on the Stream data type.
+    #
+    # @see https://valkey.io/commands/#stream
+    #
+    module StreamCommands
+      # Returns the stream information each subcommand.
+      #
+      # @example stream
+      #   valkey.xinfo('stream', 'my-stream')
+      # @example groups
+      #   valkey.xinfo('groups', 'my-stream')
+      # @example consumers
+      #   valkey.xinfo('consumers', 'my-stream', 'mygroup')
+      #
+      # @param subcommand [String] `stream` `groups` `consumers`
+      # @param key        [String] the stream key
+      # @param group      [String] the consumer group name, required if subcommand is `consumers`
+      #
+      # @return [Hash]        information of the stream if subcommand is `stream`
+      # @return [Array<Hash>] information of the consumer groups if subcommand is `groups`
+      # @return [Array<Hash>] information of the consumers if subcommand is `consumers`
+      def xinfo(subcommand, key, group = nil)
+        request =
+          case subcommand.to_s.downcase
+          when 'stream'
+            RequestType::X_INFO_STREAM
+          when 'groups'
+            RequestType::X_INFO_GROUPS
+          when 'consumers'
+            RequestType::X_INFO_CONSUMERS
+          else
+            RequestType::INVALID_REQUEST
+          end
+        args = [key, group].compact
+
+        send_command(request, args)
+      end
+
+      # Add new entry to the stream.
+      #
+      # @example Without options
+      #   valkey.xadd('mystream', { f1: 'v1', f2: 'v2' })
+      # @example With options
+      #   valkey.xadd('mystream', { f1: 'v1', f2: 'v2' }, id: '0-0', maxlen: 1000, approximate: true, nomkstream: true)
+      #
+      # @param key   [String] the stream key
+      # @param entry [Hash]   one or multiple field-value pairs
+      # @param opts  [Hash]   several options for `XADD` command
+      #
+      # @option opts [String]  :id          the entry id, default value is `*`, it means auto generation
+      # @option opts [Integer] :maxlen      max length of entries to keep
+      # @option opts [Integer] :minid       min id of entries to keep
+      # @option opts [Boolean] :approximate whether to add `~` modifier of maxlen/minid or not
+      # @option opts [Boolean] :nomkstream  whether to add NOMKSTREAM, default is not to add
+      #
+      # @return [String] the entry id
+      def xadd(key, entry, approximate: nil, maxlen: nil, minid: nil, nomkstream: nil, id: '*')
+        args = [key]
+        args << 'NOMKSTREAM' if nomkstream
+        if maxlen
+          raise ArgumentError, "can't supply both maxlen and minid" if minid
+
+          args << "MAXLEN"
+          args << "~" if approximate
+          args << maxlen
+        elsif minid
+          args << "MINID"
+          args << "~" if approximate
+          args << minid
+        end
+        args << id
+        args.concat(entry.flatten)
+
+        send_command(RequestType::X_ADD, args)
+      end
+
+      # Trims older entries of the stream if needed.
+      #
+      # @example Without options
+      #   valkey.xtrim('mystream', 1000)
+      # @example With options
+      #   valkey.xtrim('mystream', 1000, approximate: true)
+      # @example With strategy
+      #   valkey.xtrim('mystream', '1-0', strategy: 'MINID')
+      #
+      # @overload xtrim(key, maxlen, strategy: 'MAXLEN', approximate: true)
+      #   @param key         [String]  the stream key
+      #   @param maxlen      [Integer] max length of entries
+      #   @param strategy    [String]  the limit strategy, must be MAXLEN
+      #   @param approximate [Boolean] whether to add `~` modifier of maxlen or not
+      #   @param limit       [Integer] maximum count of entries to be evicted
+      # @overload xtrim(key, minid, strategy: 'MINID', approximate: true)
+      #   @param key         [String]  the stream key
+      #   @param minid       [String]  minimum id of entries
+      #   @param strategy    [String]  the limit strategy, must be MINID
+      #   @param approximate [Boolean] whether to add `~` modifier of minid or not
+      #   @param limit       [Integer] maximum count of entries to be evicted
+      #
+      # @return [Integer] the number of entries actually deleted
+      def xtrim(key, len_or_id, strategy: 'MAXLEN', approximate: false, limit: nil)
+        strategy = strategy.to_s.upcase
+
+        args = [key, strategy]
+        args << '~' if approximate
+        args << len_or_id
+        args.concat(['LIMIT', limit]) if limit
+        send_command(RequestType::X_TRIM, args)
+      end
+
+      # Delete entries by entry ids.
+      #
+      # @example With splatted entry ids
+      #   valkey.xdel('mystream', '0-1', '0-2')
+      # @example With arrayed entry ids
+      #   valkey.xdel('mystream', ['0-1', '0-2'])
+      #
+      # @param key [String]        the stream key
+      # @param ids [Array<String>] one or multiple entry ids
+      #
+      # @return [Integer] the number of entries actually deleted
+      def xdel(key, *ids)
+        # To keep compatibility with Redis
+        raise TypeError, "key cannot be nil" if key.nil?
+
+        args = [key].concat(ids.flatten)
+        send_command(RequestType::X_DEL, args)
+      end
+
+      # Fetches entries of the stream in ascending order.
+      #
+      # @example Without options
+      #   valkey.xrange('mystream')
+      # @example With a specific start
+      #   valkey.xrange('mystream', '0-1')
+      # @example With a specific start and end
+      #   valkey.xrange('mystream', '0-1', '0-3')
+      # @example With count options
+      #   valkey.xrange('mystream', count: 10)
+      #
+      # @param key [String]  the stream key
+      # @param start [String]  first entry id of range, default value is `-`
+      # @param end [String]  last entry id of range, default value is `+`
+      # @param count [Integer] the number of entries as limit
+      #
+      # @return [Array<Array<String, Hash>>] the ids and entries pairs
+      def xrange(key, start = '-', range_end = '+', count: nil)
+        # To keep compatibility with Redis
+        raise TypeError, "key cannot be nil" if key.nil?
+
+        args = [key, start, range_end]
+        args.concat(['COUNT', count]) if count
+        send_command(RequestType::X_RANGE, args, &Utils::HashifyStreamEntries)
+      end
+
+      # Fetches entries of the stream in descending order.
+      #
+      # @example Without options
+      #   valkey.xrevrange('mystream')
+      # @example With a specific end
+      #   valkey.xrevrange('mystream', '0-3')
+      # @example With a specific end and start
+      #   valkey.xrevrange('mystream', '0-3', '0-1')
+      # @example With count options
+      #   valkey.xrevrange('mystream', count: 10)
+      #
+      # @param key [String]  the stream key
+      # @param end [String]  first entry id of range, default value is `+`
+      # @param start [String]  last entry id of range, default value is `-`
+      # @params count [Integer] the number of entries as limit
+      #
+      # @return [Array<Array<String, Hash>>] the ids and entries pairs
+      def xrevrange(key, range_end = '+', start = '-', count: nil)
+        # To keep compatibility with Redis
+        raise TypeError, "key cannot be nil" if key.nil?
+
+        args = [key, range_end, start]
+        args.concat(['COUNT', count]) if count
+        send_command(RequestType::X_REV_RANGE, args, &Utils::HashifyStreamEntries)
+      end
+
+      # Returns the number of entries inside a stream.
+      #
+      # @example With key
+      #   valkey.xlen('mystream')
+      #
+      # @param key [String] the stream key
+      #
+      # @return [Integer] the number of entries
+      def xlen(key)
+        # To keep compatibility with Redis
+        raise TypeError, "key cannot be nil" if key.nil?
+
+        send_command(RequestType::X_LEN, [key])
+      end
+
+      # Fetches entries from one or multiple streams. Optionally blocking.
+      #
+      # @example With a key
+      #   valkey.xread('mystream', '0-0')
+      # @example With multiple keys
+      #   valkey.xread(%w[mystream1 mystream2], %w[0-0 0-0])
+      # @example With count option
+      #   valkey.xread('mystream', '0-0', count: 2)
+      # @example With block option
+      #   valkey.xread('mystream', '$', block: 1000)
+      #
+      # @param keys  [Array<String>] one or multiple stream keys
+      # @param ids   [Array<String>] one or multiple entry ids
+      # @param count [Integer]       the number of entries as limit per stream
+      # @param block [Integer]       the number of milliseconds as blocking timeout
+      #
+      # @return [Hash{String => Hash{String => Hash}}] the entries
+      def xread(keys, ids, count: nil, block: nil)
+        args = []
+        args << 'COUNT' << count if count
+        args << 'BLOCK' << block.to_i if block
+        _xread(RequestType::X_READ, args, keys, ids, block)
+      end
+
+      # Manages the consumer group of the stream.
+      #
+      # @example With `create` subcommand
+      #   valkey.xgroup(:create, 'mystream', 'mygroup', '$')
+      # @example With `createconsumer` subcommand
+      #   valkey.xgroup(:createconsumer, 'mystream', 'mygroup', 'consumer1')
+      # @example With `setid` subcommand
+      #   valkey.xgroup(:setid, 'mystream', 'mygroup', '$')
+      # @example With `destroy` subcommand
+      #   valkey.xgroup(:destroy, 'mystream', 'mygroup')
+      # @example With `delconsumer` subcommand
+      #   valkey.xgroup(:delconsumer, 'mystream', 'mygroup', 'consumer1')
+      #
+      # @param subcommand     [String] `create` `createconsumer` `setid` `destroy` `delconsumer`
+      # @param key            [String] the stream key
+      # @param group          [String] the consumer group name
+      # @param id_or_consumer [String]
+      #   * the entry id or `$`, required if subcommand is `create` or `setid`
+      #   * the consumer name, required if subcommand is `delconsumer`
+      # @param mkstream [Boolean] whether to create an empty stream automatically or not
+      #
+      # @return [String] `OK` if subcommand is `create` or `setid`
+      # @return [Integer] effected count if subcommand is `createconsumer` or `destroy` or `delconsumer`
+      def xgroup(subcommand, key, group, id_or_consumer = nil, mkstream: false)
+        request =
+          case subcommand.to_s.downcase
+          when 'create'
+            RequestType::X_GROUP_CREATE
+          when 'createconsumer'
+            RequestType::X_GROUP_CREATE_CONSUMER
+          when 'delconsumer'
+            RequestType::X_GROUP_DEL_CONSUMER
+          when 'destroy'
+            RequestType::X_GROUP_DESTROY
+          when 'setid'
+            RequestType::X_GROUP_SET_ID
+          else
+            RequestType::INVALID_REQUEST
+          end
+        args = [key, group, id_or_consumer, (mkstream ? 'MKSTREAM' : nil)].compact
+
+        send_command(request, args)
+      end
+
+      # Fetches a subset of the entries from one or multiple streams related with the consumer group.
+      # Optionally blocking.
+      #
+      # @example With a key
+      #   valkey.xreadgroup('mygroup', 'consumer1', 'mystream', '>')
+      # @example With multiple keys
+      #   valkey.xreadgroup('mygroup', 'consumer1', %w[mystream1 mystream2], %w[> >])
+      # @example With count option
+      #   valkey.xreadgroup('mygroup', 'consumer1', 'mystream', '>', count: 2)
+      # @example With block option
+      #   valkey.xreadgroup('mygroup', 'consumer1', 'mystream', '>', block: 1000)
+      # @example With noack option
+      #   valkey.xreadgroup('mygroup', 'consumer1', 'mystream', '>', noack: true)
+      #
+      # @param group    [String]        the consumer group name
+      # @param consumer [String]        the consumer name
+      # @param keys     [Array<String>] one or multiple stream keys
+      # @param ids      [Array<String>] one or multiple entry ids
+      # @param opts     [Hash]          several options for `XREADGROUP` command
+      #
+      # @option opts [Integer] :count the number of entries as limit
+      # @option opts [Integer] :block the number of milliseconds as blocking timeout
+      # @option opts [Boolean] :noack whether message loss is acceptable or not
+      #
+      # @return [Hash{String => Hash{String => Hash}}] the entries
+      def xreadgroup(group, consumer, keys, ids, count: nil, block: nil, noack: nil)
+        args = ['GROUP', group, consumer]
+        args << 'COUNT' << count if count
+        args << 'BLOCK' << block.to_i if block
+        args << 'NOACK' if noack
+        _xread(RequestType::X_READ_GROUP, args, keys, ids, block)
+      end
+
+      # Removes one or multiple entries from the pending entries list of a stream consumer group.
+      #
+      # @example With a entry id
+      #   valkey.xack('mystream', 'mygroup', '1526569495631-0')
+      # @example With splatted entry ids
+      #   valkey.xack('mystream', 'mygroup', '0-1', '0-2')
+      # @example With arrayed entry ids
+      #   valkey.xack('mystream', 'mygroup', %w[0-1 0-2])
+      #
+      # @param key   [String]        the stream key
+      # @param group [String]        the consumer group name
+      # @param ids   [Array<String>] one or multiple entry ids
+      #
+      # @return [Integer] the number of entries successfully acknowledged
+      def xack(key, group, *ids)
+        # To keep compatibility with Redis
+        raise TypeError, "key cannot be nil" if key.nil?
+        raise TypeError, "group cannot be nil" if group.nil?
+
+        args = [key, group].concat(ids.flatten)
+        send_command(RequestType::X_ACK, args)
+      end
+
+      # Changes the ownership of a pending entry
+      #
+      # @example With splatted entry ids
+      #   valkey.xclaim('mystream', 'mygroup', 'consumer1', 3600000, '0-1', '0-2')
+      # @example With arrayed entry ids
+      #   valkey.xclaim('mystream', 'mygroup', 'consumer1', 3600000, %w[0-1 0-2])
+      # @example With idle option
+      #   valkey.xclaim('mystream', 'mygroup', 'consumer1', 3600000, %w[0-1 0-2], idle: 1000)
+      # @example With time option
+      #   valkey.xclaim('mystream', 'mygroup', 'consumer1', 3600000, %w[0-1 0-2], time: 1542866959000)
+      # @example With retrycount option
+      #   valkey.xclaim('mystream', 'mygroup', 'consumer1', 3600000, %w[0-1 0-2], retrycount: 10)
+      # @example With force option
+      #   valkey.xclaim('mystream', 'mygroup', 'consumer1', 3600000, %w[0-1 0-2], force: true)
+      # @example With justid option
+      #   valkey.xclaim('mystream', 'mygroup', 'consumer1', 3600000, %w[0-1 0-2], justid: true)
+      #
+      # @param key           [String]        the stream key
+      # @param group         [String]        the consumer group name
+      # @param consumer      [String]        the consumer name
+      # @param min_idle_time [Integer]       the number of milliseconds
+      # @param ids           [Array<String>] one or multiple entry ids
+      # @param opts          [Hash]          several options for `XCLAIM` command
+      #
+      # @option opts [Integer] :idle       the number of milliseconds as last time it was delivered of the entry
+      # @option opts [Integer] :time       the number of milliseconds as a specific Unix Epoch time
+      # @option opts [Integer] :retrycount the number of retry counter
+      # @option opts [Boolean] :force      whether to create the pending entry to the pending entries list or not
+      # @option opts [Boolean] :justid     whether to fetch just an array of entry ids or not
+      #
+      # @return [Hash{String => Hash}] the entries successfully claimed
+      # @return [Array<String>]        the entry ids successfully claimed if justid option is `true`
+      def xclaim(key, group, consumer, min_idle_time, *ids, **opts)
+        # To keep compatibility with Redis
+        raise TypeError, "key cannot be nil" if key.nil?
+        raise TypeError, "group cannot be nil" if group.nil?
+
+        args = [key, group, consumer, min_idle_time].concat(ids.flatten)
+        args.concat(['IDLE',       opts[:idle].to_i])  if opts[:idle]
+        args.concat(['TIME',       opts[:time].to_i])  if opts[:time]
+        args.concat(['RETRYCOUNT', opts[:retrycount]]) if opts[:retrycount]
+        args << 'FORCE'                                if opts[:force]
+        args << 'JUSTID'                               if opts[:justid]
+        blk = opts[:justid] ? Utils::Noop : Utils::HashifyStreamEntries
+        send_command(RequestType::X_CLAIM, args, &blk)
+      end
+
+      # Transfers ownership of pending stream entries that match the specified criteria.
+      #
+      # @example Claim next pending message stuck > 5 minutes  and mark as retry
+      #   valkey.xautoclaim('mystream', 'mygroup', 'consumer1', 3600000, '0-0')
+      # @example Claim 50 next pending messages stuck > 5 minutes  and mark as retry
+      #   valkey.xautoclaim('mystream', 'mygroup', 'consumer1', 3600000, '0-0', count: 50)
+      # @example Claim next pending message stuck > 5 minutes and don't mark as retry
+      #   valkey.xautoclaim('mystream', 'mygroup', 'consumer1', 3600000, '0-0', justid: true)
+      # @example Claim next pending message after this id stuck > 5 minutes  and mark as retry
+      #   redis.xautoclaim('mystream', 'mygroup', 'consumer1', 3600000, '1641321233-0')
+      #
+      # @param key           [String]        the stream key
+      # @param group         [String]        the consumer group name
+      # @param consumer      [String]        the consumer name
+      # @param min_idle_time [Integer]       the number of milliseconds
+      # @param start         [String]        entry id to start scanning from or 0-0 for everything
+      # @param count         [Integer]       number of messages to claim (default 1)
+      # @param justid        [Boolean]       whether to fetch just an array of entry ids or not.
+      #                                      Does not increment retry count when true
+      #
+      # @return [Hash{String => Hash}] the entries successfully claimed
+      # @return [Array<String>]        the entry ids successfully claimed if justid option is `true`
+      def xautoclaim(key, group, consumer, min_idle_time, start, count: nil, justid: false)
+        args = [key, group, consumer, min_idle_time, start]
+        if count
+          args << 'COUNT'
+          args << count.to_s
+        end
+        args << 'JUSTID' if justid
+        blk = justid ? Utils::HashifyStreamAutoclaimJustId : Utils::HashifyStreamAutoclaim
+        send_command(RequestType::X_AUTO_CLAIM, args, &blk)
+      end
+
+      # Fetches not acknowledging pending entries
+      #
+      # @example With key and group
+      #   valkey.xpending('mystream', 'mygroup')
+      # @example With range options
+      #   valkey.xpending('mystream', 'mygroup', '-', '+', 10)
+      # @example With range and idle time options
+      #   valkey.xpending('mystream', 'mygroup', '-', '+', 10, idle: 9000)
+      # @example With range and consumer options
+      #   valkey.xpending('mystream', 'mygroup', '-', '+', 10, 'consumer1')
+      #
+      # @param key      [String]  the stream key
+      # @param group    [String]  the consumer group name
+      # @param start    [String]  start first entry id of range
+      # @param end      [String]  end   last entry id of range
+      # @param count    [Integer] count the number of entries as limit
+      # @param consumer [String]  the consumer name
+      #
+      # @option opts [Integer] :idle       pending message minimum idle time in milliseconds
+      #
+      # @return [Hash]        the summary of pending entries
+      # @return [Array<Hash>] the pending entries details if options were specified
+      def xpending(key, group, *args, idle: nil)
+        command_args = [key, group]
+        command_args << 'IDLE' << Integer(idle) if idle
+        case args.size
+        when 0, 3, 4
+          command_args.concat(args)
+        else
+          raise ArgumentError, "wrong number of arguments (given #{args.size + 2}, expected 2, 5 or 6)"
+        end
+
+        summary_needed = args.empty?
+        blk = summary_needed ? Utils::HashifyStreamPendings : Utils::HashifyStreamPendingDetails
+        send_command(RequestType::X_PENDING, command_args, &blk)
+      end
+
+      private
+
+      def _xread(request, args, keys, ids, _blocking_timeout_msec)
+        keys = keys.is_a?(Array) ? keys : [keys]
+        ids = ids.is_a?(Array) ? ids : [ids]
+        args << 'STREAMS'
+        args.concat(keys)
+        args.concat(ids)
+
+        # @todo reproduce the behavior of Redis
+        send_command(request, args, &Utils::HashifyStreams)
+      end
+    end
+  end
+end

--- a/lib/valkey/commands/string_commands.rb
+++ b/lib/valkey/commands/string_commands.rb
@@ -332,7 +332,8 @@ class Valkey
         args << "MINMATCHLEN" << min_match_len if min_match_len
         args << "WITHMATCHLEN" if with_match_len
 
-        send_command(RequestType::LCS, args)
+        blk = idx ? Utils::Arrayify : Utils::Noop
+        send_command(RequestType::LCS, args, &blk)
       end
     end
   end

--- a/test/lint/stream_commands.rb
+++ b/test/lint/stream_commands.rb
@@ -1,0 +1,877 @@
+# frozen_string_literal: true
+
+module Lint
+  module StreamCommands
+    ENTRY_ID_FORMAT = /\d+-\d+/.freeze
+
+    def test_xinfo_with_stream_subcommand
+      r.xadd('s1', { f: 'v1' })
+      r.xadd('s1', { f: 'v2' })
+      r.xadd('s1', { f: 'v3' })
+      r.xadd('s1', { f: 'v4' })
+      r.xgroup(:create, 's1', 'g1', '$')
+
+      actual = r.xinfo(:stream, 's1')
+
+      assert_match ENTRY_ID_FORMAT, actual['last-generated-id']
+      assert_equal 4, actual['length']
+      assert_equal 1, actual['groups']
+      assert_equal true, actual.key?('radix-tree-keys')
+      assert_equal true, actual.key?('radix-tree-nodes')
+      assert_kind_of Array, actual['first-entry']
+      assert_kind_of Array, actual['last-entry']
+    end
+
+    def test_xinfo_with_groups_subcommand
+      r.xadd('s1', { f: 'v' })
+      r.xgroup(:create, 's1', 'g1', '$')
+
+      actual = r.xinfo(:groups, 's1').first
+
+      assert_equal 0, actual['consumers']
+      assert_equal 0, actual['pending']
+      assert_equal 'g1', actual['name']
+      assert_match ENTRY_ID_FORMAT, actual['last-delivered-id']
+    end
+
+    def test_xinfo_with_consumers_subcommand
+      r.xadd('s1', { f: 'v' })
+      r.xgroup(:create, 's1', 'g1', '$')
+      assert_equal [], r.xinfo(:consumers, 's1', 'g1')
+    end
+
+    def test_xinfo_with_invalid_arguments
+      assert_raises(Valkey::CommandError) { r.xinfo('', '', '') }
+      assert_raises(Valkey::CommandError) { r.xinfo(nil, nil, nil) }
+      assert_raises(Valkey::CommandError) { r.xinfo(:stream, nil) }
+      assert_raises(Valkey::CommandError) { r.xinfo(:groups, nil) }
+      assert_raises(Valkey::CommandError) { r.xinfo(:consumers, nil) }
+      assert_raises(Valkey::CommandError) { r.xinfo(:consumers, 's1', nil) }
+    end
+
+    def test_xadd_with_entry_as_splatted_params
+      assert_match ENTRY_ID_FORMAT, r.xadd('s1', { f1: 'v1', f2: 'v2' })
+    end
+
+    def test_xadd_with_entry_as_a_hash_literal
+      entry = { f1: 'v1', f2: 'v2' }
+      assert_match ENTRY_ID_FORMAT, r.xadd('s1', entry)
+    end
+
+    def test_xadd_with_entry_id_option
+      entry_id = "#{Time.now.strftime('%s%L')}-14"
+      assert_equal entry_id, r.xadd('s1', { f1: 'v1', f2: 'v2' }, id: entry_id)
+    end
+
+    def test_xadd_with_invalid_entry_id_option
+      entry_id = 'invalid-format-entry-id'
+      assert_raises(Valkey::CommandError, 'ERR Invalid stream ID specified as stream command argument') do
+        r.xadd('s1', { f1: 'v1', f2: 'v2' }, id: entry_id)
+      end
+    end
+
+    def test_xadd_with_old_entry_id_option
+      r.xadd('s1', { f1: 'v1', f2: 'v2' }, id: '0-1')
+      err_msg = 'ERR The ID specified in XADD is equal or smaller than the target stream top item'
+      assert_raises(Valkey::CommandError, err_msg) do
+        r.xadd('s1', { f1: 'v1', f2: 'v2' }, id: '0-0')
+      end
+    end
+
+    def test_xadd_with_maxlen_and_approximate_option
+      actual = r.xadd('s1', { f1: 'v1', f2: 'v2' }, maxlen: 2, approximate: true)
+      assert_match ENTRY_ID_FORMAT, actual
+    end
+
+    def test_xadd_with_minid_and_approximate_option
+      actual = r.xadd('s1', { f1: 'v1', f2: 'v2' }, minid: '0-1', approximate: true)
+      assert_match ENTRY_ID_FORMAT, actual
+    end
+
+    def test_xadd_with_both_maxlen_and_minid
+      assert_raises(ArgumentError) { r.xadd('s1', { f1: 'v1', f2: 'v2' }, maxlen: 2, minid: '0-1', approximate: true) }
+    end
+
+    def test_xadd_with_nomkstream_option
+      actual = r.xadd('s1', { f1: 'v1', f2: 'v2' }, nomkstream: true)
+      assert_nil actual
+
+      actual = r.xadd('s1', { f1: 'v1', f2: 'v2' }, nomkstream: false)
+      assert_match ENTRY_ID_FORMAT, actual
+    end
+
+    def test_xadd_with_invalid_arguments
+      assert_raises(Valkey::CommandError) { r.xadd(nil, {}) }
+      assert_raises(Valkey::CommandError) { r.xadd('', {}) }
+      assert_raises(Valkey::CommandError) { r.xadd('s1', {}) }
+    end
+
+    def test_xtrim
+      r.xadd('s1', { f: 'v1' })
+      r.xadd('s1', { f: 'v2' })
+      r.xadd('s1', { f: 'v3' })
+      r.xadd('s1', { f: 'v4' })
+      assert_equal 2, r.xtrim('s1', 2)
+    end
+
+    def test_xtrim_with_approximate_option
+      r.xadd('s1', { f: 'v1' })
+      r.xadd('s1', { f: 'v2' })
+      r.xadd('s1', { f: 'v3' })
+      r.xadd('s1', { f: 'v4' })
+      assert_equal 0, r.xtrim('s1', 2, approximate: true)
+    end
+
+    def test_xtrim_with_limit_option
+      original = r.config(:get, 'stream-node-max-entries')['stream-node-max-entries']
+      r.config(:set, 'stream-node-max-entries', 1)
+
+      r.xadd('s1', { f: 'v1' })
+      r.xadd('s1', { f: 'v2' })
+      r.xadd('s1', { f: 'v3' })
+      r.xadd('s1', { f: 'v4' })
+
+      assert_equal 1, r.xtrim('s1', 0, approximate: true, limit: 1)
+      error = assert_raises(Valkey::CommandError) { r.xtrim('s1', 0, limit: 1) }
+      assert_includes error.message, "syntax error, LIMIT cannot be used without the special ~ option"
+    ensure
+      r.config(:set, 'stream-node-max-entries', original)
+    end
+
+    def test_xtrim_with_maxlen_strategy
+      r.xadd('s1', { f: 'v1' }, id: '0-1')
+      r.xadd('s1', { f: 'v1' }, id: '0-2')
+      r.xadd('s1', { f: 'v1' }, id: '1-0')
+      r.xadd('s1', { f: 'v1' }, id: '1-1')
+      assert_equal(2, r.xtrim('s1', 2, strategy: 'MAXLEN'))
+    end
+
+    def test_xtrim_with_minid_strategy
+      r.xadd('s1', { f: 'v1' }, id: '0-1')
+      r.xadd('s1', { f: 'v1' }, id: '0-2')
+      r.xadd('s1', { f: 'v1' }, id: '1-0')
+      r.xadd('s1', { f: 'v1' }, id: '1-1')
+      assert_equal(2, r.xtrim('s1', '1-0', strategy: 'MINID'))
+    end
+
+    def test_xtrim_with_approximate_minid_strategy
+      r.xadd('s1', { f: 'v1' }, id: '0-1')
+      r.xadd('s1', { f: 'v1' }, id: '0-2')
+      r.xadd('s1', { f: 'v1' }, id: '1-0')
+      r.xadd('s1', { f: 'v1' }, id: '1-1')
+      assert_equal(0, r.xtrim('s1', '1-0', strategy: 'MINID', approximate: true))
+    end
+
+    def test_xtrim_with_invalid_strategy
+      r.xadd('s1', { f: 'v1' })
+      error = assert_raises(Valkey::CommandError) { r.xtrim('s1', '1-0', strategy: '') }
+      assert_includes error.message, "syntax error"
+    end
+
+    def test_xtrim_with_not_existed_stream
+      assert_equal 0, r.xtrim('not-existed-stream', 2)
+    end
+
+    def test_xtrim_with_invalid_arguments
+      assert_raises(Valkey::CommandError) { r.xtrim('', '') }
+      assert_equal 0, r.xtrim('s1', 0)
+      assert_raises(Valkey::CommandError) { r.xtrim('s1', -1, approximate: true) }
+    end
+
+    def test_xdel_with_splatted_entry_ids
+      r.xadd('s1', { f: '1' }, id: '0-1')
+      r.xadd('s1', { f: '2' }, id: '0-2')
+      assert_equal 2, r.xdel('s1', '0-1', '0-2', '0-3')
+    end
+
+    def test_xdel_with_arrayed_entry_ids
+      r.xadd('s1', { f: '1' }, id: '0-1')
+      assert_equal 1, r.xdel('s1', %w[0-1 0-2])
+    end
+
+    def test_xdel_with_invalid_entry_ids
+      assert_equal 0, r.xdel('s1', 'invalid_format')
+    end
+
+    def test_xdel_with_invalid_arguments
+      assert_raises(TypeError) { r.xdel(nil, nil) }
+      assert_raises(TypeError) { r.xdel(nil, [nil]) }
+      assert_equal 0, r.xdel('', '')
+      assert_equal 0, r.xdel('', [''])
+      assert_raises(Valkey::CommandError) { r.xdel('s1', []) }
+    end
+
+    def test_xrange
+      r.xadd('s1', { f: 'v1' }, id: '0-1')
+      r.xadd('s1', { f: 'v2' }, id: '0-2')
+      r.xadd('s1', { f: 'v3' }, id: '0-3')
+
+      actual = r.xrange('s1')
+
+      assert_equal(%w[v1 v2 v3], actual.map { |i| i.last['f'] })
+    end
+
+    def test_xrange_with_start_option
+      r.xadd('s1', { f: 'v' }, id: '0-1')
+      r.xadd('s1', { f: 'v' }, id: '0-2')
+      r.xadd('s1', { f: 'v' }, id: '0-3')
+
+      actual = r.xrange('s1', '0-2')
+
+      assert_equal %w[0-2 0-3], actual.map(&:first)
+    end
+
+    def test_xrange_with_end_option
+      r.xadd('s1', { f: 'v' }, id: '0-1')
+      r.xadd('s1', { f: 'v' }, id: '0-2')
+      r.xadd('s1', { f: 'v' }, id: '0-3')
+
+      actual = r.xrange('s1', '-', '0-2')
+      assert_equal %w[0-1 0-2], actual.map(&:first)
+    end
+
+    def test_xrange_with_start_and_end_options
+      r.xadd('s1', { f: 'v' }, id: '0-1')
+      r.xadd('s1', { f: 'v' }, id: '0-2')
+      r.xadd('s1', { f: 'v' }, id: '0-3')
+
+      actual = r.xrange('s1', '0-2', '0-2')
+
+      assert_equal %w[0-2], actual.map(&:first)
+    end
+
+    def test_xrange_with_incomplete_entry_id_options
+      r.xadd('s1', { f: 'v' }, id: '0-1')
+      r.xadd('s1', { f: 'v' }, id: '1-1')
+      r.xadd('s1', { f: 'v' }, id: '2-1')
+
+      actual = r.xrange('s1', '0', '1')
+
+      assert_equal 2, actual.size
+      assert_equal %w[0-1 1-1], actual.map(&:first)
+    end
+
+    def test_xrange_with_count_option
+      r.xadd('s1', { f: 'v' }, id: '0-1')
+      r.xadd('s1', { f: 'v' }, id: '0-2')
+      r.xadd('s1', { f: 'v' }, id: '0-3')
+
+      actual = r.xrange('s1', count: 2)
+
+      assert_equal %w[0-1 0-2], actual.map(&:first)
+    end
+
+    def test_xrange_with_not_existed_stream_key
+      assert_equal([], r.xrange('not-existed'))
+    end
+
+    def test_xrange_with_invalid_entry_id_options
+      assert_raises(Valkey::CommandError) { r.xrange('s1', 'invalid', 'invalid') }
+    end
+
+    def test_xrange_with_invalid_arguments
+      assert_raises(TypeError) { r.xrange(nil) }
+      assert_equal([], r.xrange(''))
+    end
+
+    def test_xrevrange
+      r.xadd('s1', { f: 'v1' }, id: '0-1')
+      r.xadd('s1', { f: 'v2' }, id: '0-2')
+      r.xadd('s1', { f: 'v3' }, id: '0-3')
+
+      actual = r.xrevrange('s1')
+
+      assert_equal %w[0-3 0-2 0-1], actual.map(&:first)
+      assert_equal(%w[v3 v2 v1], actual.map { |i| i.last['f'] })
+    end
+
+    def test_xrevrange_with_start_option
+      r.xadd('s1', { f: 'v' }, id: '0-1')
+      r.xadd('s1', { f: 'v' }, id: '0-2')
+      r.xadd('s1', { f: 'v' }, id: '0-3')
+
+      actual = r.xrevrange('s1', '+', '0-2')
+
+      assert_equal %w[0-3 0-2], actual.map(&:first)
+    end
+
+    def test_xrevrange_with_end_option
+      r.xadd('s1', { f: 'v' }, id: '0-1')
+      r.xadd('s1', { f: 'v' }, id: '0-2')
+      r.xadd('s1', { f: 'v' }, id: '0-3')
+
+      actual = r.xrevrange('s1', '0-2')
+
+      assert_equal %w[0-2 0-1], actual.map(&:first)
+    end
+
+    def test_xrevrange_with_start_and_end_options
+      r.xadd('s1', { f: 'v' }, id: '0-1')
+      r.xadd('s1', { f: 'v' }, id: '0-2')
+      r.xadd('s1', { f: 'v' }, id: '0-3')
+
+      actual = r.xrevrange('s1', '0-2', '0-2')
+
+      assert_equal %w[0-2], actual.map(&:first)
+    end
+
+    def test_xrevrange_with_incomplete_entry_id_options
+      r.xadd('s1', { f: 'v' }, id: '0-1')
+      r.xadd('s1', { f: 'v' }, id: '1-1')
+      r.xadd('s1', { f: 'v' }, id: '2-1')
+
+      actual = r.xrevrange('s1', '1', '0')
+
+      assert_equal 2, actual.size
+      assert_equal '1-1', actual.first.first
+    end
+
+    def test_xrevrange_with_count_option
+      r.xadd('s1', { f: 'v' }, id: '0-1')
+      r.xadd('s1', { f: 'v' }, id: '0-2')
+      r.xadd('s1', { f: 'v' }, id: '0-3')
+
+      actual = r.xrevrange('s1', count: 2)
+
+      assert_equal 2, actual.size
+      assert_equal '0-3', actual.first.first
+    end
+
+    def test_xrevrange_with_not_existed_stream_key
+      assert_equal([], r.xrevrange('not-existed'))
+    end
+
+    def test_xrevrange_with_invalid_entry_id_options
+      assert_raises(Valkey::CommandError) { r.xrevrange('s1', 'invalid', 'invalid') }
+    end
+
+    def test_xrevrange_with_invalid_arguments
+      assert_raises(TypeError) { r.xrevrange(nil) }
+      assert_equal([], r.xrevrange(''))
+    end
+
+    def test_xlen
+      r.xadd('s1', { f: 'v1' })
+      r.xadd('s1', { f: 'v2' })
+      assert_equal 2, r.xlen('s1')
+    end
+
+    def test_xlen_with_not_existed_key
+      assert_equal 0, r.xlen('not-existed')
+    end
+
+    def test_xlen_with_invalid_key
+      assert_raises(TypeError) { r.xlen(nil) }
+      assert_equal 0, r.xlen('')
+    end
+
+    def test_xread_with_a_key
+      r.xadd('s1', { f: 'v1' }, id: '0-1')
+      r.xadd('s1', { f: 'v2' }, id: '0-2')
+
+      actual = r.xread('s1', 0)
+
+      assert_equal(%w[v1 v2], actual.fetch('s1').map { |i| i.last['f'] })
+    end
+
+    def test_xread_with_multiple_keys
+      r.xadd('s1', { f: 'v01' }, id: '0-1')
+      r.xadd('s1', { f: 'v02' }, id: '0-2')
+      r.xadd('s2', { f: 'v11' }, id: '1-1')
+      r.xadd('s2', { f: 'v12' }, id: '1-2')
+
+      actual = r.xread(%w[s1 s2], %w[0-1 1-1])
+
+      assert_equal 1, actual['s1'].size
+      assert_equal 1, actual['s2'].size
+      assert_equal 'v02', actual['s1'][0].last['f']
+      assert_equal 'v12', actual['s2'][0].last['f']
+    end
+
+    def test_xread_with_count_option
+      r.xadd('s1', { f: 'v1' }, id: '0-1')
+      r.xadd('s1', { f: 'v2' }, id: '0-2')
+
+      actual = r.xread('s1', 0, count: 1)
+
+      assert_equal 1, actual['s1'].size
+    end
+
+    def test_xread_with_block_option
+      actual = r.xread('s1', '$', block: LOW_TIMEOUT * 1000)
+      assert_equal({}, actual)
+    end
+
+    def test_xread_does_not_raise_timeout_error_when_the_block_option_is_zero_msec
+      prepared = false
+      actual = nil
+      thread = Thread.new do
+        prepared = true
+        actual = r.xread('s1', 0, block: 0)
+      ensure
+        prepared = true
+      end
+      Thread.pass until prepared
+      r2 = init _new_client
+      r2.xadd('s1', { f: 'v1' }, id: '0-1')
+      thread.join(3)
+
+      assert_equal(['v1'], actual.fetch('s1').map { |i| i.last['f'] })
+    end
+
+    def test_xread_with_invalid_arguments
+      assert_raises(Valkey::CommandError) { r.xread(nil, nil) }
+      assert_raises(Valkey::CommandError) { r.xread('', '') }
+      assert_raises(Valkey::CommandError) { r.xread([], []) }
+      assert_raises(Valkey::CommandError) { r.xread([''], ['']) }
+      assert_raises(Valkey::CommandError) { r.xread('s1', '0-0', count: 'a') }
+      assert_raises(Valkey::CommandError) { r.xread('s1', %w[0-0 0-0]) }
+    end
+
+    def test_xgroup_with_create_subcommand
+      r.xadd('s1', { f: 'v' })
+      assert_equal 'OK', r.xgroup(:create, 's1', 'g1', '$')
+    end
+
+    def test_xgroup_with_create_subcommand_and_mkstream_option
+      err_msg = 'ERR The XGROUP subcommand requires the key to exist. '\
+        'Note that for CREATE you may want to use the MKSTREAM option to create an empty stream automatically.'
+      assert_raises(Valkey::CommandError, err_msg) { r.xgroup(:create, 's2', 'g1', '$') }
+      assert_equal 'OK', r.xgroup(:create, 's2', 'g1', '$', mkstream: true)
+    end
+
+    def test_xgroup_with_create_subcommand_and_existed_stream_key
+      r.xadd('s1', { f: 'v' })
+      r.xgroup(:create, 's1', 'g1', '$')
+      assert_raises(Valkey::CommandError, 'BUSYGROUP Consumer Group name already exists') do
+        r.xgroup(:create, 's1', 'g1', '$')
+      end
+    end
+
+    def test_xgroup_with_setid_subcommand
+      r.xadd('s1', { f: 'v' })
+      r.xgroup(:create, 's1', 'g1', '$')
+      assert_equal 'OK', r.xgroup(:setid, 's1', 'g1', '0')
+    end
+
+    def test_xgroup_with_destroy_subcommand
+      r.xadd('s1', { f: 'v' })
+      r.xgroup(:create, 's1', 'g1', '$')
+      assert_equal true, r.xgroup(:destroy, 's1', 'g1')
+    end
+
+    def test_xgroup_with_delconsumer_subcommand
+      r.xadd('s1', { f: 'v' })
+      r.xgroup(:create, 's1', 'g1', '$')
+      assert_equal 0, r.xgroup(:delconsumer, 's1', 'g1', 'c1')
+    end
+
+    def test_xgroup_with_invalid_arguments
+      assert_raises(Valkey::CommandError) { r.xgroup(nil, nil, nil) }
+      assert_raises(Valkey::CommandError) { r.xgroup('', '', '') }
+    end
+
+    def test_xreadgroup_with_a_key
+      r.xadd('s1', { f: 'v1' }, id: '0-1')
+      r.xgroup(:create, 's1', 'g1', '$')
+      r.xadd('s1', { f: 'v2' }, id: '0-2')
+      r.xadd('s1', { f: 'v3' }, id: '0-3')
+
+      actual = r.xreadgroup('g1', 'c1', 's1', '>')
+
+      assert_equal 2, actual['s1'].size
+      assert_equal 'v2', actual['s1'][0].last['f']
+      assert_equal 'v3', actual['s1'][1].last['f']
+    end
+
+    def test_xreadgroup_with_multiple_keys
+      r.xadd('s1', { f: 'v01' }, id: '0-1')
+      r.xgroup(:create, 's1', 'g1', '$')
+      r.xadd('s2', { f: 'v11' }, id: '1-1')
+      r.xgroup(:create, 's2', 'g1', '$')
+      r.xadd('s1', { f: 'v02' }, id: '0-2')
+      r.xadd('s2', { f: 'v12' }, id: '1-2')
+
+      actual = r.xreadgroup('g1', 'c1', %w[s1 s2], %w[> >])
+
+      assert_equal 1, actual['s1'].size
+      assert_equal 1, actual['s2'].size
+      assert_equal 'v02', actual['s1'][0].last['f']
+      assert_equal 'v12', actual['s2'][0].last['f']
+    end
+
+    def test_xreadgroup_with_count_option
+      r.xadd('s1', { f: 'v1' }, id: '0-1')
+      r.xgroup(:create, 's1', 'g1', '$')
+      r.xadd('s1', { f: 'v2' }, id: '0-2')
+      r.xadd('s1', { f: 'v3' }, id: '0-3')
+
+      actual = r.xreadgroup('g1', 'c1', 's1', '>', count: 1)
+
+      assert_equal 1, actual['s1'].size
+    end
+
+    def test_xreadgroup_with_noack_option
+      r.xadd('s1', { f: 'v1' }, id: '0-1')
+      r.xgroup(:create, 's1', 'g1', '$')
+      r.xadd('s1', { f: 'v2' }, id: '0-2')
+      r.xadd('s1', { f: 'v3' }, id: '0-3')
+
+      actual = r.xreadgroup('g1', 'c1', 's1', '>', noack: true)
+
+      assert_equal 2, actual['s1'].size
+    end
+
+    def test_xreadgroup_with_block_option
+      r.xadd('s1', { f: 'v' })
+      r.xgroup(:create, 's1', 'g1', '$')
+
+      actual = r.xreadgroup('g1', 'c1', 's1', '>', block: LOW_TIMEOUT * 1000)
+
+      assert_equal({}, actual)
+    end
+
+    def test_xreadgroup_with_invalid_arguments
+      assert_raises(Valkey::CommandError) { r.xreadgroup(nil, nil, nil, nil) }
+      assert_raises(Valkey::CommandError) { r.xreadgroup('', '', '', '') }
+      assert_raises(Valkey::CommandError) { r.xreadgroup('', '', [], []) }
+      assert_raises(Valkey::CommandError) { r.xreadgroup('', '', [''], ['']) }
+      r.xadd('s1', { f: 'v1' }, id: '0-1')
+      r.xgroup(:create, 's1', 'g1', '$')
+      assert_raises(Valkey::CommandError) { r.xreadgroup('g1', 'c1', 's1', '>', count: 'a') }
+      assert_raises(Valkey::CommandError) { r.xreadgroup('g1', 'c1', 's1', %w[> >]) }
+    end
+
+    def test_xreadgroup_a_trimmed_entry
+      r.xgroup(:create, 'k1', 'g1', '0', mkstream: true)
+      entry_id = r.xadd('k1', { value: 'v1' })
+
+      assert_equal({ 'k1' => [[entry_id, { 'value' => 'v1' }]] }, r.xreadgroup('g1', 'c1', 'k1', '>'))
+      assert_equal({ 'k1' => [[entry_id, { 'value' => 'v1' }]] }, r.xreadgroup('g1', 'c1', 'k1', '0'))
+      r.xtrim('k1', 0)
+
+      assert_equal({ 'k1' => [[entry_id, nil]] }, r.xreadgroup('g1', 'c1', 'k1', '0'))
+    end
+
+    def test_xack_with_a_entry_id
+      r.xadd('s1', { f: 'v1' }, id: '0-1')
+      r.xgroup(:create, 's1', 'g1', '$')
+      r.xadd('s1', { f: 'v2' }, id: '0-2')
+      r.xreadgroup('g1', 'c1', 's1', '>')
+      r.xadd('s1', { f: 'v3' }, id: '0-3')
+      assert_equal 1, r.xack('s1', 'g1', '0-2')
+    end
+
+    def test_xack_with_splatted_entry_ids
+      r.xadd('s1', { f: 'v1' }, id: '0-1')
+      r.xgroup(:create, 's1', 'g1', '$')
+      r.xadd('s1', { f: 'v2' }, id: '0-2')
+      r.xadd('s1', { f: 'v3' }, id: '0-3')
+      r.xreadgroup('g1', 'c1', 's1', '>')
+      r.xadd('s1', { f: 'v4' }, id: '0-4')
+      r.xadd('s1', { f: 'v5' }, id: '0-5')
+      assert_equal 2, r.xack('s1', 'g1', '0-2', '0-3')
+    end
+
+    def test_xack_with_arrayed_entry_ids
+      r.xadd('s1', { f: 'v1' }, id: '0-1')
+      r.xgroup(:create, 's1', 'g1', '$')
+      r.xadd('s1', { f: 'v2' }, id: '0-2')
+      r.xadd('s1', { f: 'v3' }, id: '0-3')
+      r.xreadgroup('g1', 'c1', 's1', '>')
+      r.xadd('s1', { f: 'v4' }, id: '0-4')
+      r.xadd('s1', { f: 'v5' }, id: '0-5')
+      assert_equal 2, r.xack('s1', 'g1', %w[0-2 0-3])
+    end
+
+    def test_xack_with_invalid_arguments
+      assert_raises(TypeError) { r.xack(nil, nil, nil) }
+      assert_equal 0, r.xack('', '', '')
+      assert_raises(Valkey::CommandError) { r.xack('', '', []) }
+      assert_equal 0, r.xack('', '', [''])
+    end
+
+    def test_xclaim_with_splatted_entry_ids
+      r.xadd('s1', { f: 'v1' }, id: '0-1')
+      r.xgroup(:create, 's1', 'g1', '$')
+      r.xadd('s1', { f: 'v2' }, id: '0-2')
+      r.xadd('s1', { f: 'v3' }, id: '0-3')
+      r.xreadgroup('g1', 'c1', 's1', '>')
+      sleep 0.01
+
+      actual = r.xclaim('s1', 'g1', 'c2', 10, '0-2', '0-3')
+
+      assert_equal %w[0-2 0-3], actual.map(&:first)
+      assert_equal(%w[v2 v3], actual.map { |i| i.last['f'] })
+    end
+
+    def test_xclaim_with_arrayed_entry_ids
+      r.xadd('s1', { f: 'v1' }, id: '0-1')
+      r.xgroup(:create, 's1', 'g1', '$')
+      r.xadd('s1', { f: 'v2' }, id: '0-2')
+      r.xadd('s1', { f: 'v3' }, id: '0-3')
+      r.xreadgroup('g1', 'c1', 's1', '>')
+      sleep 0.01
+
+      actual = r.xclaim('s1', 'g1', 'c2', 10, %w[0-2 0-3])
+
+      assert_equal %w[0-2 0-3], actual.map(&:first)
+      assert_equal(%w[v2 v3], actual.map { |i| i.last['f'] })
+    end
+
+    def test_xclaim_with_idle_option
+      r.xadd('s1', { f: 'v1' }, id: '0-1')
+      r.xgroup(:create, 's1', 'g1', '$')
+      r.xadd('s1', { f: 'v2' }, id: '0-2')
+      r.xadd('s1', { f: 'v3' }, id: '0-3')
+      r.xreadgroup('g1', 'c1', 's1', '>')
+      sleep 0.01
+
+      actual = r.xclaim('s1', 'g1', 'c2', 10, '0-2', '0-3', idle: 0)
+
+      assert_equal %w[0-2 0-3], actual.map(&:first)
+      assert_equal(%w[v2 v3], actual.map { |i| i.last['f'] })
+    end
+
+    def test_xclaim_with_time_option
+      time = Time.now.strftime('%s%L')
+      r.xadd('s1', { f: 'v1' }, id: '0-1')
+      r.xgroup(:create, 's1', 'g1', '$')
+      r.xadd('s1', { f: 'v2' }, id: '0-2')
+      r.xadd('s1', { f: 'v3' }, id: '0-3')
+      r.xreadgroup('g1', 'c1', 's1', '>')
+      sleep 0.01
+
+      actual = r.xclaim('s1', 'g1', 'c2', 10, '0-2', '0-3', time: time)
+
+      assert_equal %w[0-2 0-3], actual.map(&:first)
+      assert_equal(%w[v2 v3], actual.map { |i| i.last['f'] })
+    end
+
+    def test_xclaim_with_retrycount_option
+      r.xadd('s1', { f: 'v1' }, id: '0-1')
+      r.xgroup(:create, 's1', 'g1', '$')
+      r.xadd('s1', { f: 'v2' }, id: '0-2')
+      r.xadd('s1', { f: 'v3' }, id: '0-3')
+      r.xreadgroup('g1', 'c1', 's1', '>')
+      sleep 0.01
+
+      actual = r.xclaim('s1', 'g1', 'c2', 10, '0-2', '0-3', retrycount: 10)
+
+      assert_equal %w[0-2 0-3], actual.map(&:first)
+      assert_equal(%w[v2 v3], actual.map { |i| i.last['f'] })
+    end
+
+    def test_xclaim_with_force_option
+      r.xadd('s1', { f: 'v1' }, id: '0-1')
+      r.xgroup(:create, 's1', 'g1', '$')
+      r.xadd('s1', { f: 'v2' }, id: '0-2')
+      r.xadd('s1', { f: 'v3' }, id: '0-3')
+      r.xreadgroup('g1', 'c1', 's1', '>')
+      sleep 0.01
+
+      actual = r.xclaim('s1', 'g1', 'c2', 10, '0-2', '0-3', force: true)
+
+      assert_equal(%w[0-2 0-3], actual.map(&:first))
+      assert_equal(%w[v2 v3], actual.map { |i| i.last['f'] })
+    end
+
+    def test_xclaim_with_justid_option
+      r.xadd('s1', { f: 'v1' }, id: '0-1')
+      r.xgroup(:create, 's1', 'g1', '$')
+      r.xadd('s1', { f: 'v2' }, id: '0-2')
+      r.xadd('s1', { f: 'v3' }, id: '0-3')
+      r.xreadgroup('g1', 'c1', 's1', '>')
+      sleep 0.01
+
+      actual = r.xclaim('s1', 'g1', 'c2', 10, '0-2', '0-3', justid: true)
+
+      assert_equal 2, actual.size
+      assert_equal '0-2', actual[0]
+      assert_equal '0-3', actual[1]
+    end
+
+    def test_xclaim_with_invalid_arguments
+      assert_raises(TypeError) { r.xclaim(nil, nil, nil, nil, nil) }
+      assert_raises(Valkey::CommandError) { r.xclaim('', '', '', '', '') }
+    end
+
+    def test_xautoclaim
+      r.xadd('s1', { f: 'v1' }, id: '0-1')
+      r.xgroup(:create, 's1', 'g1', '$')
+      r.xadd('s1', { f: 'v2' }, id: '0-2')
+      r.xadd('s1', { f: 'v3' }, id: '0-3')
+      r.xreadgroup('g1', 'c1', 's1', '>')
+      sleep 0.01
+
+      actual = r.xautoclaim('s1', 'g1', 'c2', 10, '0-0')
+
+      assert_equal '0-0', actual['next']
+      assert_equal %w[0-2 0-3], actual['entries'].map(&:first)
+      assert_equal(%w[v2 v3], actual['entries'].map { |i| i.last['f'] })
+    end
+
+    def test_xautoclaim_with_justid_option
+      r.xadd('s1', { f: 'v1' }, id: '0-1')
+      r.xgroup(:create, 's1', 'g1', '$')
+      r.xadd('s1', { f: 'v2' }, id: '0-2')
+      r.xadd('s1', { f: 'v3' }, id: '0-3')
+      r.xreadgroup('g1', 'c1', 's1', '>')
+      sleep 0.01
+
+      actual = r.xautoclaim('s1', 'g1', 'c2', 10, '0-0', justid: true)
+
+      assert_equal '0-0', actual['next']
+      assert_equal %w[0-2 0-3], actual['entries']
+    end
+
+    def test_xautoclaim_with_count_option
+      r.xadd('s1', { f: 'v1' }, id: '0-1')
+      r.xgroup(:create, 's1', 'g1', '$')
+      r.xadd('s1', { f: 'v2' }, id: '0-2')
+      r.xadd('s1', { f: 'v3' }, id: '0-3')
+      r.xreadgroup('g1', 'c1', 's1', '>')
+      sleep 0.01
+
+      actual = r.xautoclaim('s1', 'g1', 'c2', 10, '0-0', count: 1)
+
+      assert_equal '0-3', actual['next']
+      assert_equal %w[0-2], actual['entries'].map(&:first)
+      assert_equal(%w[v2], actual['entries'].map { |i| i.last['f'] })
+    end
+
+    def test_xautoclaim_with_larger_interval
+      r.xadd('s1', { f: 'v1' }, id: '0-1')
+      r.xgroup(:create, 's1', 'g1', '$')
+      r.xadd('s1', { f: 'v2' }, id: '0-2')
+      r.xadd('s1', { f: 'v3' }, id: '0-3')
+      r.xreadgroup('g1', 'c1', 's1', '>')
+      sleep 0.01
+
+      actual = r.xautoclaim('s1', 'g1', 'c2', 36_000, '0-0')
+
+      assert_equal '0-0', actual['next']
+      assert_equal [], actual['entries']
+    end
+
+    def test_xautoclaim_with_deleted_entry
+      r.xadd('s1', { f: 'v1' }, id: '0-1')
+      r.xgroup(:create, 's1', 'g1', '$')
+      r.xadd('s1', { f: 'v2' }, id: '0-2')
+      r.xreadgroup('g1', 'c1', 's1', '>')
+      r.xdel('s1', '0-2')
+      sleep 0.01
+
+      actual = r.xautoclaim('s1', 'g1', 'c2', 0, '0-0')
+
+      assert_equal '0-0', actual['next']
+      assert_equal [], actual['entries']
+    end
+
+    def test_xpending
+      r.xadd('s1', { f: 'v1' }, id: '0-1')
+      r.xgroup(:create, 's1', 'g1', '$')
+      r.xadd('s1', { f: 'v2' }, id: '0-2')
+      r.xadd('s1', { f: 'v3' }, id: '0-3')
+      r.xreadgroup('g1', 'c1', 's1', '>')
+
+      actual = r.xpending('s1', 'g1')
+
+      assert_equal 2, actual['size']
+      assert_equal '0-2', actual['min_entry_id']
+      assert_equal '0-3', actual['max_entry_id']
+      assert_equal '2', actual['consumers']['c1']
+    end
+
+    def test_xpending_with_range_options
+      r.xadd('s1', { f: 'v1' }, id: '0-1')
+      r.xgroup(:create, 's1', 'g1', '$')
+      r.xadd('s1', { f: 'v2' }, id: '0-2')
+      r.xadd('s1', { f: 'v3' }, id: '0-3')
+      r.xreadgroup('g1', 'c1', 's1', '>')
+      r.xadd('s1', { f: 'v4' }, id: '0-4')
+      r.xreadgroup('g1', 'c2', 's1', '>')
+
+      actual = r.xpending('s1', 'g1', '-', '+', 10)
+
+      assert_equal 3, actual.size
+      assert_equal '0-2', actual[0]['entry_id']
+      assert_equal 'c1', actual[0]['consumer']
+      assert_equal true, actual[0]['elapsed'] >= 0
+      assert_equal 1, actual[0]['count']
+      assert_equal '0-3', actual[1]['entry_id']
+      assert_equal 'c1', actual[1]['consumer']
+      assert_equal true, actual[1]['elapsed'] >= 0
+      assert_equal 1, actual[1]['count']
+      assert_equal '0-4', actual[2]['entry_id']
+      assert_equal 'c2', actual[2]['consumer']
+      assert_equal true, actual[2]['elapsed'] >= 0
+      assert_equal 1, actual[2]['count']
+    end
+
+    def test_xpending_with_range_and_idle_options
+      r.xadd('s1', { f: 'v1' }, id: '0-1')
+      r.xgroup(:create, 's1', 'g1', '$')
+      r.xadd('s1', { f: 'v2' }, id: '0-2')
+      r.xadd('s1', { f: 'v3' }, id: '0-3')
+      r.xreadgroup('g1', 'c1', 's1', '>')
+
+      actual = r.xpending('s1', 'g1', '-', '+', 10)
+      assert_equal 2, actual.size
+      actual = r.xpending('s1', 'g1', '-', '+', 10, idle: 10)
+      assert_equal 0, actual.size
+      sleep 0.1
+      actual = r.xpending('s1', 'g1', '-', '+', 10, idle: 10)
+      assert_equal 2, actual.size
+
+      r.xadd('s1', { f: 'v4' }, id: '0-4')
+      r.xreadgroup('g1', 'c2', 's1', '>')
+
+      actual = r.xpending('s1', 'g1', '-', '+', 10, idle: 1000)
+      assert_equal 0, actual.size
+
+      actual = r.xpending('s1', 'g1', '-', '+', 10)
+      assert_equal 3, actual.size
+      actual = r.xpending('s1', 'g1', '-', '+', 10, idle: 10)
+      assert_equal 2, actual.size
+      sleep 0.01
+      actual = r.xpending('s1', 'g1', '-', '+', 10, idle: 10)
+      assert_equal 3, actual.size
+
+      assert_equal '0-2', actual[0]['entry_id']
+      assert_equal 'c1', actual[0]['consumer']
+      assert_equal true, actual[0]['elapsed'] >= 0
+      assert_equal 1, actual[0]['count']
+      assert_equal '0-3', actual[1]['entry_id']
+      assert_equal 'c1', actual[1]['consumer']
+      assert_equal true, actual[1]['elapsed'] >= 0
+      assert_equal 1, actual[1]['count']
+      assert_equal '0-4', actual[2]['entry_id']
+      assert_equal 'c2', actual[2]['consumer']
+      assert_equal true, actual[2]['elapsed'] >= 0
+      assert_equal 1, actual[2]['count']
+    end
+
+    def test_xpending_with_range_and_consumer_options
+      r.xadd('s1', { f: 'v1' }, id: '0-1')
+      r.xgroup(:create, 's1', 'g1', '$')
+      r.xadd('s1', { f: 'v2' }, id: '0-2')
+      r.xadd('s1', { f: 'v3' }, id: '0-3')
+      r.xreadgroup('g1', 'c1', 's1', '>')
+      r.xadd('s1', { f: 'v4' }, id: '0-4')
+      r.xreadgroup('g1', 'c2', 's1', '>')
+
+      actual = r.xpending('s1', 'g1', '-', '+', 10, 'c1')
+
+      assert_equal 2, actual.size
+      assert_equal '0-2', actual[0]['entry_id']
+      assert_equal 'c1', actual[0]['consumer']
+      assert_equal true, actual[0]['elapsed'] >= 0
+      assert_equal 1, actual[0]['count']
+      assert_equal '0-3', actual[1]['entry_id']
+      assert_equal 'c1', actual[1]['consumer']
+      assert_equal true, actual[1]['elapsed'] >= 0
+      assert_equal 1, actual[1]['count']
+    end
+  end
+end

--- a/test/valkey/stream_commands_test.rb
+++ b/test/valkey/stream_commands_test.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestStreamCommands < Minitest::Test
+  include Helper::Client
+  include Lint::StreamCommands
+end


### PR DESCRIPTION
ref #16

- XINFO
- XADD
- XTRIM
- XDEL
- XRANGE
- XREVRANGE
- XLEN
- XREAD
- XGROUP
- XREADGROUP
- XACK
- XCLAIM
- XAUTOCLAIM
- XPENDING

I changed `convert_response` behavior when it's response_type == MAP.
So I adjusted some other commands which fails tests.
I'm not sure whether it alighs with the project way to absorb the gap between redis-rb and GLIDE.
Please let me know if there are any violations.