### PR TITLE
test(ruby): privatize CLIENT TRACKING, CLIENT CACHING, and CLIENT TRACKINGINFO

### DIFF
--- a/lib/valkey/commands/connection_commands.rb
+++ b/lib/valkey/commands/connection_commands.rb
@@ -299,8 +299,9 @@ class Valkey
           when :redirect
             args << "REDIRECT" << value.to_s
           when :prefix
-            args << "PREFIX"
-            Array(value).each { |prefix| args << prefix }
+            # Valkey requires the PREFIX keyword before each prefix value,
+            # e.g. PREFIX foo PREFIX bar.
+            Array(value).each { |prefix| args << "PREFIX" << prefix }
           when :bcast
             args << "BCAST" if value
           when :optin

--- a/lib/valkey/commands/connection_commands.rb
+++ b/lib/valkey/commands/connection_commands.rb
@@ -94,7 +94,7 @@ class Valkey
       #   client(:set_name, "my_app")  # => "OK"
       #   client(:list)                # => [{"id" => "1", ...}, ...]
       def client(subcommand, *args)
-        send("client_#{subcommand.to_s.downcase}", *args)
+        public_send("client_#{subcommand.to_s.downcase}", *args)
       end
 
       # Get the current client's ID.
@@ -289,6 +289,12 @@ class Valkey
       def client_no_touch(mode)
         send_command(RequestType::CLIENT_NO_TOUCH, [mode.to_s.upcase])
       end
+
+      # Client-side caching commands are intentionally private.
+      #
+      # GLIDE's managed client-side caching is not yet implemented in the Ruby client
+      # These commands are not meant to be called directly and will be kept private.
+      private :client_tracking, :client_caching, :client_tracking_info, :client_getredir
 
       private
 

--- a/test/lint/connection_commands.rb
+++ b/test/lint/connection_commands.rb
@@ -150,11 +150,6 @@ module Lint
       end
     end
 
-    def test_client_getredir
-      redir = r.client_getredir
-      assert_kind_of Integer, redir
-    end
-
     def test_hello_default
       result = r.hello
       # Backend returns array in current implementation
@@ -206,93 +201,6 @@ module Lint
         sleep(0.05) # 50ms between retries
       end
       assert_nil r.client_get_name
-    end
-
-    def test_client_caching
-      # In cluster mode, CLIENT TRACKING and CLIENT CACHING may hit different nodes
-      # so tracking state isn't shared - skip this test in cluster mode
-      skip("CLIENT CACHING requires tracking state to be shared, not reliable in cluster mode") if cluster_mode?
-
-      # CLIENT CACHING YES works with OPTIN mode
-      r.client_tracking("ON", "OPTIN")
-      assert_equal "OK", r.client_caching("YES")
-      r.client_tracking("OFF")
-      # CLIENT CACHING NO requires OPTOUT mode
-      r.client_tracking("ON", "OPTOUT")
-      assert_equal "OK", r.client_caching("NO")
-      r.client_tracking("OFF")
-    end
-
-    def test_client_tracking
-      assert_equal "OK", r.client_tracking("ON")
-      assert_equal "OK", r.client_tracking("OFF")
-    end
-
-    def test_client_tracking_info
-      info = r.client_tracking_info
-      assert_kind_of Array, info
-    end
-
-    def test_client_tracking_with_bcast
-      # Keyword options exercise build_client_tracking_args (BCAST branch).
-      assert_equal "OK", r.client_tracking("ON", bcast: true)
-      assert_equal "OK", r.client_tracking("OFF")
-    end
-
-    def test_client_tracking_with_prefix
-      # PREFIX is only valid alongside BCAST.
-      assert_equal "OK", r.client_tracking("ON", bcast: true, prefix: %w[foo bar])
-      assert_equal "OK", r.client_tracking("OFF")
-    end
-
-    def test_client_tracking_with_optin_optout_keywords
-      # optin: / optout: keyword forms exercise build_client_tracking_args.
-      assert_equal "OK", r.client_tracking("ON", optin: true)
-      assert_equal "OK", r.client_tracking("OFF")
-      assert_equal "OK", r.client_tracking("ON", optout: true)
-      assert_equal "OK", r.client_tracking("OFF")
-    end
-
-    def test_client_tracking_with_noloop
-      assert_equal "OK", r.client_tracking("ON", noloop: true)
-      assert_equal "OK", r.client_tracking("OFF")
-    end
-
-    def test_client_tracking_invalid_status
-      assert_raises(Valkey::CommandError) do
-        r.client_tracking("MAYBE")
-      end
-    end
-
-    def test_client_tracking_info_reflects_state
-      # Tracking state is connection-local; in cluster mode TRACKING and
-      # TRACKINGINFO may hit different nodes, so skip there.
-      skip("CLIENT TRACKINGINFO reflects per-connection state, not reliable in cluster mode") if cluster_mode?
-
-      r.client_tracking("ON")
-      info = r.client_tracking_info
-      assert info.include?("flags"), "tracking info should report flags"
-      assert info.flatten.include?("on"), "flags should report 'on' when tracking enabled"
-
-      r.client_tracking("OFF")
-      info = r.client_tracking_info
-      assert info.flatten.include?("off"), "flags should report 'off' when tracking disabled"
-    end
-
-    def test_client_caching_invalid_mode
-      # CLIENT CACHING requires shared tracking state, not reliable in cluster mode.
-      skip("CLIENT CACHING requires tracking state to be shared, not reliable in cluster mode") if cluster_mode?
-
-      r.client_tracking("ON", "OPTIN")
-      assert_raises(Valkey::CommandError) do
-        r.client_caching("MAYBE")
-      end
-      r.client_tracking("OFF")
-    end
-
-    def test_client_getredir_when_disabled
-      # With no tracking redirection configured, GETREDIR returns -1.
-      assert_equal(-1, r.client_getredir)
     end
 
     def test_quit

