### PR TITLE
Adding documentation and examples

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,224 @@
+# AGENTS: Ruby Client Context for Agentic Tools
+
+This file provides AI agents and developers with the minimum but sufficient context to work productively with the Valkey GLIDE Ruby client (`valkey-rb`). It covers build commands, testing, contribution requirements, and essential guardrails specific to the Ruby implementation.
+
+## Repository Overview
+
+This is the **Ruby client** for Valkey GLIDE, published as the `valkey-rb` gem. It provides a synchronous, redis-rb-compatible API on top of the Rust GLIDE core via FFI.
+
+**Primary Languages:** Ruby, Rust (FFI native library, built separately from [valkey-glide](https://github.com/valkey-io/valkey-glide))
+
+**Build System:** Bundler, Rake, RubyGems
+
+**Architecture:** Ruby wrapper around `glide-ffi` (`libglide_ffi.so` / `.dylib`) — same FFI path as Go and Python sync clients
+
+**Key Components:**
+
+- `lib/valkey.rb` — Main client, pipelining, response conversion
+- `lib/valkey/bindings.rb` — FFI bindings
+- `lib/valkey/commands/` — Command modules
+- `lib/valkey/opentelemetry.rb` — Native OTel configuration
+- `test/valkey/` — Standalone integration tests
+- `test/cluster/` — Cluster integration tests
+- `test/lint/` — redis-rb compatibility lint suites
+
+## Architecture Quick Facts
+
+**Core Implementation:** Ruby wrapper around glide-core via `glide-ffi` cdylib
+
+**Client Types:** `Valkey` — standalone or cluster (`cluster_mode: true`)
+
+**API Style:** Synchronous, blocking calls (redis-rb style)
+
+**Communication:** Direct FFI (`Bindings.command`, `Bindings.batch`)
+
+**Supported Platforms:**
+
+- Linux: Ubuntu 20+, Amazon Linux 2/2023 (x86_64, aarch64)
+- macOS: 13.7+ (x86_64), 14.7+ (aarch64)
+- **Note:** Alpine Linux / MUSL is **not** supported
+
+**Ruby Versions:** 2.6, 2.7, 3.0, 3.1, 3.2, 3.3, 3.4, JRuby (CI matrix)
+
+**Gem name:** `valkey-rb` on RubyGems
+
+## Build and Test Rules (Agents)
+
+### Preferred (Bundler / Rake)
+
+```bash
+# Setup
+bin/setup                              # bundle install
+
+# Linting
+bundle exec rubocop
+
+# Testing
+bundle exec rake test                  # standalone (default)
+bundle exec rake test:valkey           # standalone explicitly
+bundle exec rake test:cluster          # cluster (needs nodes 7000-7005)
+
+# Verbose / CI mode
+CI=1 bundle exec rake test:valkey
+
+# Console
+bundle exec bin/console
+```
+
+### Raw Equivalents
+
+```bash
+# Run a single test file
+bundle exec ruby test/valkey/string_commands_test.rb
+
+# Run with custom port
+VALKEY_PORT=6379 TIMEOUT=10 bundle exec rake test:valkey
+
+# Load gem from lib/ without install
+RUBYOPT="-I$(pwd)/lib" ruby -r valkey -e 'p Valkey.new.ping'
+```
+
+### Test Prerequisites
+
+| Suite | Server requirement |
+|-------|-------------------|
+| `test:valkey` | Standalone Valkey/Redis on `localhost:6379` (DB 15) |
+| `test:cluster` | 6-node cluster on `127.0.0.1:7000`–`7005` |
+| SSL tests | TLS Valkey on port `6380` + certs in `test/fixtures/ssl/` |
+| Module tests | JSON, Bloom, Search modules loaded (see CI workflow) |
+
+### Rebuild Native FFI (when changing glide-core)
+
+```bash
+cd /path/to/valkey-glide/ffi
+cargo build --release
+cp target/release/libglide_ffi.so /path/to/valkey-glide-ruby/lib/valkey/   # Linux
+# cp target/release/libglide_ffi.dylib ...                                   # macOS
+```
+
+## Contribution Requirements
+
+### Developer Certificate of Origin (DCO) Signoff REQUIRED
+
+All commits must include a `Signed-off-by` line (per [valkey-glide CONTRIBUTING](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)):
+
+```bash
+git commit -s -m "feat(ruby): add new command implementation"
+git config --global format.signOff true
+```
+
+### Conventional Commits
+
+```
+<type>(<scope>): <description>
+```
+
+**Example:** `feat(ruby): implement CLUSTER SCAN with routing options`
+
+**Scopes:** `ruby`, or command family name when appropriate.
+
+### Code Quality Requirements
+
+**RuboCop (required before commit):**
+
+```bash
+bundle exec rubocop
+bundle exec rubocop -A   # auto-correct safe offenses
+```
+
+**Rust FFI (when updating native library):**
+
+```bash
+cd valkey-glide/ffi
+cargo clippy --all-features --all-targets -- -D warnings
+cargo fmt --manifest-path ./Cargo.toml --all
+```
+
+## Guardrails & Policies
+
+### Generated Outputs (Never Commit)
+
+- `*.gem` — built gem packages
+- `coverage/` — coverage reports
+- `tmp/`, `test/tmp/` — temporary test artifacts
+- Regenerated SSL certs unless intentionally updated (`test/fixtures/ssl/*.pem` may be committed for CI)
+- Wrong-platform `libglide_ffi` binaries (build per OS/arch)
+
+### Ruby-Specific Rules
+
+- **Ruby 2.6+ Required:** Minimum per `valkey.gemspec`
+- **FFI dependency:** `ffi ~> 1.17.0` — do not break ABI without rebuilding native lib
+- **Synchronous only:** No async client in this repo; do not add EventMachine/async patterns without design review
+- **redis-rb compatibility:** Prefer matching redis-rb method signatures and return types when implementing commands
+- **Command args:** All FFI args are strings; convert types in Ruby before `send_command`
+- **Pipeline transactions:** `MULTI`/`EXEC`/`DISCARD` in `pipelined` use sequential fallback — do not remove without fixing FFI batch stability
+- **OpenTelemetry:** Init once per process via `Valkey::OpenTelemetry.init`; spans created in FFI layer
+
+### Command Implementation Guidelines
+
+1. Check `RequestType` in `lib/valkey/request_type.rb` against glide-core `request_type.rs`
+2. Add method to appropriate `lib/valkey/commands/*.rb` module
+3. Use `send_command(RequestType::..., args)` 
+4. Add tests: `test/valkey/` + `test/lint/` when applicable
+5. Document with YARD comments + Valkey command link
+
+### Never Commit
+
+- Secrets, `.env` credentials, production URLs
+- Debug `puts` in production code paths (PubSub callback is intentional for now)
+
+## Project Structure (Essential)
+
+```text
+valkey-glide-ruby/
+├── lib/valkey.rb
+├── lib/valkey/
+│   ├── bindings.rb
+│   ├── libglide_ffi.{so,dylib}
+│   ├── commands/*.rb
+│   ├── opentelemetry.rb
+│   ├── pipeline.rb
+│   ├── request_type.rb
+│   └── response_type.rb
+├── test/valkey/          # standalone tests
+├── test/cluster/         # cluster tests
+├── test/lint/            # shared lint
+├── valkey.gemspec
+├── Rakefile
+└── .github/workflows/CI.yml
+```
+
+## Quality Gates (Agent Checklist)
+
+- [ ] `bundle exec rubocop` passes
+- [ ] `bundle exec rake test:valkey` passes (with Valkey running)
+- [ ] `bundle exec rake test:cluster` passes (if cluster commands touched)
+- [ ] New commands have tests in `test/valkey/` and lint coverage where applicable
+- [ ] `RequestType` matches glide-core enum
+- [ ] No secrets or generated junk committed
+- [ ] DCO signoff: `git log --format="%B" -n 1 | grep "Signed-off-by"`
+- [ ] Conventional commit format used
+- [ ] README / DEVELOPER.md updated if public API or setup changed
+- [ ] Native lib rebuilt and copied if FFI/protobuf changed upstream
+
+## Quick Facts for Reasoners
+
+**Package:** `valkey-rb` on RubyGems  
+**API Style:** Synchronous, redis-rb-compatible  
+**Client:** `Valkey.new` — standalone or `cluster_mode: true`  
+**Key Features:** Pipelining, OpenTelemetry (native), statistics, TLS, URL parsing, cluster routing  
+**Testing:** Minitest + rake tasks; lint suites for redis-rb parity  
+**Core repo:** [valkey-glide](https://github.com/valkey-io/valkey-glide) (`ffi/`, `glide-core/`)  
+**This repo:** [valkey-glide-ruby](https://github.com/valkey-io/valkey-glide-ruby)
+
+## If You Need More
+
+- **Getting Started:** [README.md](./README.md)
+- **Contributing:** [CONTRIBUTING.md](./CONTRIBUTING.md)
+- **Examples:** [examples/](./examples/)
+- **Development Setup:** [DEVELOPER.md](./DEVELOPER.md)
+- **Claude-specific rules:** [CLAUDE.md](./CLAUDE.md)
+- **Command coverage:** [Wiki — implementation status](https://github.com/valkey-io/valkey-glide-ruby/wiki/The-implementation-status-of-the-Valkey-commands)
+- **GLIDE docs:** [glide.valkey.io](https://glide.valkey.io/)
+- **Upstream FFI:** [valkey-glide/ffi](https://github.com/valkey-io/valkey-glide/tree/main/ffi)
+- **Other language AGENTS.md:** [valkey-glide/python/AGENTS.md](https://github.com/valkey-io/valkey-glide/blob/main/python/AGENTS.md), [java/AGENTS.md](https://github.com/valkey-io/valkey-glide/blob/main/java/AGENTS.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,130 @@
+# CLAUDE.md
+
+Valkey GLIDE Ruby (`valkey-rb`) is the official Ruby binding for Valkey and Redis OSS. It uses the shared Rust **glide-core** driver via the **glide-ffi** C library, with a redis-rb-compatible Ruby API. This repository is separate from the [valkey-glide](https://github.com/valkey-io/valkey-glide) mono-repo (Python, Java, Node, Go).
+
+## Hard Constraints (non-negotiable)
+
+- NO task completion without tests covering it and passing (when a Valkey server or cluster is available for integration tests)
+- NO PR creation without addressing review feedback on tests, docs, and RuboCop
+- NEVER assume — verify against `test/valkey/` and `test/lint/` suites
+- NEVER ignore bugs, even out of scope — open a GitHub issue on [valkey-glide-ruby](https://github.com/valkey-io/valkey-glide-ruby/issues)
+
+## Rules
+
+### Always
+
+- Direct and concise; no compliments or apologies
+- Ask if unsure; stop and reassess if looping
+- Match redis-rb conventions when implementing or fixing command APIs
+- If asked to do X a certain way, do it that way; disagree in review, do not change without approval
+
+### When Writing
+
+- Commit frequently with meaningful messages; git is our diary
+- Focus on **Ruby + FFI** in this repo; core/FFI changes require rebuilding `libglide_ffi` from [valkey-glide/ffi](https://github.com/valkey-io/valkey-glide/tree/main/ffi)
+- Keep PRs small and focused
+- Update README.md / DEVELOPER.md when changing setup, public API, or test requirements
+
+### Before Task Completion
+
+- Tests cover the change and pass (`bundle exec rake test:valkey` at minimum)
+- `bundle exec rubocop` passes for changed Ruby files
+- If FFI binary updated, smoke-test: `Valkey.new.ping` on target OS
+
+### Before Push
+
+- `git pull --rebase` on your base branch; resolve conflicts
+- Run tests for relevant scope (`test:valkey` and/or `test:cluster`)
+
+### Before PR Creation/Update
+
+- RuboCop clean
+- Tests pass for touched areas
+- Docs updated if behavior or setup changed
+- DCO sign-off on commits (`git commit -s`)
+
+## What the user cares about (all equally important)
+
+- **Performance** — low latency via GLIDE core; avoid unnecessary Ruby allocations in hot paths
+- **Reliability** — correct error types (`CommandError`, `ConnectionError`, `TimeoutError`, `CannotConnectError`)
+- **Usability** — redis-rb familiarity, clear README and connection options
+- **Maintainability** — command modules, lint tests, minimal scope per PR
+- **Correctness** — verify with Minitest, not assumptions; compare with other GLIDE clients for semantics
+
+---
+
+## Project Structure
+
+```text
+valkey-glide-ruby/
+├── lib/valkey.rb              # Client entry: connect, pipeline, convert_response
+├── lib/valkey/
+│   ├── bindings.rb            # FFI to libglide_ffi
+│   ├── libglide_ffi.so|.dylib # Native library (from valkey-glide/ffi)
+│   ├── commands/              # One module per command family
+│   ├── opentelemetry.rb       # Valkey::OpenTelemetry.init
+│   ├── pipeline.rb            # Valkey::Pipeline
+│   ├── request_type.rb        # Maps to glide-core RequestType
+│   └── response_type.rb       # FFI response decoding
+├── test/valkey/                # Standalone integration tests
+├── test/cluster/               # Cluster tests
+└── test/lint/                  # redis-rb parity lint
+```
+
+## Architecture: Ruby to Core
+
+| Component | Mechanism | Native library | Communication |
+|-----------|-----------|----------------|---------------|
+| Ruby client | FFI gem | `libglide_ffi` (glide-ffi cdylib) | Direct FFI calls |
+| glide-ffi | Rust cdylib | Built from valkey-glide/ffi | glide-core |
+| glide-core | Rust | N/A (in valkey-glide repo) | Valkey/Redis protocol |
+
+```
+Ruby (Valkey#send_command)
+  → Bindings.command / Bindings.batch
+    → libglide_ffi (Rust)
+      → glide-core
+        → Valkey / Redis OSS
+```
+
+Same FFI stack as **Go** and **Python sync**; different from Java (JNI) and Python async (PyO3 + UDS).
+
+## Context Retrieval
+
+When working on a feature, read these paths first:
+
+| Topic | Read first |
+|-------|------------|
+| Connection / options | `lib/valkey.rb` (`#initialize`), `test/lint/connection_options.rb` |
+| New command | `lib/valkey/request_type.rb`, matching `lib/valkey/commands/*.rb`, `test/lint/*` |
+| Pipelining / batch | `lib/valkey.rb` (`pipelined`, `send_batch_commands`), `lib/valkey/pipeline.rb` |
+| OpenTelemetry | `lib/valkey/opentelemetry.rb`, `test/valkey/test_opentelemetry.rb` |
+| FFI / errors | `lib/valkey/bindings.rb`, `lib/valkey/errors.rb` |
+| Cluster | `test/support/helper/cluster.rb`, `test/cluster/` |
+| Upstream semantics | [valkey-glide glide-core](https://github.com/valkey-io/valkey-glide/tree/main/glide-core), peer client in `go/` or `python/glide-sync/` |
+
+## Build and Test (quick reference)
+
+```bash
+bin/setup
+bundle exec rubocop
+bundle exec rake test:valkey      # needs localhost:6379
+bundle exec rake test:cluster     # needs cluster 7000-7005
+```
+
+Rebuild FFI after core changes:
+
+```bash
+cd valkey-glide/ffi && cargo build --release
+cp target/release/libglide_ffi.* /path/to/valkey-glide-ruby/lib/valkey/
+```
+
+## Agent docs in this repo
+
+- [AGENTS.md](./AGENTS.md) — build/test/contribution checklist for agents
+- [CONTRIBUTING.md](./CONTRIBUTING.md) — PR and DCO guidelines
+- [DEVELOPER.md](./DEVELOPER.md) — full developer setup guide
+- [examples/](./examples/) — runnable sample scripts
+- [README.md](./README.md) — user-facing getting started
+
+Upstream mono-repo agent context: [valkey-glide/AGENTS.md](https://github.com/valkey-io/valkey-glide/blob/main/AGENTS.md), [valkey-glide/CLAUDE.md](https://github.com/valkey-io/valkey-glide/blob/main/CLAUDE.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,115 @@
+# Contributing Guidelines
+
+Thank you for your interest in contributing to Valkey GLIDE for Ruby (`valkey-rb`). Whether it's a bug report, new feature, correction, or documentation, we value feedback from the community.
+
+Please read this document before submitting issues or pull requests.
+
+## Reporting Bugs and Feature Requests
+
+Use the [GitHub issue tracker](https://github.com/valkey-io/valkey-glide-ruby/issues) for bugs, feature requests, and questions.
+
+Before creating a new issue:
+
+1. Search [existing issues](https://github.com/valkey-io/valkey-glide-ruby/issues) to avoid duplicates.
+2. Include Ruby version, OS/architecture, `valkey-rb` version, and Valkey/Redis server version.
+3. For connection problems, note standalone vs cluster and whether TLS is enabled.
+4. Provide a minimal reproduction script when possible.
+
+For issues that affect the shared Rust core or other language clients, consider opening an issue in [valkey-glide](https://github.com/valkey-io/valkey-glide/issues) as well.
+
+## Contributing via Pull Requests
+
+1. Work against the latest `main` branch.
+2. Check [open](https://github.com/valkey-io/valkey-glide-ruby/pulls) and recently merged PRs for duplicates.
+3. For large changes (new command families, FFI updates, API breaks), open an issue first to discuss scope.
+
+### Pull request steps
+
+1. Fork [valkey-glide-ruby](https://github.com/valkey-io/valkey-glide-ruby).
+2. Make focused changes; avoid unrelated formatting drive-by edits.
+3. Run local checks (see [DEVELOPER.md](./DEVELOPER.md)):
+   ```bash
+   bundle exec rubocop
+   bundle exec rake test:valkey    # standalone — requires Valkey on :6379
+   bundle exec rake test:cluster   # if cluster-related — requires nodes :7000–:7005
+   ```
+4. Commit with **DCO sign-off** and **conventional commits**:
+   ```bash
+   git commit -s -m "feat(ruby): add EXAMPLE command"
+   ```
+   Configure automatic signoff: `git config --global format.signOff true`
+
+5. Open a PR and respond to CI feedback (RuboCop + test matrix in `.github/workflows/CI.yml`).
+
+GitHub guides: [fork a repo](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo), [create a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request).
+
+### Commit message format
+
+```
+<type>(<scope>): <description>
+```
+
+| Type | Use for |
+|------|---------|
+| `feat` | New feature or command |
+| `fix` | Bug fix |
+| `docs` | Documentation only |
+| `test` | Tests only |
+| `refactor` | Code change without behavior change |
+| `chore` | Tooling, CI, deps |
+
+**Scope:** `ruby` or a command area (e.g. `ruby-pubsub`).
+
+### Developer Certificate of Origin (DCO)
+
+All commits must include:
+
+```
+Signed-off-by: Your Name <your.email@example.com>
+```
+
+By signing off, you agree to the [Developer Certificate of Origin](https://developercertificate.org/).
+
+## Adding or Updating Commands
+
+1. Confirm the command exists in [glide-core `request_type.rs`](https://github.com/valkey-io/valkey-glide/blob/main/glide-core/src/request_type.rs).
+2. Add or verify `RequestType` in `lib/valkey/request_type.rb`.
+3. Implement in the appropriate `lib/valkey/commands/*.rb` module.
+4. Add tests under `test/valkey/` and lint coverage in `test/lint/` when matching redis-rb behavior.
+5. Update the [command implementation wiki](https://github.com/valkey-io/valkey-glide-ruby/wiki/The-implementation-status-of-the-Valkey-commands).
+
+See [DEVELOPER.md](./DEVELOPER.md) for full details.
+
+## Updating the Native FFI Library
+
+Changes that require a new `libglide_ffi` build:
+
+1. Build from [valkey-glide/ffi](https://github.com/valkey-io/valkey-glide/tree/main/ffi) at a compatible release tag.
+2. Copy `libglide_ffi.so` or `libglide_ffi.dylib` into `lib/valkey/`.
+3. Document the valkey-glide version in the PR description.
+4. Test on the target platform (Linux x86_64/aarch64, macOS Intel/Apple Silicon).
+
+## AI-Assisted Development
+
+If you use Cursor, Claude Code, or similar tools, read:
+
+- [AGENTS.md](./AGENTS.md) — build, test, and quality checklist
+- [CLAUDE.md](./CLAUDE.md) — workflow constraints for this repository
+
+## Code of Conduct
+
+This project follows the [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct). See the [FAQ](https://aws.github.io/code-of-conduct-faq) or contact opensource-codeofconduct@amazon.com with questions.
+
+## Security
+
+Report security vulnerabilities via [valkey-glide SECURITY.md](https://github.com/valkey-io/valkey-glide/blob/main/SECURITY.md).
+
+## Licensing
+
+Contributions are licensed under the same terms as the project. See [LICENSE](./LICENSE). You will be asked to confirm licensing in your PR.
+
+## Community
+
+Join Valkey Slack: [Join Valkey Slack](https://join.slack.com/t/valkey-oss-developer/shared_invite/zt-2nxs51chx-EB9hu9Qdch3GMfRcztTSkQ).
+
+Broader GLIDE contributing process: [valkey-glide CONTRIBUTING.md](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md).

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -1,0 +1,358 @@
+# Developer Guide
+
+This document describes how to set up your development environment to build and test the Valkey GLIDE Ruby client (`valkey-rb`).
+
+## Development Overview
+
+The Valkey GLIDE Ruby client consists of **Ruby** application code and a **Rust FFI** native library. Ruby talks to [glide-core](https://github.com/valkey-io/valkey-glide/tree/main/glide-core) through the [`glide-ffi`](https://github.com/valkey-io/valkey-glide/tree/main/ffi) crate, exposed as `libglide_ffi.so` (Linux) or `libglide_ffi.dylib` (macOS) via the [`ffi`](https://github.com/ffi/ffi) gem.
+
+| Layer | Technology | Location |
+|-------|------------|----------|
+| Application API | Ruby | `lib/valkey.rb`, `lib/valkey/commands/` |
+| FFI bindings | Ruby FFI | `lib/valkey/bindings.rb` |
+| Native bridge | Rust `cdylib` | `lib/valkey/libglide_ffi.{so,dylib}` |
+| Core driver | Rust `glide-core` | Built from [valkey-glide](https://github.com/valkey-io/valkey-glide) |
+
+This architecture matches the **Go** and **Python sync** clients (C FFI), not the Java (JNI) or Python async (PyO3 + UDS) stacks.
+
+## Project Structure
+
+```text
+valkey-glide-ruby/
+├── lib/
+│   ├── valkey.rb                 # Client, pipelining, response conversion
+│   ├── valkey/
+│   │   ├── bindings.rb           # FFI definitions
+│   │   ├── libglide_ffi.so       # Prebuilt Linux native library
+│   │   ├── libglide_ffi.dylib    # Prebuilt macOS native library
+│   │   ├── commands/             # Command modules per data type
+│   │   ├── opentelemetry.rb      # OTel init and sampling
+│   │   ├── pipeline.rb           # Pipeline helper
+│   │   ├── request_type.rb       # Command enum (maps to glide-core)
+│   │   ├── response_type.rb      # Response enum
+│   │   └── errors.rb             # Ruby exception types
+├── test/
+│   ├── valkey/                   # Standalone server tests
+│   ├── cluster/                  # Cluster tests
+│   ├── lint/                     # Shared lint suites
+│   └── support/helper/           # Test helpers (client, cluster, SSL)
+├── bin/
+│   ├── setup                     # bundle install
+│   └── console                   # IRB with gem loaded
+├── .github/workflows/CI.yml      # RuboCop + test matrix
+├── valkey.gemspec
+├── Gemfile
+└── Rakefile                      # test:valkey, test:cluster
+```
+
+## Prerequisites
+
+### Software Dependencies
+
+- **Ruby** 2.6+ (3.x recommended for development)
+- **Bundler**
+- **git**
+- **Valkey** or Redis OSS (for integration tests)
+- **Docker** (optional; matches CI setup)
+
+To **rebuild** the native FFI library from source:
+
+- **Rust** (`rustup`)
+- **GCC** / Xcode command-line tools
+- **cmake**, **pkg-config**, **openssl** / **libssl-dev**
+- Clone of [valkey-glide](https://github.com/valkey-io/valkey-glide) at a compatible release tag
+
+### Valkey Installation
+
+See the [Valkey installation guide](https://valkey.io/topics/installation/) to install `valkey-server` and `valkey-cli`.
+
+**Ubuntu / Debian (standalone testing):**
+
+```bash
+sudo apt update -y
+sudo apt install -y ruby-full build-essential
+```
+
+**macOS:**
+
+```bash
+brew install ruby
+```
+
+## Clone and Local Setup
+
+```bash
+git clone https://github.com/valkey-io/valkey-glide-ruby.git
+cd valkey-glide-ruby
+bin/setup   # runs bundle install
+```
+
+Load the gem from the checkout without installing:
+
+```bash
+export RUBYOPT="-I$(pwd)/lib"
+bundle exec ruby -r valkey -e 'puts Valkey::VERSION'
+```
+
+Interactive console:
+
+```bash
+bundle exec bin/console
+```
+
+## Build Native FFI from Source
+
+The published gem includes prebuilt `libglide_ffi` binaries. To update them from [valkey-glide](https://github.com/valkey-io/valkey-glide):
+
+```bash
+VERSION=main   # or a release tag, e.g. v2.4.0
+git clone --branch ${VERSION} https://github.com/valkey-io/valkey-glide.git
+cd valkey-glide/ffi
+
+# Install Rust if needed
+# curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+
+cargo build --release
+```
+
+Copy the built library into the Ruby gem:
+
+```bash
+# Linux
+cp target/release/libglide_ffi.so /path/to/valkey-glide-ruby/lib/valkey/
+
+# macOS
+cp target/release/libglide_ffi.dylib /path/to/valkey-glide-ruby/lib/valkey/
+```
+
+Verify the gem loads the new library:
+
+```bash
+cd /path/to/valkey-glide-ruby
+bundle exec ruby -e 'require "valkey"; c = Valkey.new; puts c.ping; c.close'
+```
+
+### Rust Linters (when changing FFI)
+
+From `valkey-glide/ffi/`:
+
+```bash
+rustup component add clippy rustfmt
+cargo clippy --all-features --all-targets -- -D warnings
+cargo fmt --manifest-path ./Cargo.toml --all
+```
+
+See [ffi/README.md](https://github.com/valkey-io/valkey-glide/blob/main/ffi/README.md) in valkey-glide for C header generation (`cbindgen`) if needed.
+
+## Running Tests
+
+Tests use **Minitest**. The suite is split into standalone (`test/valkey/`) and cluster (`test/cluster/`) groups.
+
+### Start Valkey (standalone)
+
+Default test configuration (see `test/test_helper.rb`):
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `VALKEY_PORT` | `6379` | Plain TCP |
+| `VALKEY_SSL_PORT` | `6380` | TLS (optional) |
+| `TIMEOUT` | `5.0` | Client timeout |
+| DB | `15` | Test database |
+
+```bash
+# Example: Docker standalone (matches CI)
+docker run -d --name valkey-test -p 6379:6379 valkey/valkey:8 \
+  valkey-server --enable-module-command yes
+```
+
+### Start Valkey Cluster
+
+Cluster tests expect six nodes on `127.0.0.1:7000`–`7005`. CI uses `grokzen/redis-cluster:7.0.15`.
+
+```bash
+docker run -d --name redis-cluster -p 7000-7005:7000-7005 grokzen/redis-cluster:7.0.15
+```
+
+### Run Tests
+
+```bash
+# All default (standalone) tests
+bundle exec rake test
+# or
+bundle exec rake test:valkey
+
+# Cluster tests only
+bundle exec rake test:cluster
+
+# Verbose output (also enabled when CI=1)
+CI=1 bundle exec rake test:valkey
+```
+
+### SSL Tests
+
+Generate test certificates:
+
+```bash
+ruby test/fixtures/ssl/generate_certs.rb
+```
+
+Start TLS Valkey on port 6380 (see `.github/workflows/CI.yml` for a full Docker example).
+
+### Module Tests (JSON, Bloom, Search)
+
+CI copies prebuilt modules into `test/fixtures/`:
+
+- `redisjson.so` — JSON commands
+- `redisbloom.so` — Bloom filters
+- `redisearch.so` — Vector / FT commands
+
+Load modules when starting Valkey if you run module-specific tests locally.
+
+### Environment Overrides
+
+```bash
+VALKEY_PORT=6379 TIMEOUT=10 bundle exec rake test:valkey
+```
+
+## Linters
+
+### RuboCop
+
+```bash
+bundle exec rubocop
+```
+
+CI runs RuboCop on every push and pull request (see `.github/workflows/CI.yml`).
+
+Auto-correct safe offenses:
+
+```bash
+bundle exec rubocop -A
+```
+
+Configuration: `.rubocop.yml`, `.rubocop_todo.yml`.
+
+## Contributing New Valkey Commands
+
+When adding a command, check whether it already exists in [glide-core](https://github.com/valkey-io/valkey-glide/blob/main/glide-core/src/request_type.rs) and [command_request.proto](https://github.com/valkey-io/valkey-glide/blob/main/glide-core/src/protobuf/command_request.proto). Other language clients (Python, Java, Go) are the reference for semantics and routing.
+
+### Steps
+
+1. **Add `RequestType` constant** in `lib/valkey/request_type.rb` if not present (must match glide-core enum).
+2. **Implement the command** in the appropriate file under `lib/valkey/commands/` (e.g. `string_commands.rb`, `hash_commands.rb`).
+3. **Use `send_command`** with the correct `RequestType` and argument list (all arguments converted to strings for FFI).
+4. **Add standalone tests** in `test/valkey/<group>_commands_test.rb`.
+5. **Add lint tests** in `test/lint/<group>_commands.rb` when the command should match redis-rb behavior.
+6. **Update the wiki** [command implementation status](https://github.com/valkey-io/valkey-glide-ruby/wiki/The-implementation-status-of-the-Valkey-commands).
+
+### Command module layout
+
+| Module file | Valkey command families |
+|-------------|-------------------------|
+| `string_commands.rb` | Strings, counters |
+| `hash_commands.rb` | Hashes |
+| `list_commands.rb` | Lists |
+| `set_commands.rb` | Sets |
+| `sorted_set_commands.rb` | Sorted sets |
+| `stream_commands.rb` | Streams |
+| `bitmap_commands.rb` | Bitmaps |
+| `hyper_log_log_commands.rb` | HyperLogLog |
+| `geo_commands.rb` | Geo |
+| `generic_commands.rb` | Keys, scan, type, … |
+| `connection_commands.rb` | Connection, auth, select |
+| `server_commands.rb` | Server, config, ACL |
+| `scripting_commands.rb` | Lua scripting |
+| `function_commands.rb` | Functions |
+| `transaction_commands.rb` | MULTI, WATCH, … |
+| `pubsub_commands.rb` | Pub/Sub |
+| `cluster_commands.rb` | Cluster administration |
+| `json_commands.rb` | RedisJSON / Valkey JSON |
+| `vector_search_commands.rb` | RediSearch / FT |
+| `module_commands.rb` | MODULE |
+
+### Tests
+
+- **Unit-style command tests**: `test/valkey/*_test.rb` — require a running server.
+- **Lint suites**: `test/lint/*.rb` — included from valkey and cluster tests for API parity checks.
+- **OpenTelemetry**: `test/valkey/test_opentelemetry.rb` — uses file exporter endpoints.
+- **Statistics**: `test/valkey/test_statistics.rb`.
+
+### Documentation in code
+
+Follow existing YARD-style comments in command modules: link to [valkey.io/commands](https://valkey.io/commands/), document parameters and return types, note cluster vs standalone behavior.
+
+## OpenTelemetry Development
+
+OpenTelemetry is configured via `Valkey::OpenTelemetry.init` before client creation. Sampling is applied in Ruby (`should_sample?`); spans are created in FFI (`create_otel_span`, `create_batch_otel_span`).
+
+File exporter example for local debugging:
+
+```ruby
+Valkey::OpenTelemetry.init(
+  traces: { endpoint: "file:///tmp/valkey_traces.json", sample_percentage: 100 },
+  metrics: { endpoint: "file:///tmp/valkey_metrics.json" }
+)
+```
+
+Run OTel tests:
+
+```bash
+bundle exec ruby test/valkey/test_opentelemetry.rb
+```
+
+## CI Overview
+
+GitHub Actions (`.github/workflows/CI.yml`):
+
+| Job | Matrix |
+|-----|--------|
+| `lint` | Ruby 3.3, RuboCop |
+| `standalone` | Ruby 2.6–3.4 + JRuby; Valkey 7.2, 8, 8.1 |
+| `cluster` | Ruby 2.6–3.4; grokzen/redis-cluster |
+
+## Packaging
+
+Release artifacts are built via `valkey.gemspec`:
+
+- Native libraries under `lib/valkey/` are included in the gem.
+- Test files, `bin/`, and `.github/` are excluded from the release.
+
+Build locally:
+
+```bash
+gem build valkey.gemspec
+gem install ./valkey-rb-*.gem
+```
+
+## Troubleshooting
+
+| Problem | Suggestion |
+|---------|------------|
+| `CannotConnectError` | Ensure Valkey is running on the configured host/port; cluster requires all seed nodes. |
+| `LoadError` / FFI library not found | Confirm `lib/valkey/libglide_ffi.{so,dylib}` exists and matches your OS/arch. |
+| Wrong architecture after FFI rebuild | Rebuild `glide-ffi` on the target platform; do not copy Linux `.so` to macOS. |
+| Cluster tests flaky | Wait for `cluster_state:ok`; increase `TIMEOUT` env var. |
+| SSL test failures | Regenerate certs: `ruby test/fixtures/ssl/generate_certs.rb`. |
+| Pipeline / MULTI crashes | Transaction commands in `pipelined` use sequential fallback by design. |
+
+## Recommended Editor Extensions
+
+- [Ruby LSP](https://marketplace.visualstudio.com/items?itemName=Shopify.ruby-lsp) or [Solargraph](https://marketplace.visualstudio.com/items?itemName=castwide.solargraph)
+- [RuboCop](https://marketplace.visualstudio.com/items?itemName=rubocop.vscode-rubocop)
+- [rust-analyzer](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer) — when editing valkey-glide FFI
+
+## Examples
+
+Sample scripts live in [examples/](./examples/). Run from the repo root:
+
+```bash
+bundle exec ruby examples/standalone.rb
+```
+
+See [examples/README.md](./examples/README.md) for Docker setup and environment variables.
+
+## Community and Feedback
+
+Join Valkey Slack: [Join Valkey Slack](https://join.slack.com/t/valkey-oss-developer/shared_invite/zt-2nxs51chx-EB9hu9Qdch3GMfRcztTSkQ).
+
+Contribution guidelines: [CONTRIBUTING.md](./CONTRIBUTING.md). Broader GLIDE process: [valkey-glide CONTRIBUTING.md](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -1,95 +1,268 @@
-# Valkey
+# Valkey GLIDE for Ruby
 
-A Ruby client library for [Valkey][valkey-home] built with [Valkey Glide Core][valkey-glide-home] that tries to provide a drop in replacement for redis-rb.
+Valkey General Language Independent Driver for the Enterprise (GLIDE) is the official open-source Valkey client library, proudly part of the [Valkey](https://valkey.io) organization. The Ruby gem (`valkey-rb`) wraps [Valkey GLIDE Core](https://github.com/valkey-io/valkey-glide) (Rust) and aims to be a **drop-in replacement for [redis-rb](https://github.com/redis/redis-rb)** while delivering GLIDE performance, reliability, and enterprise features.
 
-## Features
+## Why Choose Valkey GLIDE?
 
-- **High Performance**: Built on Valkey GLIDE Core (Rust-based) for optimal performance
-- **OpenTelemetry Integration**: Built-in distributed tracing support
-- **Client Statistics**: Real-time monitoring of connections and commands
-- **Drop-in Replacement**: Compatible with redis-rb API
+- **Community and Open Source**: Join our vibrant community and contribute to the project.
+- **Reliability**: Built with best practices learned from over a decade of operating Redis OSS-compatible services.
+- **Performance**: Optimized for high performance and low latency via the Rust-based GLIDE core.
+- **High Availability**: Cluster-aware routing, reconnection, and fault tolerance.
+- **Cross-Language Consistency**: Same core driver as Python, Java, Node.js, and Go clients.
+- **Drop-in Replacement**: Familiar redis-rb-style API (`Valkey.new`, command methods, `pipelined`, URL parsing).
+- **Observability**: Native OpenTelemetry tracing and client statistics.
 
-## Getting started
+## Documentation
 
-Install with:
+- **Command coverage**: [Implementation status wiki](https://github.com/valkey-io/valkey-glide-ruby/wiki/The-implementation-status-of-the-Valkey-commands)
+- **Valkey GLIDE overview**: [glide.valkey.io](https://glide.valkey.io/)
+- **Supported engine versions**: [valkey-glide README — Supported Engine Versions](https://github.com/valkey-io/valkey-glide/blob/main/README.md#supported-engine-versions)
+- **Local development**: [DEVELOPER.md](./DEVELOPER.md)
 
+## Supported Engine Versions
+
+| Engine Type | 6.2 | 7.0 | 7.1 | 7.2 | 8.0 | 8.1 | 9.0 |
+|-------------|-----|-----|-----|-----|-----|-----|-----|
+| Valkey      | -   | -   | -   | ✓   | ✓   | ✓   | ✓   |
+| Redis OSS   | ✓   | ✓   | ✓   | ✓   | -   | -   | -   |
+
+## Getting Started — Ruby Wrapper
+
+### System Requirements
+
+The release of Valkey GLIDE Ruby was tested on the following platforms:
+
+**Linux:**
+
+- Ubuntu 20+ (x86_64/amd64 and arm64/aarch64)
+- Amazon Linux 2 (AL2) and 2023 (AL2023) (x86_64)
+
+**Note:** Alpine Linux / MUSL is **not** currently supported.
+
+**macOS:**
+
+- macOS 14.7+ (Apple silicon / aarch64)
+- macOS 13.7+ (x86_64 / amd64)
+
+### Ruby Supported Versions
+
+| Ruby Version | MRI | JRuby |
+|--------------|-----|-------|
+| 2.6          | ✓   | -     |
+| 2.7          | ✓   | -     |
+| 3.0 – 3.4    | ✓   | ✓     |
+
+Minimum Ruby version: **2.6.0** (see `valkey.gemspec`).
+
+### Installation and Setup
+
+Install from RubyGems:
+
+```bash
+gem install valkey-rb
 ```
-$ gem install valkey-rb
+
+Or add to your `Gemfile`:
+
+```ruby
+gem "valkey-rb"
 ```
 
-You can connect to Valkey by instantiating the `Valkey` class:
+Verify installation:
+
+```bash
+ruby -e 'require "valkey"; puts Valkey::VERSION'
+```
+
+The gem ships prebuilt native libraries (`libglide_ffi.so` on Linux, `libglide_ffi.dylib` on macOS) and depends on the [`ffi`](https://github.com/ffi/ffi) gem.
+
+## Basic Examples
+
+### Standalone Mode
 
 ```ruby
 require "valkey"
 
-valkey = Valkey.new
+client = Valkey.new(host: "localhost", port: 6379)
 
-valkey.set("mykey", "hello world")
+client.set("mykey", "hello world")
 # => "OK"
 
-valkey.get("mykey")
+client.get("mykey")
 # => "hello world"
+
+client.close
 ```
 
-## OpenTelemetry and Monitoring
-
-The Valkey client includes built-in support for OpenTelemetry distributed tracing and client statistics monitoring.
-
-### OpenTelemetry Tracing
-
-Enable automatic tracing of all Valkey operations:
+### Standalone with URL (redis-rb compatible)
 
 ```ruby
-require 'valkey'
-require 'opentelemetry/sdk'
+client = Valkey.new(url: "redis://localhost:6379/0")
+# TLS: rediss://user:password@localhost:6380/0
 
-# Configure OpenTelemetry
-OpenTelemetry::SDK.configure do |c|
-  c.service_name = 'my-app'
+client.ping
+# => "PONG"
+```
+
+### Cluster Mode
+
+```ruby
+nodes = [
+  { host: "127.0.0.1", port: 7000 },
+  { host: "127.0.0.1", port: 7001 },
+  { host: "127.0.0.1", port: 7002 },
+  { host: "127.0.0.1", port: 7003 },
+  { host: "127.0.0.1", port: 7004 },
+  { host: "127.0.0.1", port: 7005 }
+]
+
+client = Valkey.new(nodes: nodes, cluster_mode: true)
+client.set("foo", "bar")
+client.get("foo")
+# => "bar"
+```
+
+### Pipelining
+
+Batch multiple commands in a single network round trip (non-atomic pipeline):
+
+```ruby
+results = client.pipelined do |pipe|
+  pipe.set("key1", "value1")
+  pipe.get("key1")
+  pipe.incr("counter")
 end
+# => ["OK", "value1", 1]
+```
 
-# Create client with tracing enabled
+> **Note:** Transactional commands (`MULTI` / `EXEC` / `DISCARD`) in a pipeline are executed sequentially as a workaround for FFI batch stability. Prefer `multi` / `exec` on the main client for transactions.
+
+### Connection Options (redis-rb compatible)
+
+| Option | Description |
+|--------|-------------|
+| `host`, `port` | Server address (default `127.0.0.1:6379`) |
+| `url` | `redis://` or `rediss://` URI (merged with explicit options) |
+| `db` | Database index (standalone only) |
+| `password`, `username` | Authentication |
+| `timeout` | Request timeout in seconds (default `5.0`) |
+| `connect_timeout` | Connection timeout in seconds |
+| `ssl`, `ssl_params` | TLS (`ca_file`, `cert`, `key`, `ca_path`, `root_certs`) |
+| `cluster_mode` | Enable cluster client |
+| `nodes` | Array of `{ host:, port: }` hashes |
+| `protocol` | `:resp2` (default) or `:resp3` |
+| `client_name` | `CLIENT SETNAME` value |
+| `reconnect_attempts`, `reconnect_delay`, `reconnect_delay_max` | Connection retry strategy |
+
+```ruby
 client = Valkey.new(
-  host: 'localhost',
+  host: "localhost",
   port: 6379,
-  tracing: true
+  timeout: 2.0,
+  connect_timeout: 1.0,
+  client_name: "my-app",
+  protocol: :resp3
+)
+```
+
+## OpenTelemetry
+
+Valkey GLIDE Ruby configures OpenTelemetry in the **native Rust core** (not via the Ruby `opentelemetry-sdk` gem). Initialize once per process before creating clients:
+
+```ruby
+require "valkey"
+
+Valkey::OpenTelemetry.init(
+  traces: {
+    endpoint: "http://localhost:4318/v1/traces",
+    sample_percentage: 10
+  },
+  metrics: {
+    endpoint: "http://localhost:4318/v1/metrics"
+  },
+  flush_interval_ms: 5000
 )
 
-# All commands are automatically traced
-client.set('key', 'value')
-client.get('key')
+client = Valkey.new(host: "localhost", port: 6379)
+client.set("key", "value")  # traced when sampling applies
 ```
 
-### Client Statistics
+**Supported endpoint formats:**
 
-Monitor connection and command metrics in real-time:
+- HTTP/HTTPS: `http://localhost:4318/v1/traces`
+- gRPC: `grpc://localhost:4317`
+- File (testing): `file:///tmp/valkey_traces.json`
+
+OpenTelemetry can only be initialized **once per process**. Spans are created in the FFI layer when sampling is enabled.
+
+## Examples
+
+Runnable examples are in [examples/](./examples/):
+
+```bash
+bundle exec ruby examples/standalone.rb
+bundle exec ruby examples/pipelining.rb
+bundle exec ruby examples/opentelemetry.rb
+```
+
+See [examples/README.md](./examples/README.md) for cluster setup and environment variables.
+
+## Client Statistics
+
+Monitor global client metrics (shared across all clients in the process):
 
 ```ruby
-client = Valkey.new
-
-# Execute some operations
-client.set('key1', 'value1')
-client.get('key1')
-
-# Get statistics
 stats = client.get_statistics
+# alias: client.statistics
 
-puts "Active connections: #{stats[:connection_stats][:active_connections]}"
-puts "Total commands: #{stats[:command_stats][:total_commands]}"
-puts "Success rate: #{
-  (stats[:command_stats][:successful_commands].to_f / 
-   stats[:command_stats][:total_commands] * 100).round(2)
-}%"
+puts "Connections: #{stats[:total_connections]}"
+puts "Clients: #{stats[:total_clients]}"
+puts "Compressed values: #{stats[:total_values_compressed]}"
 ```
 
-For detailed documentation, see [OPENTELEMETRY_GUIDE.md](OPENTELEMETRY_GUIDE.md) and [opentelemetry_example.rb](opentelemetry_example.rb).
+Available keys: `:total_connections`, `:total_clients`, `:total_values_compressed`, `:total_values_decompressed`, `:total_original_bytes`, `:total_bytes_compressed`, `:total_bytes_decompressed`, `:compression_skipped_count`.
 
-## Documentation
+## Pub/Sub
 
-Checkout [the implementation status of the Valkey commands][commands-implementation-progress].
+Pub/Sub uses a native callback registered at connection time. Configure subscriptions via command modules (`subscribe`, `psubscribe`, etc.). See [DEVELOPER.md](./DEVELOPER.md) and integration tests in `test/valkey/pubsub_commands_test.rb` for details.
 
+## Layout of Ruby Code
 
-[valkey-home]: https://valkey.io
-[valkey-glide-home]: https://github.com/valkey-io/valkey-glide
-[commands-implementation-progress]: https://github.com/valkey-io/valkey-glide-ruby/wiki/The-implementation-status-of-the-Valkey-commands
+| Path | Purpose |
+|------|---------|
+| `lib/valkey.rb` | Main client: connection, pipelining, response conversion |
+| `lib/valkey/bindings.rb` | FFI bindings to `libglide_ffi` |
+| `lib/valkey/commands/` | Command modules (strings, hashes, streams, cluster, JSON, vector search, …) |
+| `lib/valkey/opentelemetry.rb` | OpenTelemetry configuration |
+| `lib/valkey/pipeline.rb` | Pipeline command batching |
+| `test/valkey/` | Standalone integration tests |
+| `test/cluster/` | Cluster integration tests |
+| `test/lint/` | Shared lint tests (redis-rb compatibility patterns) |
 
+## redis-rb Compatibility
+
+This client mirrors redis-rb conventions where possible:
+
+- `Valkey.new` with `url`, `host`, `port`, `db`, `ssl_params`
+- Command method names and argument ordering aligned with redis-rb
+- `pipelined`, `multi` / `exec`, `disconnect!` (alias of `close`)
+
+Not every redis-rb API is implemented yet. See the [command implementation wiki](https://github.com/valkey-io/valkey-glide-ruby/wiki/The-implementation-status-of-the-Valkey-commands) for coverage.
+
+## Building and Testing
+
+Instructions for building from source, updating the FFI library, running tests, and contributing are in [DEVELOPER.md](./DEVELOPER.md).
+
+For AI-assisted development, see [AGENTS.md](./AGENTS.md) and [CLAUDE.md](./CLAUDE.md).
+
+Contributing: [CONTRIBUTING.md](./CONTRIBUTING.md).
+
+## Community and Feedback
+
+We encourage you to join our community to support, share feedback, and ask questions on Valkey Slack: [Join Valkey Slack](https://join.slack.com/t/valkey-oss-developer/shared_invite/zt-2nxs51chx-EB9hu9Qdch3GMfRcztTSkQ).
+
+Report issues: [valkey-glide-ruby issues](https://github.com/valkey-io/valkey-glide-ruby/issues).
+
+## License
+
+Apache-2.0 — see [LICENSE](https://github.com/valkey-io/valkey-glide-ruby/blob/main/LICENSE) in the repository.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,55 @@
+# Examples
+
+Runnable examples for Valkey GLIDE Ruby. Requires a Valkey or Redis OSS server unless noted.
+
+## Prerequisites
+
+From the repository root:
+
+```bash
+bin/setup
+```
+
+Run examples with the gem loaded from `lib/`:
+
+```bash
+bundle exec ruby examples/standalone.rb
+```
+
+Or:
+
+```bash
+RUBYOPT="-I$(pwd)/lib" ruby examples/standalone.rb
+```
+
+## Examples
+
+| File | Description | Server |
+|------|-------------|--------|
+| [standalone.rb](./standalone.rb) | Basic connect, SET, GET | Standalone `:6379` |
+| [cluster.rb](./cluster.rb) | Cluster connect, SET, GET | Cluster `:7000`–`:7005` |
+| [pipelining.rb](./pipelining.rb) | Non-atomic pipeline | Standalone `:6379` |
+| [opentelemetry.rb](./opentelemetry.rb) | OTel file exporter + traced commands | Standalone `:6379` |
+| [statistics.rb](./statistics.rb) | Client statistics | Standalone `:6379` |
+
+## Environment variables
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `VALKEY_HOST` | `127.0.0.1` | Server host |
+| `VALKEY_PORT` | `6379` | Standalone port |
+| `VALKEY_CLUSTER_PORT` | `7000` | First cluster node port |
+
+## Standalone with Docker
+
+```bash
+docker run -d --name valkey -p 6379:6379 valkey/valkey:8
+bundle exec ruby examples/standalone.rb
+```
+
+## Cluster with Docker
+
+```bash
+docker run -d -p 7000-7005:7000-7005 grokzen/redis-cluster:7.0.15
+bundle exec ruby examples/cluster.rb
+```

--- a/examples/cluster.rb
+++ b/examples/cluster.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Cluster mode example.
+#
+# Run: bundle exec ruby examples/cluster.rb
+# Requires a 6-node cluster on 127.0.0.1:7000-7005 (see examples/README.md).
+
+require "valkey"
+
+base_port = Integer(ENV.fetch("VALKEY_CLUSTER_PORT", 7000))
+host = ENV.fetch("VALKEY_HOST", "127.0.0.1")
+
+nodes = 6.times.map { |i| { host: host, port: base_port + i } }
+
+client = Valkey.new(nodes: nodes, cluster_mode: true)
+
+puts "PING: #{client.ping}"
+puts "SET: #{client.set('cluster_key', 'cluster_value')}"
+puts "GET: #{client.get('cluster_key')}"
+
+client.del("cluster_key")
+client.close
+
+puts "Done."

--- a/examples/opentelemetry.rb
+++ b/examples/opentelemetry.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# OpenTelemetry example using file exporters (no collector required).
+#
+# Run: bundle exec ruby examples/opentelemetry.rb
+# Traces: /tmp/valkey_ruby_example_traces.json
+# Metrics: /tmp/valkey_ruby_example_metrics.json
+
+require "valkey"
+require "fileutils"
+
+TRACES_FILE = "/tmp/valkey_ruby_example_traces.json"
+METRICS_FILE = "/tmp/valkey_ruby_example_metrics.json"
+
+FileUtils.rm_f(TRACES_FILE)
+FileUtils.rm_f(METRICS_FILE)
+
+Valkey::OpenTelemetry.init(
+  traces: {
+    endpoint: "file://#{TRACES_FILE}",
+    sample_percentage: 100
+  },
+  metrics: {
+    endpoint: "file://#{METRICS_FILE}"
+  },
+  flush_interval_ms: 1000
+)
+
+host = ENV.fetch("VALKEY_HOST", "127.0.0.1")
+port = Integer(ENV.fetch("VALKEY_PORT", 6379))
+
+client = Valkey.new(host: host, port: port)
+
+client.set("otel_key", "otel_value")
+client.get("otel_key")
+client.pipelined do |pipe|
+  pipe.set("otel_pipe_1", "a")
+  pipe.get("otel_pipe_1")
+end
+
+client.del("otel_key", "otel_pipe_1")
+client.close
+
+# Allow exporter flush
+sleep 2
+
+puts "OpenTelemetry initialized: #{Valkey::OpenTelemetry.initialized?}"
+puts "Traces file: #{TRACES_FILE} (#{File.size?(TRACES_FILE) || 0} bytes)"
+puts "Metrics file: #{METRICS_FILE} (#{File.size?(METRICS_FILE) || 0} bytes)"
+puts "Done."

--- a/examples/pipelining.rb
+++ b/examples/pipelining.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# Pipeline example — batch commands in one round trip.
+#
+# Run: bundle exec ruby examples/pipelining.rb
+
+require "valkey"
+
+host = ENV.fetch("VALKEY_HOST", "127.0.0.1")
+port = Integer(ENV.fetch("VALKEY_PORT", 6379))
+
+client = Valkey.new(host: host, port: port)
+
+client.del("pipe_counter")
+
+results = client.pipelined do |pipe|
+  pipe.set("pipe_key", "pipe_value")
+  pipe.get("pipe_key")
+  pipe.incr("pipe_counter")
+  pipe.get("pipe_counter")
+end
+
+puts "Pipeline results:"
+results.each_with_index { |r, i| puts "  [#{i}] #{r.inspect}" }
+
+client.del("pipe_key", "pipe_counter")
+client.close
+
+puts "Done."

--- a/examples/standalone.rb
+++ b/examples/standalone.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# Basic standalone Valkey example.
+#
+# Run: bundle exec ruby examples/standalone.rb
+# Requires Valkey/Redis on VALKEY_HOST:VALKEY_PORT (default 127.0.0.1:6379).
+
+require "valkey"
+
+host = ENV.fetch("VALKEY_HOST", "127.0.0.1")
+port = Integer(ENV.fetch("VALKEY_PORT", 6379))
+
+client = Valkey.new(host: host, port: port)
+
+puts "PING: #{client.ping}"
+puts "SET: #{client.set('hello', 'world')}"
+puts "GET: #{client.get('hello')}"
+
+client.del("hello")
+client.close
+
+puts "Done."

--- a/examples/statistics.rb
+++ b/examples/statistics.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Client statistics example.
+#
+# Run: bundle exec ruby examples/statistics.rb
+
+require "valkey"
+
+host = ENV.fetch("VALKEY_HOST", "127.0.0.1")
+port = Integer(ENV.fetch("VALKEY_PORT", 6379))
+
+client = Valkey.new(host: host, port: port)
+client.set("stats_demo", "1")
+client.get("stats_demo")
+
+stats = client.get_statistics
+
+puts "Client statistics:"
+stats.each { |k, v| puts "  #{k}: #{v}" }
+
+client.del("stats_demo")
+client.close
+
+puts "Done."

--- a/lib/valkey.rb
+++ b/lib/valkey.rb
@@ -588,7 +588,7 @@ class Valkey
   #
   # @example Get client statistics
   #   client = Valkey.new(host: 'localhost', port: 6379)
-  #   stats = client.statistics
+  #   stats = client.get_statistics
   #   puts "Total connections: #{stats[:total_connections]}"
   #   puts "Total clients: #{stats[:total_clients]}"
   #   puts "Values compressed: #{stats[:total_values_compressed]}"
@@ -612,4 +612,6 @@ class Valkey
       compression_skipped_count: stats[:compression_skipped_count]
     }
   end
+
+  alias get_statistics statistics
 end


### PR DESCRIPTION
## Summary

Adds GA-ready documentation and contributor tooling for the Valkey GLIDE Ruby client (`valkey-rb`), aligned with the depth and structure of other Valkey GLIDE language clients (Python, Java, Go).

## Documentation

### User-facing
- **README.md** — Expanded with GLIDE overview, supported engines/platforms/Ruby versions, installation, standalone/cluster/URL/pipeline examples, connection options, OpenTelemetry, client statistics, project layout, and redis-rb compatibility notes.

### Developer & agent guides
- **DEVELOPER.md** — Full developer guide: architecture (Ruby → FFI → glide-core), project structure, prerequisites, local setup, rebuilding `libglide_ffi` from valkey-glide, running tests (standalone/cluster/SSL/modules), RuboCop, contributing new commands, CI overview, troubleshooting.
- **AGENTS.md** — Concise context for AI agents: build/test commands, DCO/conventional commits, guardrails, quality checklist.
- **CLAUDE.md** — Workflow constraints and architecture quick reference for Claude/Cursor (adapted from valkey-glide mono-repo).
- **CONTRIBUTING.md** — Ruby-repo contribution guidelines: issues, PRs, DCO, commit format, command contribution flow, FFI update process.

## Examples

New **`examples/`** directory with runnable scripts and `examples/README.md`:

| Example | Description |
|---------|-------------|
| `standalone.rb` | Basic connect, SET, GET |
| `cluster.rb` | Cluster mode (ports 7000–7005) |
| `pipelining.rb` | Non-atomic pipeline |
| `opentelemetry.rb` | File exporter + traced commands |
| `statistics.rb` | Client statistics |

## API fix

- Added `alias get_statistics statistics` on `Valkey` so tests and docs match the public API (`get_statistics` was used in tests but only `statistics` existed).

## Test plan

- [ ] Review README / DEVELOPER / AGENTS / CLAUDE / CONTRIBUTING for accuracy
- [ ] `bundle exec rubocop`
- [ ] `bundle exec rake test:valkey` (Valkey on `localhost:6379`)
- [ ] `bundle exec rake test:cluster` (optional; cluster on `7000`–`7005`)
- [ ] `bundle exec ruby examples/standalone.rb`
- [ ] `bundle exec ruby examples/statistics.rb` — confirms `get_statistics` alias
- [ ] `ruby -e 'require "./lib/valkey"; c=Valkey.new; p c.get_statistics; c.close'`
