### PR TITLE
test(ruby): added default and ACL authentication tests

### DIFF
--- a/test/standalone/valkey_test.rb
+++ b/test/standalone/valkey_test.rb
@@ -8,6 +8,7 @@ class TestStandaloneValkey < Minitest::Test
   include Helper::Client
 
   # ValkeyTests modules for valkey-glide-ruby specific functionality
+  include ValkeyTests::AuthCommands
   include ValkeyTests::Bitpos
   include ValkeyTests::FunctionCommands
   include ValkeyTests::GenericCommands

--- a/test/support/helper/generic.rb
+++ b/test/support/helper/generic.rb
@@ -8,6 +8,10 @@ module Helper
 
     alias r valkey
 
+    # Credentials used by the auth helpers (with_acl / with_default_user_password).
+    AUTH_TEST_PASSWORD = "mysecret"
+    ACL_TEST_USERNAME = "johndoe"
+
     def run
       if respond_to?(:around)
         around { super }
@@ -87,33 +91,44 @@ module Helper
       # ACL user must be granted those even though the test only exercises PING/SET.
       # This mirrors the python reference grant (+ping +info +client +cluster ...);
       # +set is intentionally withheld so the disallowed-command test still fails.
-      admin.acl("SETUSER", "johndoe", "on",
+      admin.acl("SETUSER", ACL_TEST_USERNAME, "on",
                 "+ping", "+select", "+command", "+info", "+client",
                 "+cluster|slots", "+cluster|nodes", "+readonly",
-                ">mysecret")
-      yield("johndoe", "mysecret")
+                ">#{AUTH_TEST_PASSWORD}")
+      yield(ACL_TEST_USERNAME, AUTH_TEST_PASSWORD)
     ensure
-      begin
-        admin&.acl("DELUSER", "johndoe")
-      rescue Valkey::BaseError
-        # best-effort restore; never let teardown cascade into other tests
-      ensure
-        admin&.close
-      end
+      admin&.close
+      delete_acl_user(ACL_TEST_USERNAME)
+    end
+
+    # Remove the ACL test user. Mirrors restore_default_user_nopass: run the
+    # cleanup from a fresh privileged (default / no-password) connection rather
+    # than as `johndoe` (which lacks +acl) or via a possibly-stale `admin`.
+    def delete_acl_user(username)
+      client = _new_client
+      client.acl("DELUSER", username)
+    rescue Valkey::BaseError => e
+      warn "[auth-helper] could not delete ACL user `#{username}`: #{e.class}: #{e.message}"
+    ensure
+      client&.close
     end
 
     def with_default_user_password
-      admin = _new_client
-      admin.acl("SETUSER", "default", ">mysecret")
-      yield("default", "mysecret")
+      client = _new_client
+      client.acl("SETUSER", "default", ">#{AUTH_TEST_PASSWORD}")
+      yield("default", AUTH_TEST_PASSWORD)
     ensure
-      begin
-        admin&.acl("SETUSER", "default", "nopass")
-      rescue Valkey::BaseError
-        # best-effort restore; never let teardown cascade into other tests
-      ensure
-        admin&.close
-      end
+      client&.close
+      restore_default_user_nopass
+    end
+
+    def restore_default_user_nopass
+      client = _new_client(password: AUTH_TEST_PASSWORD)
+      client.acl("SETUSER", "default", "nopass")
+    rescue Valkey::BaseError => e
+      warn "[auth-helper] could not reset `default` user to nopass: #{e.class}: #{e.message}"
+    ensure
+      client&.close
     end
   end
 end

--- a/test/support/helper/generic.rb
+++ b/test/support/helper/generic.rb
@@ -86,14 +86,6 @@ module Helper
     end
 
     def with_acl
-      # NOTE: The ACL auth tests intermittently hang the entire standalone suite
-      # in CI. Investigation (PR #113) showed the ACL tests' connection/command
-      # pattern wedges the shared glide-core FFI runtime, after which a later
-      # unrelated FFI command (e.g. FUNCTION LOAD) blocks indefinitely with no
-      # client-side timeout, exceeding the 30-minute job cap. Skipped until the
-      # underlying FFI robustness issue is resolved.
-      skip("ACL auth tests temporarily disabled: cause intermittent CI hang (see PR #113)")
-
       admin = _new_client
       # glide-core runs INFO (and CLIENT) during the connection handshake, so the
       # ACL user must be granted those even though the test only exercises PING/SET.

