### PR TITLE
Fix setting of library name

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -59,6 +59,9 @@ jobs:
 
       - name: Build native library
         working-directory: valkey-glide/ffi
+        env:
+          GLIDE_NAME: GlideRuby
+          GLIDE_VERSION: ${{ github.ref_name }}
         run: cargo build --release
 
       - name: Upload native library

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -95,6 +95,9 @@ jobs:
 
       - name: Build native library
         working-directory: valkey-glide/ffi
+        env:
+          GLIDE_NAME: GlideRuby
+          GLIDE_VERSION: ${{ env.RELEASE_VERSION }}
         run: |
           cargo build --release
 

--- a/Rakefile
+++ b/Rakefile
@@ -29,7 +29,10 @@ namespace :native do
   task build: :submodule do
     puts "Building native FFI library..."
     Dir.chdir("valkey-glide/ffi") do
-      sh "cargo build --release"
+      # Set GLIDE_NAME to identify this as the Ruby client in CLIENT SETINFO
+      # GLIDE_VERSION is set from lib/valkey/version.rb
+      version = File.read("../../lib/valkey/version.rb")[/VERSION = "([^"]+)"/, 1] || "unknown"
+      sh({ "GLIDE_NAME" => "GlideRuby", "GLIDE_VERSION" => version }, "cargo build --release")
     end
     puts "Native library built successfully!"
     puts "Location: valkey-glide/ffi/target/release/libglide_ffi.#{native_lib_ext}"
@@ -39,7 +42,9 @@ namespace :native do
   task build_debug: :submodule do
     puts "Building native FFI library (debug)..."
     Dir.chdir("valkey-glide/ffi") do
-      sh "cargo build"
+      # Set GLIDE_NAME to identify this as the Ruby client in CLIENT SETINFO
+      version = File.read("../../lib/valkey/version.rb")[/VERSION = "([^"]+)"/, 1] || "unknown"
+      sh({ "GLIDE_NAME" => "GlideRuby", "GLIDE_VERSION" => version }, "cargo build")
     end
     puts "Native library built successfully!"
     puts "Location: valkey-glide/ffi/target/debug/libglide_ffi.#{native_lib_ext}"

--- a/lib/valkey.rb
+++ b/lib/valkey.rb
@@ -414,7 +414,7 @@ class Valkey
       json_options["connection_timeout"] = (connect_timeout * 1000).to_i
     end
 
-    # Client name
+    # Client name (user-configurable)
     json_options["client_name"] = options[:client_name] if options[:client_name]
 
     # TLS/SSL certificates

--- a/test/lint/connection_commands.rb
+++ b/test/lint/connection_commands.rb
@@ -82,6 +82,24 @@ module Lint
       end
     end
 
+    def test_library_version_is_set
+      # CLIENT SETINFO (which sets lib-ver) was added in Redis/Valkey 7.2
+      target_version "7.2" do
+        # The GLIDE Ruby client should set lib-ver during connection handshake
+        # Note: In CI builds, GLIDE_VERSION may differ from Valkey::VERSION (e.g., branch name),
+        # so we only verify that lib-ver is set, not its exact value
+        info = r.client(:info)
+        assert_kind_of String, info
+
+        # Extract lib-ver from client info
+        lib_ver_match = info.match(/lib-ver=([^ ]+)/)
+        assert lib_ver_match, "Client info should contain lib-ver"
+
+        lib_ver = lib_ver_match[1]
+        refute_empty lib_ver, "Library version should not be empty"
+      end
+    end
+
     def test_client_pause_unpause
       # Pause for a short duration
       assert_equal "OK", r.client(:pause, 100) # 100ms pause

--- a/test/lint/connection_commands.rb
+++ b/test/lint/connection_commands.rb
@@ -65,6 +65,23 @@ module Lint
       assert info.include?("id="), "Client info should contain client ID"
     end
 
+    def test_library_name_is_set
+      # CLIENT SETINFO (which sets lib-name) was added in Redis/Valkey 7.2
+      target_version "7.2" do
+        # The GLIDE Ruby client should identify itself with lib-name=GlideRuby
+        # This is sent via CLIENT SETINFO lib-name during connection handshake
+        info = r.client(:info)
+        assert_kind_of String, info
+
+        # Extract lib-name from client info
+        lib_name_match = info.match(/lib-name=([^ ]+)/)
+        assert lib_name_match, "Client info should contain lib-name"
+
+        lib_name = lib_name_match[1]
+        assert_equal "GlideRuby", lib_name, "Library name should be 'GlideRuby', got '#{lib_name}'"
+      end
+    end
+
     def test_client_pause_unpause
       # Pause for a short duration
       assert_equal "OK", r.client(:pause, 100) # 100ms pause


### PR DESCRIPTION
This PR updates the build process to set an environment variable to properly set the library name to GlideRuby.