--- a/test/lint/connection_commands.rb
+++ b/test/lint/connection_commands.rb
@@ -233,6 +233,68 @@ module Lint
       assert_kind_of Array, info
     end
 
+    def test_client_tracking_with_bcast
+      # Keyword options exercise build_client_tracking_args (BCAST branch).
+      assert_equal "OK", r.client_tracking("ON", bcast: true)
+      assert_equal "OK", r.client_tracking("OFF")
+    end
+
+    def test_client_tracking_with_prefix
+      # PREFIX is only valid alongside BCAST.
+      assert_equal "OK", r.client_tracking("ON", bcast: true, prefix: %w[foo bar])
+      assert_equal "OK", r.client_tracking("OFF")
+    end
+
+    def test_client_tracking_with_optin_optout_keywords
+      # optin: / optout: keyword forms exercise build_client_tracking_args.
+      assert_equal "OK", r.client_tracking("ON", optin: true)
+      assert_equal "OK", r.client_tracking("OFF")
+      assert_equal "OK", r.client_tracking("ON", optout: true)
+      assert_equal "OK", r.client_tracking("OFF")
+    end
+
+    def test_client_tracking_with_noloop
+      assert_equal "OK", r.client_tracking("ON", noloop: true)
+      assert_equal "OK", r.client_tracking("OFF")
+    end
+
+    def test_client_tracking_invalid_status
+      assert_raises(Valkey::CommandError) do
+        r.client_tracking("MAYBE")
+      end
+    end
+
+    def test_client_tracking_info_reflects_state
+      # Tracking state is connection-local; in cluster mode TRACKING and
+      # TRACKINGINFO may hit different nodes, so skip there.
+      skip("CLIENT TRACKINGINFO reflects per-connection state, not reliable in cluster mode") if cluster_mode?
+
+      r.client_tracking("ON")
+      info = r.client_tracking_info
+      assert info.include?("flags"), "tracking info should report flags"
+      assert info.flatten.include?("on"), "flags should report 'on' when tracking enabled"
+
+      r.client_tracking("OFF")
+      info = r.client_tracking_info
+      assert info.flatten.include?("off"), "flags should report 'off' when tracking disabled"
+    end
+
+    def test_client_caching_invalid_mode
+      # CLIENT CACHING requires shared tracking state, not reliable in cluster mode.
+      skip("CLIENT CACHING requires tracking state to be shared, not reliable in cluster mode") if cluster_mode?
+
+      r.client_tracking("ON", "OPTIN")
+      assert_raises(Valkey::CommandError) do
+        r.client_caching("MAYBE")
+      end
+      r.client_tracking("OFF")
+    end
+
+    def test_client_getredir_when_disabled
+      # With no tracking redirection configured, GETREDIR returns -1.
+      assert_equal(-1, r.client_getredir)
+    end
+
     def test_quit
       # NOTE: This test is tricky because QUIT closes the connection
       # We'll skip it in lint tests to avoid connection issues