--- a/test/support/helper/generic.rb
+++ b/test/support/helper/generic.rb
@@ -83,13 +83,23 @@ module Helper
 
     def with_acl
       admin = _new_client
+      # glide-core runs INFO (and CLIENT) during the connection handshake, so the
+      # ACL user must be granted those even though the test only exercises PING/SET.
+      # This mirrors the python reference grant (+ping +info +client +cluster ...);
+      # +set is intentionally withheld so the disallowed-command test still fails.
       admin.acl("SETUSER", "johndoe", "on",
-                "+ping", "+select", "+command", "+cluster|slots", "+cluster|nodes", "+readonly",
+                "+ping", "+select", "+command", "+info", "+client",
+                "+cluster|slots", "+cluster|nodes", "+readonly",
                 ">mysecret")
       yield("johndoe", "mysecret")
     ensure
-      admin.acl("DELUSER", "johndoe")
-      admin.close
+      begin
+        admin&.acl("DELUSER", "johndoe")
+      rescue Valkey::BaseError
+        # best-effort restore; never let teardown cascade into other tests
+      ensure
+        admin&.close
+      end
     end
 
     def with_default_user_password
@@ -97,8 +107,13 @@ module Helper
       admin.acl("SETUSER", "default", ">mysecret")
       yield("default", "mysecret")
     ensure
-      admin.acl("SETUSER", "default", "nopass")
-      admin.close
+      begin
+        admin&.acl("SETUSER", "default", "nopass")
+      rescue Valkey::BaseError
+        # best-effort restore; never let teardown cascade into other tests
+      ensure
+        admin&.close
+      end
     end
   end
 end

--- a/test/support/helper/generic.rb
+++ b/test/support/helper/generic.rb
@@ -86,6 +86,14 @@ module Helper
     end
 
     def with_acl
+      # NOTE: The ACL auth tests intermittently hang the entire standalone suite
+      # in CI. Investigation (PR #113) showed the ACL tests' connection/command
+      # pattern wedges the shared glide-core FFI runtime, after which a later
+      # unrelated FFI command (e.g. FUNCTION LOAD) blocks indefinitely with no
+      # client-side timeout, exceeding the 30-minute job cap. Skipped until the
+      # underlying FFI robustness issue is resolved.
+      skip("ACL auth tests temporarily disabled: cause intermittent CI hang (see PR #113)")
+
       admin = _new_client
       # glide-core runs INFO (and CLIENT) during the connection handshake, so the
       # ACL user must be granted those even though the test only exercises PING/SET.

--- a/test/valkey/auth_commands_test.rb
+++ b/test/valkey/auth_commands_test.rb
@@ -12,14 +12,8 @@
 # - ACL rules are defined per node th inside the block helpers.
 module ValkeyTests
   module AuthCommands
-    # Tests that open a connection with WRONG credentials (server replies
-    # "AuthenticationFailed") intermittently hang the native connection-creation
-    # path and wedge the entire standalone suite (30-min CI timeout). The
-    # missing-credentials/NOAUTH path is NOT affected. Disabled until the
-    # underlying FFI connection-creation race is fixed upstream. See PR #113.
     WRONG_CREDENTIALS_HANG_SKIP =
-      "Disabled: wrong-credentials connect (AuthenticationFailed) intermittently hangs " \
-      "the native connection-creation path and wedges the suite. See PR #113."
+      "Disabled: wrong-credentials tests as it is causing suites to hang. See valkey-glide-ruby/issues/115"
 
     # =========================================================
     # Default user -- connect-time

--- a/test/valkey/auth_commands_test.rb
+++ b/test/valkey/auth_commands_test.rb
@@ -12,6 +12,15 @@
 # - ACL rules are defined per node th inside the block helpers.
 module ValkeyTests
   module AuthCommands
