### PR TITLE
CI/CD: Adopt shared actions from valkey-glide

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,10 +35,14 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Install Rust and Protoc
-        uses: ./valkey-glide/.github/actions/install-rust-and-protoc
+      - name: Install Rust
+        uses: ./valkey-glide/.github/actions/install-rust
         with:
           target: x86_64-unknown-linux-gnu
+
+      - name: Install protoc
+        uses: ./valkey-glide/.github/actions/install-protoc
+        with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Cargo

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,14 +35,11 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Install protoc (protobuf)
-        uses: arduino/setup-protoc@v3
+      - name: Install Rust and Protoc
+        uses: ./valkey-glide/.github/actions/install-rust-and-protoc
         with:
-          version: "29.1"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          target: x86_64-unknown-linux-gnu
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Cargo
         uses: actions/cache@v4
@@ -100,34 +97,34 @@ jobs:
         with:
           name: native-lib-linux-x64
           path: valkey-glide/ffi/target/release/
-      
+
       - name: Copy modules for testing
         run: |
           echo "Copying modules for testing..."
           mkdir -p test/fixtures
-          
+
           echo "Copying RedisJSON module for JSON commands testing..."
           cp .github/files/librejson-v2.8.15.so test/fixtures/redisjson.so
           chmod +x test/fixtures/redisjson.so
           ls -lh test/fixtures/redisjson.so
-          
+
           echo "Copying RedisBloom module..."
           cp .github/files/redisbloom-amd64-v2.6.12.so test/fixtures/redisbloom.so
           chmod +x test/fixtures/redisbloom.so
           ls -lh test/fixtures/redisbloom.so
-          
+
           echo "Copying RediSearch module for Vector Search commands testing..."
           cp .github/files/redisearch-amd64-v2.10.24.so test/fixtures/redisearch.so
           chmod +x test/fixtures/redisearch.so
           ls -lh test/fixtures/redisearch.so