--- a/test/lint/server_commands.rb
+++ b/test/lint/server_commands.rb
@@ -158,29 +158,6 @@ module Lint
       assert [0, 1].include?(result), "Expected unblock to return 0 or 1"
     end
 
-    def test_redis_rb_client_caching
-      # CLIENT CACHING requires shared tracking state, which is not reliable in
-      # cluster mode because TRACKING and CACHING may hit different nodes.
-      skip("CLIENT CACHING requires tracking state to be shared, not reliable in cluster mode") if cluster_mode?
-
-      # The redis-rb dispatcher (r.client(:caching, mode)) forwards to client_caching.
-      # CLIENT CACHING YES works with OPTIN mode.
-      r.client(:tracking, "ON", "OPTIN")
-      assert_equal "OK", r.client(:caching, "YES")
-      r.client(:tracking, "OFF")
-      # CLIENT CACHING NO requires OPTOUT mode.
-      r.client(:tracking, "ON", "OPTOUT")
-      assert_equal "OK", r.client(:caching, "NO")
-      r.client(:tracking, "OFF")
-    end
-
-    def test_redis_rb_client_tracking
-      # The redis-rb dispatcher (r.client(:tracking, status)) forwards to
-      # client_tracking, which requires a status argument.
-      assert_equal "OK", r.client(:tracking, "ON")
-      assert_equal "OK", r.client(:tracking, "OFF")
-    end
-
     def test_client_reply
       assert_equal "OK", r.client(:reply, "ON") # TODO: "OFF" or "SKIP" doesnt work yet
     end
@@ -221,51 +198,6 @@ module Lint
       else
         skip("No client address found to kill")
       end
-    end
-
-    def test_redis_rb_client_tracking_info
-      # The redis-rb dispatcher (r.client(:tracking_info)) forwards to
-      # client_tracking_info, which takes no arguments.
-      assert_kind_of Array, r.client(:tracking_info)
-    end
-
-    def test_redis_rb_client_tracking_with_options
-      # The dispatcher forwards extra positional args to client_tracking,
-      # so broadcast/optin flags can be passed through r.client(:tracking, ...).
-      assert_equal "OK", r.client(:tracking, "ON", "BCAST")
-      assert_equal "OK", r.client(:tracking, "OFF")
-      assert_equal "OK", r.client(:tracking, "ON", "OPTIN")
-      assert_equal "OK", r.client(:tracking, "OFF")
-    end
-
-    def test_redis_rb_client_tracking_symbol_status
-      # Symbol args are coerced to strings (build_command_args calls #to_s) and
-      # Valkey accepts the status case-insensitively.
-      assert_equal "OK", r.client(:tracking, :on)
-      assert_equal "OK", r.client(:tracking, :off)
-    end
-
-    def test_redis_rb_client_tracking_invalid_status
-      assert_raises(Valkey::CommandError) do
-        r.client(:tracking, "MAYBE")
-      end
-    end
-
-    def test_redis_rb_client_caching_invalid_mode
-      # CLIENT CACHING needs shared tracking state, not reliable in cluster mode.
-      skip("CLIENT CACHING requires tracking state to be shared, not reliable in cluster mode") if cluster_mode?
-
-      r.client(:tracking, "ON", "OPTIN")
-      assert_raises(Valkey::CommandError) do
-        r.client(:caching, "MAYBE")
-      end
-      r.client(:tracking, "OFF")
-    end
-
-    def test_redis_rb_client_getredir
-      # extra_client = Valkey.new
-      # extra_client.client('tracking', 'on', 'bcast') # TODO: Ensure tracking is implemented
-      assert_kind_of Integer, r.client(:getredir)
     end
 
     def test_client_no_evict

--- a/test/lint/server_commands.rb
+++ b/test/lint/server_commands.rb
@@ -158,20 +158,27 @@ module Lint
       assert [0, 1].include?(result), "Expected unblock to return 0 or 1"
     end
 
-    def test_client_caching
-      skip("CLIENT CACHING command not implemented in backend yet")
+    def test_redis_rb_client_caching
+      # CLIENT CACHING requires shared tracking state, which is not reliable in
+      # cluster mode because TRACKING and CACHING may hit different nodes.
+      skip("CLIENT CACHING requires tracking state to be shared, not reliable in cluster mode") if cluster_mode?
 