+    # Tests that open a connection with WRONG credentials (server replies
+    # "AuthenticationFailed") intermittently hang the native connection-creation
+    # path and wedge the entire standalone suite (30-min CI timeout). The
+    # missing-credentials/NOAUTH path is NOT affected. Disabled until the
+    # underlying FFI connection-creation race is fixed upstream. See PR #113.
+    WRONG_CREDENTIALS_HANG_SKIP =
+      "Disabled: wrong-credentials connect (AuthenticationFailed) intermittently hangs " \
+      "the native connection-creation path and wedges the suite. See PR #113."
+
     # =========================================================
     # Default user -- connect-time
     # =========================================================
@@ -27,6 +36,7 @@ module ValkeyTests
 
     # should refuse to connect when the default-user password is wrong
     def test_connect_with_wrong_password_raises
+      skip(WRONG_CREDENTIALS_HANG_SKIP)
       with_default_user_password do |_user, _password|
         error = assert_raises(::Valkey::CannotConnectError) do
           _new_client(password: "wrongpass", connect_timeout: 1.0, reconnect_attempts: 0)
@@ -79,6 +89,7 @@ module ValkeyTests
     # should refuse to connect when the ACL user's password is wrong
     def test_connect_with_acl_user_wrong_password_raises
       skip("ACL auth tests only run on standalone mode") if cluster_mode?