-      
+
       - name: Generate SSL certificates for testing
         run: |
           echo "Generating SSL certificates for SSL/TLS testing..."
           ruby test/fixtures/ssl/generate_certs.rb
           echo "SSL certificates generated:"
           ls -lh test/fixtures/ssl/*.pem
-      
+
       - name: Start Valkey with MODULE commands enabled
         run: |
           echo "Starting Valkey ${{ matrix.valkey }} with MODULE commands enabled..."
@@ -137,7 +134,7 @@ jobs:
             -v $(pwd)/test/fixtures:/tmp/modules:ro \
             valkey/valkey:${{ matrix.valkey }} \
             valkey-server --enable-module-command yes
-          
+
           echo "Waiting for Valkey to be ready..."
           for i in {1..30}; do
             if docker exec valkey-test valkey-cli ping > /dev/null 2>&1; then
@@ -147,13 +144,13 @@ jobs:
             echo "Waiting... ($i/30)"
             sleep 1
           done
-          
+
           echo "Verifying MODULE commands are enabled..."
           docker exec valkey-test valkey-cli CONFIG GET enable-module-command
-          
+
           echo "Verifying module files are accessible..."
           docker exec valkey-test ls -lh /tmp/modules/
-      
+
       - name: Start SSL-enabled Valkey on port 6380
         run: |
           echo "Creating Valkey SSL configuration..."
@@ -161,25 +158,25 @@ jobs:
           # Disable regular port, use TLS port only
           port 0
           tls-port 6380
-          
+
           # SSL/TLS certificate files
           tls-cert-file /ssl/server-cert.pem
           tls-key-file /ssl/server-key.pem
           tls-ca-cert-file /ssl/ca-cert.pem
-          
+
           # Don't require client certificates (optional)
           tls-auth-clients no
-          
+
           # Allow TLS v1.2 and v1.3
           tls-protocols "TLSv1.2 TLSv1.3"
           EOF
-          
+
           echo "SSL configuration created:"
           cat /tmp/valkey-ssl.conf
-          
+
           echo "Verifying SSL certificate files exist..."
           ls -lh $(pwd)/test/fixtures/ssl/*.pem
-          
+
           echo "Starting SSL-enabled Valkey on port 6380..."
           docker run -d \
             --name valkey-ssl \
@@ -188,20 +185,20 @@ jobs:
             -v /tmp/valkey-ssl.conf:/etc/valkey-ssl.conf:ro \
             valkey/valkey:${{ matrix.valkey }} \
             valkey-server /etc/valkey-ssl.conf
-          
+
           echo "Waiting for container to start..."
           sleep 2
-          
+
           echo "Checking if container is running..."
           docker ps -a | grep valkey-ssl || echo "Container not found!"
-          
+
           echo "Checking container logs..."
           docker logs valkey-ssl || echo "Could not get logs"
-          
+
           echo "Verifying SSL cert files are accessible inside container..."
           docker exec valkey-ssl ls -lh /ssl/ || echo "Cannot access /ssl/ directory"
           docker exec valkey-ssl cat /etc/valkey-ssl.conf || echo "Cannot read config file"
-          
+
           echo "Waiting for SSL Valkey to be ready..."
           for i in {1..30}; do
             if docker exec valkey-ssl valkey-cli --tls --insecure -p 6380 ping > /dev/null 2>&1; then
@@ -211,22 +208,22 @@ jobs:
             echo "Waiting... ($i/30)"
             sleep 1
           done
-          
+
           echo "Verifying SSL connection from host..."
           docker exec valkey-ssl valkey-cli --tls --insecure -p 6380 ping || echo "SSL verification failed"
-          
+
           echo "Testing connection from host machine..."
           docker run --rm --network host valkey/valkey:${{ matrix.valkey }} valkey-cli --tls --insecure -p 6380 ping || echo "Host connection test failed"
-      
+
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-      
+
       - name: Run standalone tests
         run: bundle exec rake test:standalone
-      
+
       - name: Stop Valkey containers
         if: always()
         run: |
@@ -258,16 +255,11 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Build and install Valkey from source
-        run: |
-          echo "Building Valkey 8.0.0 from source..."
-          git clone https://github.com/valkey-io/valkey.git
-          cd valkey
-          git checkout 8.0.0
-          make BUILD_TLS=yes -j4
-          sudo make install
-          echo "Verifying Valkey installation..."
-          valkey-server --version
+      - name: Install Valkey
+        uses: ./valkey-glide/.github/actions/install-engine
+        with:
+          engine-version: "8.0"
+          target: x86_64-unknown-linux-gnu
 
       - name: Download native library
         uses: actions/download-artifact@v4

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,6 +35,8 @@ jobs:
         with:
           submodules: recursive
 
+      # Composite actions from the valkey-glide submodule use relative paths
+      # (vs reusable workflows which use org/repo/path@ref syntax)
       - name: Install Rust
         uses: ./valkey-glide/.github/actions/install-rust
         with:

--- a/.github/workflows/git-secrets-scan.yml
+++ b/.github/workflows/git-secrets-scan.yml
@@ -8,4 +8,4 @@ on:
 
 jobs:
   git-secrets-scan:
-    uses: valkey-io/valkey-glide/.github/workflows/git-secrets-scan.yml@ci-cd-workflow-consolidation
+    uses: valkey-io/valkey-glide/.github/workflows/git-secrets-scan.yml@main

--- a/.github/workflows/git-secrets-scan.yml
+++ b/.github/workflows/git-secrets-scan.yml
@@ -1,0 +1,11 @@
+name: Git Secrets Scan
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  git-secrets-scan:
+    uses: valkey-io/valkey-glide/.github/workflows/git-secrets-scan.yml@ci-cd-workflow-consolidation

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -8,4 +8,4 @@ on:
 
 jobs:
   semgrep:
-    uses: valkey-io/valkey-glide/.github/workflows/semgrep.yml@ci-cd-workflow-consolidation
+    uses: valkey-io/valkey-glide/.github/workflows/semgrep.yml@main

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,11 @@
+name: Semgrep
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  semgrep:
+    uses: valkey-io/valkey-glide/.github/workflows/semgrep.yml@ci-cd-workflow-consolidation


### PR DESCRIPTION
## Summary

Migrates the Ruby CI to use shared composite actions from the valkey-glide submodule, part of the cross-repo CI consolidation effort.

### Changes

**CI Workflow:**
- Replace direct `dtolnay/rust-toolchain` + `arduino/setup-protoc` with shared `install-rust-and-protoc` action
- Replace manual Valkey build-from-source in cluster tests with shared `install-engine` action (cached binary)
- Existing standalone Docker-based tests remain unchanged

**Security Workflows (new):**
- Add `semgrep.yml` calling reusable workflow from valkey-glide
- Add `git-secrets-scan.yml` calling reusable workflow from valkey-glide

**Submodule:**
- Updated to `ci-cd-workflow-consolidation` branch (will be updated to main after main repo PR merges)

### What's preserved
- All existing test matrix (Ruby 3.0-3.4, Valkey 7.2/8/8.1)
- Standalone Docker-based tests with modules, SSL
- Cluster tests with all Ruby versions
- CD workflow unchanged