-      # Assuming caching is enabled by default, this should return true
-      response = r.client(:caching)
-      assert_equal true, response
+      # The redis-rb dispatcher (r.client(:caching, mode)) forwards to client_caching.
+      # CLIENT CACHING YES works with OPTIN mode.
+      r.client(:tracking, "ON", "OPTIN")
+      assert_equal "OK", r.client(:caching, "YES")
+      r.client(:tracking, "OFF")
+      # CLIENT CACHING NO requires OPTOUT mode.
+      r.client(:tracking, "ON", "OPTOUT")
+      assert_equal "OK", r.client(:caching, "NO")
+      r.client(:tracking, "OFF")
     end
 
-    def test_client_tracking
-      skip("CLIENT TRACKING command not implemented in backend yet")
-
-      # Assuming tracking is enabled by default, this should return true
-      response = r.client(:tracking)
-      assert_equal true, response
+    def test_redis_rb_client_tracking
+      # The redis-rb dispatcher (r.client(:tracking, status)) forwards to
+      # client_tracking, which requires a status argument.
+      assert_equal "OK", r.client(:tracking, "ON")
+      assert_equal "OK", r.client(:tracking, "OFF")
     end
 
     def test_client_reply
@@ -216,13 +223,46 @@ module Lint
       end
     end
 
-    def test_client_tracking_info
-      skip("CLIENT TRACKING command not implemented in backend yet")
-
+    def test_redis_rb_client_tracking_info
+      # The redis-rb dispatcher (r.client(:tracking_info)) forwards to
+      # client_tracking_info, which takes no arguments.
       assert_kind_of Array, r.client(:tracking_info)
     end
 
-    def test_client_getredir
+    def test_redis_rb_client_tracking_with_options
+      # The dispatcher forwards extra positional args to client_tracking,
+      # so broadcast/optin flags can be passed through r.client(:tracking, ...).
+      assert_equal "OK", r.client(:tracking, "ON", "BCAST")
+      assert_equal "OK", r.client(:tracking, "OFF")
+      assert_equal "OK", r.client(:tracking, "ON", "OPTIN")
+      assert_equal "OK", r.client(:tracking, "OFF")
+    end
+
+    def test_redis_rb_client_tracking_symbol_status
+      # Symbol args are coerced to strings (build_command_args calls #to_s) and
+      # Valkey accepts the status case-insensitively.
+      assert_equal "OK", r.client(:tracking, :on)
+      assert_equal "OK", r.client(:tracking, :off)
+    end
+
+    def test_redis_rb_client_tracking_invalid_status
+      assert_raises(Valkey::CommandError) do
+        r.client(:tracking, "MAYBE")
+      end
+    end
+
+    def test_redis_rb_client_caching_invalid_mode
+      # CLIENT CACHING needs shared tracking state, not reliable in cluster mode.
+      skip("CLIENT CACHING requires tracking state to be shared, not reliable in cluster mode") if cluster_mode?
+
+      r.client(:tracking, "ON", "OPTIN")
+      assert_raises(Valkey::CommandError) do
+        r.client(:caching, "MAYBE")
+      end
+      r.client(:tracking, "OFF")
+    end
+
+    def test_redis_rb_client_getredir
       # extra_client = Valkey.new
       # extra_client.client('tracking', 'on', 'bcast') # TODO: Ensure tracking is implemented
       assert_kind_of Integer, r.client(:getredir)


### PR DESCRIPTION
## Overview

Valkey Client Side Caching requires implementation of GLIDE's dedicated CSC interface which has not been done. Public interfaces for `CLIENT TRACKING`, `CLIENT CACHING`, and `CLIENT TRACKINGINFO` commands has been made private and their tests are removed. 

## Other changes
- Fixes a bug in tracking argument construction surfaced by the new tests.
- Updated `reddis-rb` send command to only access public methods.
 
## Related Issue
Closes #105 

## Changes
- `connection_commands.rb`: privatized `client_tracking`, `client_caching`, `client_tracking_info`, and `client_getredir`
- `connection_commands.rb`: Removed tests related to the privatized CSC methods.
- `server_commands.rb`: Removed tests related to the privatized CSC methods.
- `connection_commands.rb`: fixed `build_client_tracking_args` to emit `PREFIX` before each prefix value (`PREFIX foo PREFIX bar`).
- `connection_commands.rb`: Updated send to use `public_send`, restricting it to public methods only. 