+      skip(WRONG_CREDENTIALS_HANG_SKIP)
       with_acl do |username, _password|
         error = assert_raises(::Valkey::CannotConnectError) do
           _new_client(username: username, password: "wrong",
@@ -91,6 +102,7 @@ module ValkeyTests
     # should refuse to connect when the username does not exist
     def test_connect_with_acl_user_unknown_username_raises
       skip("ACL auth tests only run on standalone mode") if cluster_mode?
+      skip(WRONG_CREDENTIALS_HANG_SKIP)
       with_acl do |_username, password|
         error = assert_raises(::Valkey::CannotConnectError) do
           _new_client(username: "nobody", password: password,

--- a/test/valkey/auth_commands_test.rb
+++ b/test/valkey/auth_commands_test.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+# Behavioral authentication tests for valkey-glide-ruby.
+#
+# Unlike uri_connection_test.rb (which connects to a no-auth server and rescues
+# away every failure), these tests actually toggle auth at runtime via the
+# Helper::Generic `with_default_user_password` / `with_acl` block helpers and
+# assert the concrete success/failure behavior.
+#
+# Note:
+# - Credentials are created and torn down per-test.
+# - ACL rules are defined per node th inside the block helpers.
+module ValkeyTests
+  module AuthCommands
+    # =========================================================
+    # Default user -- connect-time
+    # =========================================================
+
+    # should connect and respond to PING when given the correct default-user password
+    def test_connect_with_correct_password_succeeds
+      with_default_user_password do |_user, password|
+        client = _new_client(password: password)
+        assert_equal "PONG", client.ping
+        client.close
+      end
+    end
+
+    # should refuse to connect when the default-user password is wrong
+    def test_connect_with_wrong_password_raises
+      with_default_user_password do |_user, _password|
+        error = assert_raises(::Valkey::CannotConnectError) do
+          _new_client(password: "wrongpass", connect_timeout: 1.0, reconnect_attempts: 0)
+        end
+        # glide-core surfaces a wrong password at connect-time as
+        # "Password authentication failed- AuthenticationFailed" (not the raw
+        # server WRONGPASS, which only appears via the runtime AUTH command).
+        assert_includes error.message, "AuthenticationFailed"
+      end
+    end
+
+    # should refuse to connect when no credentials are supplied to a password-protected server
+    def test_connect_without_password_raises
+      with_default_user_password do |_user, _password|
+        error = assert_raises(::Valkey::CannotConnectError) do
+          _new_client(connect_timeout: 1.0, reconnect_attempts: 0)
+        end
+        assert_includes error.message, "NOAUTH"
+      end
+    end
+
+    # should refuse to connect when given an empty password against a password-protected server
+    def test_connect_with_empty_password_against_auth_server_raises
+      with_default_user_password do |_user, _password|
+        error = assert_raises(::Valkey::CannotConnectError) do
+          _new_client(password: "", connect_timeout: 1.0, reconnect_attempts: 0)
+        end
+        # An empty password is currently treated as "no credentials", so the
+        # server returns NOAUTH (same as the missing-password case). This
+        # empty-vs-missing behavior is implementation-defined and could change.
+        assert_includes error.message, "NOAUTH"
+      end
+    end
+
+    # =========================================================
+    # ACL user -- connect-time (skipped in cluster mode)
+    # =========================================================
+
+    # should connect and respond to PING when given valid ACL user credentials
+    def test_connect_with_acl_user_credentials_succeeds
+      skip("ACL auth tests only run on standalone mode") if cluster_mode?
+      with_acl do |username, password|
+        # Built directly, not via init: johndoe lacks +flushdb.
+        client = _new_client(username: username, password: password)
+        assert_equal "PONG", client.ping
+        client.close
+      end
+    end
+
+    # should refuse to connect when the ACL user's password is wrong
+    def test_connect_with_acl_user_wrong_password_raises
+      skip("ACL auth tests only run on standalone mode") if cluster_mode?
+      with_acl do |username, _password|
+        error = assert_raises(::Valkey::CannotConnectError) do
+          _new_client(username: username, password: "wrong",
+                      connect_timeout: 1.0, reconnect_attempts: 0)
+        end
+        assert_includes error.message, "AuthenticationFailed"
+      end
+    end
+
+    # should refuse to connect when the username does not exist
+    def test_connect_with_acl_user_unknown_username_raises
+      skip("ACL auth tests only run on standalone mode") if cluster_mode?
+      with_acl do |_username, password|
+        error = assert_raises(::Valkey::CannotConnectError) do
+          _new_client(username: "nobody", password: password,
+                      connect_timeout: 1.0, reconnect_attempts: 0)
+        end
+        # An unknown username surfaces the same connect-time auth failure as a
+        # wrong password (the server does not distinguish the two to clients).
+        assert_includes error.message, "AuthenticationFailed"
+      end
+    end
+
+    # should raise when an ACL user runs a command outside its permissions
+    # The FFI maps the permission error to Valkey::CommandError. glide-core
+    # translates the server's NOPERM into a "PermissionDenied" message, so we
+    # assert the class and that distinctive token.
+    def test_acl_user_disallowed_command_raises
+      skip("ACL auth tests only run on standalone mode") if cluster_mode?
+      with_acl do |username, password|
+        # Built directly, not via init: johndoe lacks +flushdb (and +set).
+        client = _new_client(username: username, password: password)
+        begin
+          error = assert_raises(::Valkey::CommandError) do
+            client.set("k", "v")
+          end
+          assert_includes error.message, "PermissionDenied"
+        ensure
+          client.close
+        end
+      end
+    end
+
+    # should return OK when AUTH is called with the correct password
+    def test_auth_command_with_correct_password
+      with_default_user_password do |_user, password|
+        client = _new_client(password: password)
+        assert_equal "OK", client.auth(password)
+        client.close
+      end
+    end
+
+    # should raise when AUTH is called with the wrong password
+    def test_auth_command_with_wrong_password_raises
+      with_default_user_password do |_user, password|
+        client = _new_client(password: password)
+        begin
+          error = assert_raises(::Valkey::CommandError) do
+            client.auth("wrongpass")
+          end
+          # The runtime AUTH command surfaces the raw server WRONGPASS reply
+          # (unlike connect-time failures, which report AuthenticationFailed).
+          assert_includes error.message, "WRONGPASS"
+        ensure
+          client.close
+        end
+      end
+    end
+
+    # should return OK when AUTH is called with a valid username and password
+    def test_auth_command_with_username_and_password
+      skip("ACL auth tests only run on standalone mode") if cluster_mode?
+      with_acl do |username, password|
+        client = _new_client(username: username, password: password)
+        begin
+          # This switches the live connection to the limited johndoe user;
+          # don't run privileged commands on this client afterward.
+          assert_equal "OK", client.auth(username, password)
+        ensure
+          client.close
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Overview

Added authentication tests for both default and ACL user tests. 

Wrong password tests are skipped because of a discovered bug. See #115

## Related Issue

Closes #106 

Follow-up #115

## Changes

- `test/valkey/auth_commands_test.rb`: **new** — defines `module ValkeyTests::AuthCommands` with 11 tests.
- `test/support/helper/generic.rb`: Updated default and ACL credentials set up.
