### PR TITLE
test: add tests for connection lifecycles, FAILOVER and CLUSTER FAILOVER.

### DIFF
--- a/lib/valkey.rb
+++ b/lib/valkey.rb
@@ -243,13 +243,12 @@ class Valkey
   end
 
   def send_command(command_type, command_args = [], &block)
-    # Validate connection
-    if @connection.nil?
-      raise "Connection is nil"
-    elsif @connection.null?
-      raise "Connection pointer is null"
-    elsif @connection.address.zero?
-      raise "Connection address is 0"
+    # Validate connection. A nil/null pointer means the client was closed (or
+    # never established a usable connection); surface it as a typed error with
+    # the same "the client is closed" wording the sibling GLIDE clients use
+    # (Go ClosingError, Node/Java ClosingException).
+    if @connection.nil? || @connection.null? || @connection.address.zero?
+      raise ConnectionError, "the client is closed"
     end
 
     channel = 0

--- a/lib/valkey.rb
+++ b/lib/valkey.rb
@@ -247,9 +247,7 @@ class Valkey
     # never established a usable connection); surface it as a typed error with
     # the same "the client is closed" wording the sibling GLIDE clients use
     # (Go ClosingError, Node/Java ClosingException).
-    if @connection.nil? || @connection.null? || @connection.address.zero?
-      raise ConnectionError, "the client is closed"
-    end
+    raise ConnectionError, "the client is closed" if @connection.nil? || @connection.null? || @connection.address.zero?
 
     channel = 0
     route = ""

--- a/lib/valkey/commands/cluster_commands.rb
+++ b/lib/valkey/commands/cluster_commands.rb
@@ -71,13 +71,30 @@ class Valkey
         send_command(RequestType::CLUSTER_DEL_SLOTS_RANGE, [start_slot, end_slot])
       end
 
+      # Valid modes for CLUSTER FAILOVER: FORCE, TAKEOVER.
+      CLUSTER_FAILOVER_MODES = %i[force takeover].freeze
+
       # Force a failover of the cluster.
       #
-      # @param [String] force force the failover
+      # Must be sent to a replica node. Without a mode, performs a coordinated
+      # failover (the primary is asked to pause clients and hand over). +:force+
+      # promotes the replica without coordinating with the primary (useful when
+      # the primary is unreachable); +:takeover+ promotes it without any cluster
+      # consensus (most aggressive — risks data loss / split brain).
+      #
+      # @param [Symbol, nil] mode optional failover mode: +:force+ or +:takeover+
       # @return [String] `"OK"`
-      def cluster_failover(force = nil)
+      # @raise [ArgumentError] if +mode+ is not nil, +:force+, or +:takeover+
+      # @see https://valkey.io/commands/cluster-failover/
+      def cluster_failover(mode = nil)
         args = []
-        args << "FORCE" if force
+        unless mode.nil?
+          unless CLUSTER_FAILOVER_MODES.include?(mode)
+            raise ArgumentError, "invalid CLUSTER FAILOVER mode #{mode.inspect}: expected :force or :takeover"
+          end
+
+          args << mode.to_s.upcase
+        end
         send_command(RequestType::CLUSTER_FAILOVER, args)
       end
 

--- a/lib/valkey/commands/server_commands.rb
+++ b/lib/valkey/commands/server_commands.rb
@@ -499,13 +499,19 @@ class Valkey
       # @see https://valkey.io/commands/failover/
       def failover(to: nil, force: false, abort: false, timeout: nil)
         args = []
-        if to
-          host, port = to.split
-          args << "TO" << host << port
+        if abort
+          # ABORT is mutually exclusive: cancels an ongoing failover and
+          # ignores any other arguments (matches the core GLIDE clients).
+          args << "ABORT"
+        else
+          if to
+            host, port = to.split
+            args << "TO" << host << port
+            # FORCE is only valid in combination with TO.
+            args << "FORCE" if force
+          end
+          args << "TIMEOUT" << timeout.to_s if timeout
         end
-        args << "FORCE" if force
-        args << "ABORT" if abort
-        args << "TIMEOUT" << timeout.to_s if timeout
         send_command(RequestType::FAIL_OVER, args)
       end
 

--- a/test/lint/cluster_commands.rb
+++ b/test/lint/cluster_commands.rb
@@ -282,40 +282,44 @@ module Lint
       pass "Cluster setslot correctly failed with invalid parameters"
     end
 
-    def test_cluster_failover_on_cluster
-      # Test cluster failover (only works on replica nodes)
-      result = r.cluster_failover
-      # This will fail on master nodes, which is expected
-      case result
-      when "OK"
-        pass "Cluster failover succeeded as expected"
-      when false
-        pass "Cluster failover returned false (not ready for failover)"
-      when Valkey::CommandError
-        pass "Cluster failover correctly failed as expected"
-      else
-        flunk "Unexpected result from cluster_failover: #{result.inspect}"
-      end
-    rescue Valkey::CommandError => e
-      # Expected to fail on master nodes - accept any error message
-      pass "Cluster failover correctly failed on master node as expected: #{e.message}"
+    # CLUSTER FAILOVER must run on a replica and, on default routing, may be
+    # sent to a replica and trigger a *real* failover — which would destabilize
+    # the shared test cluster. So instead of issuing it live, we stub
+    # send_command and assert the arguments the client builds.
+    #
+    # should send "CLUSTER FAILOVER" with no extra args for a coordinated failover
+    def test_cluster_failover_coordinated_sends_no_args
+      assert_equal [], capture_cluster_failover_args
     end
 
-    def test_cluster_force_failover
-      # Test cluster failover with force option - should still fail on master
-      result = r.cluster_failover("FORCE")
-      # This might return false or raise an error on master nodes
-      case result
-      when "OK"
-        pass "Cluster force failover succeeded as expected"
-      when false
-        pass "Cluster force failover returned false (not ready for failover)"
-      else
-        flunk "Unexpected result from cluster force failover: #{result.inspect}"
+    # should append "FORCE" for the :force mode
+    def test_cluster_failover_force_sends_force_arg
+      assert_equal ["FORCE"], capture_cluster_failover_args(:force)
+    end
+
+    # should append "TAKEOVER" for the :takeover mode
+    def test_cluster_failover_takeover_sends_takeover_arg
+      assert_equal ["TAKEOVER"], capture_cluster_failover_args(:takeover)
+    end
+
+    # should raise ArgumentError for an unrecognized mode (incl. strings/booleans)
+    def test_cluster_failover_invalid_mode_raises
+      assert_raises(ArgumentError) { r.cluster_failover(:bogus) }
+      assert_raises(ArgumentError) { r.cluster_failover("FORCE") }
+      assert_raises(ArgumentError) { r.cluster_failover(true) }
+    end
+
+    # Invokes cluster_failover while intercepting send_command, and returns the
+    # argument array the client would have sent — without issuing a real
+    # failover against the cluster.
+    def capture_cluster_failover_args(*mode)
+      captured = nil
+      recorder = lambda do |_request_type, args = [], &_block|
+        captured = args
+        "OK"
       end
-    rescue Valkey::CommandError => e
-      # Expected to fail on master nodes even with force - accept any error message
-      pass "Cluster force failover correctly failed on master node as expected: #{e.message}"
+      r.stub(:send_command, recorder) { r.cluster_failover(*mode) }
+      captured
     end
 
     def test_cluster_set_config_epoch

--- a/test/standalone/valkey_test.rb
+++ b/test/standalone/valkey_test.rb
@@ -11,7 +11,7 @@ class TestStandaloneValkey < Minitest::Test
   include ValkeyTests::AuthCommands
   include ValkeyTests::Bitpos
 
-  # include ValkeyTests::ConnectionLifecycle
+  include ValkeyTests::ConnectionLifecycle
   include ValkeyTests::FailoverCommands
   include ValkeyTests::FunctionCommands
   include ValkeyTests::GenericCommands

--- a/test/standalone/valkey_test.rb
+++ b/test/standalone/valkey_test.rb
@@ -10,7 +10,8 @@ class TestStandaloneValkey < Minitest::Test
   # ValkeyTests modules for valkey-glide-ruby specific functionality
   include ValkeyTests::AuthCommands
   include ValkeyTests::Bitpos
-  include ValkeyTests::ConnectionLifecycle
+
+  # include ValkeyTests::ConnectionLifecycle
   include ValkeyTests::FailoverCommands
   include ValkeyTests::FunctionCommands
   include ValkeyTests::GenericCommands

--- a/test/standalone/valkey_test.rb
+++ b/test/standalone/valkey_test.rb
@@ -10,6 +10,7 @@ class TestStandaloneValkey < Minitest::Test
   # ValkeyTests modules for valkey-glide-ruby specific functionality
   include ValkeyTests::AuthCommands
   include ValkeyTests::Bitpos
+  include ValkeyTests::ConnectionLifecycle
   include ValkeyTests::FailoverCommands
   include ValkeyTests::FunctionCommands
   include ValkeyTests::GenericCommands

--- a/test/standalone/valkey_test.rb
+++ b/test/standalone/valkey_test.rb
@@ -10,6 +10,7 @@ class TestStandaloneValkey < Minitest::Test
   # ValkeyTests modules for valkey-glide-ruby specific functionality
   include ValkeyTests::AuthCommands
   include ValkeyTests::Bitpos
+  include ValkeyTests::FailoverCommands
   include ValkeyTests::FunctionCommands
   include ValkeyTests::GenericCommands
   include ValkeyTests::Scanning

--- a/test/valkey/connection_lifecycle_test.rb
+++ b/test/valkey/connection_lifecycle_test.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+# Connection-lifecycle tests: behavior on close and on connection timeout.
+#
+# Mirrors the sibling GLIDE clients:
+#   - test 4 (closed client): go/integTest/standalone_commands_test.go ->
+#     TestPing_ClosedClient; python .../test_async_client.py ->
+#     test_closed_client_raises_error (asserts "the client is closed")
+#   - test 5 (recreation): python -> test_client_recreation_after_close
+#   - test 6 (unavailable host): python -> test_connection_timeout_on_unavailable_host
+#   - test 7 (blocked server): node/tests/GlideClient.test.ts:1279
+#     "should handle connection timeout when client is blocked by long-running command";
+#     python -> test_connection_timeout_when_client_is_blocked
+#
+# All are standalone-shaped and skipped in cluster mode.
+module ValkeyTests
+  module ConnectionLifecycle
+    # =================================================================
+    # Test 4 — command on a closed client
+    # =================================================================
+
+    # should raise a connection error stating the client is closed when a
+    # command is issued after close
+    def test_closed_client_raises_error
+      skip("connection lifecycle tests only run on standalone mode") if cluster_mode?
+
+      client = _new_client
+      client.close
+
+      error = assert_raises(Valkey::ConnectionError) { client.set("foo", "bar") }
+      assert_match(/the client is closed/, error.message)
+    end
+
+    # =================================================================
+    # Test 5 — client recreation after close
+    # =================================================================
+
+    # should let a new client connect and round-trip set/get after a previous
+    # client was closed (the shared FFI pipe stays valid across lifecycles)
+    def test_client_recreation_after_close
+      skip("connection lifecycle tests only run on standalone mode") if cluster_mode?
+
+      key = "lifecycle:recreate"
+
+      client1 = _new_client
+      assert_equal "OK", client1.set(key, "v1")
+      assert_equal "v1", client1.get(key)
+      client1.close
+
+      client2 = _new_client
+      assert_equal "OK", client2.set(key, "v2")
+      assert_equal "v2", client2.get(key)
+      client2.del(key)
+      client2.close
+    end
+
+    # =================================================================
+    # Test 6 — connection timeout on an unavailable host
+    # =================================================================
+
+    # should fail fast (within ~2.5x the connect timeout) instead of hanging
+    # when connecting to an unreachable host
+    def test_connection_timeout_on_unavailable_host
+      skip("connection lifecycle tests only run on standalone mode") if cluster_mode?
+
+      connect_timeout = 1.0
+      # 192.0.2.1 is TEST-NET-1 (RFC 5737), reserved and unroutable, so the
+      # connect attempt hangs until the timeout rather than being refused or
+      # incurring DNS delay.
+      started = monotonic_now
+      assert_raises(Valkey::CannotConnectError) do
+        ::Valkey.new(
+          host: "192.0.2.1",
+          port: 6379,
+          connect_timeout: connect_timeout,
+          reconnect_attempts: 0
+        )
+      end
+      elapsed = monotonic_now - started
+
+      max_allowed = connect_timeout * 2.5
+      assert elapsed < max_allowed,
+             "connect took #{elapsed.round(2)}s, expected < #{max_allowed}s " \
+             "(connect_timeout not being respected)"
+    end
+
+    # =================================================================
+    # Test 7 — connection timeout while the server is blocked
+    # =================================================================
+
+    # should reject a new connection with a small connect timeout while the
+    # server is blocked by a long-running command, yet allow one with a
+    # generous timeout
+    def test_connection_timeout_when_server_is_blocked
+      skip("connection lifecycle tests only run on standalone mode") if cluster_mode?
+      skip("DEBUG SLEEP is not enabled on this server") unless debug_sleep_available?
+
+      blocker = _new_client
+      sleep_seconds = 3
+      blocker_thread = Thread.new do
+        # DEBUG SLEEP blocks the (single-threaded) server for the full duration
+        # even if this client's request times out first; the FFI command call
+        # releases the GVL, so the main thread keeps running.
+        blocker.send_command(Valkey::RequestType::CUSTOM_COMMAND, ["DEBUG", "SLEEP", sleep_seconds.to_s])
+      rescue Valkey::BaseError
+        nil # the assertions below are what matter
+      end
+
+      # Give the server a moment to enter the blocked state.
+      sleep(0.5)
+
+      # A short connection timeout must fail while the server is blocked.
+      assert_raises(Valkey::CannotConnectError) do
+        _new_client(connect_timeout: 0.1, reconnect_attempts: 0)
+      end
+
+      # A generous connection timeout should still connect once the block clears.
+      patient = _new_client(connect_timeout: 10.0)
+      assert_equal "PONG", patient.ping
+      patient.close
+    ensure
+      blocker_thread&.join
+      blocker&.close
+    end
+
+    private
+
+    def monotonic_now
+      Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    end
+
+    # Probes whether DEBUG SLEEP is permitted on the server (it requires
+    # enable-debug-command). Uses the shared client and a zero-length sleep.
+    def debug_sleep_available?
+      r.send_command(Valkey::RequestType::CUSTOM_COMMAND, ["DEBUG", "SLEEP", "0"])
+      true
+    rescue Valkey::CommandError
+      false
+    end
+  end
+end

--- a/test/valkey/connection_lifecycle_test.rb
+++ b/test/valkey/connection_lifecycle_test.rb
@@ -50,7 +50,6 @@ module ValkeyTests
     # when connecting to an unreachable host
     def test_connection_timeout_on_unavailable_host
       skip("connection lifecycle tests only run on standalone mode") if cluster_mode?
-      skip("connect_timeout not enforced by the native sync client for an unreachable host; hangs CI (see PR #114)")
 
       connect_timeout = 1.0
       # 192.0.2.1 is TEST-NET-1 (RFC 5737), reserved and unroutable, so the
@@ -62,7 +61,7 @@ module ValkeyTests
           host: "192.0.2.1",
           port: 6379,
           connect_timeout: connect_timeout,
-          reconnect_attempts: 1
+          reconnect_attempts: 1 # Should be zero however issue #117 blocks this.
         )
       end
       elapsed = monotonic_now - started
@@ -96,7 +95,7 @@ module ValkeyTests
 
       # A short connection timeout must fail while the server is blocked.
       assert_raises(Valkey::CannotConnectError) do
-        _new_client(connect_timeout: 0.1, reconnect_attempts: 1)
+        _new_client(connect_timeout: 0.1, reconnect_attempts: 1) # Should be zero however issue #117 blocks this.
       end
 
       # A generous connection timeout should still connect once the block clears.

--- a/test/valkey/connection_lifecycle_test.rb
+++ b/test/valkey/connection_lifecycle_test.rb
@@ -15,10 +15,6 @@
 # All are standalone-shaped and skipped in cluster mode.
 module ValkeyTests
   module ConnectionLifecycle
-    # =================================================================
-    # Test 4 — command on a closed client
-    # =================================================================
-
     # should raise a connection error stating the client is closed when a
     # command is issued after close
     def test_closed_client_raises_error
@@ -30,10 +26,6 @@ module ValkeyTests
       error = assert_raises(Valkey::ConnectionError) { client.set("foo", "bar") }
       assert_match(/the client is closed/, error.message)
     end
-
-    # =================================================================
-    # Test 5 — client recreation after close
-    # =================================================================
 
     # should let a new client connect and round-trip set/get after a previous
     # client was closed (the shared FFI pipe stays valid across lifecycles)
@@ -53,10 +45,6 @@ module ValkeyTests
       client2.del(key)
       client2.close
     end
-
-    # =================================================================
-    # Test 6 — connection timeout on an unavailable host
-    # =================================================================
 
     # should fail fast (within ~2.5x the connect timeout) instead of hanging
     # when connecting to an unreachable host
@@ -91,10 +79,6 @@ module ValkeyTests
              "connect took #{elapsed.round(2)}s, expected < #{max_allowed}s " \
              "(connect_timeout not being respected)"
     end
-
-    # =================================================================
-    # Test 7 — connection timeout while the server is blocked
-    # =================================================================
 
     # should reject a new connection with a small connect timeout while the
     # server is blocked by a long-running command, yet allow one with a

--- a/test/valkey/connection_lifecycle_test.rb
+++ b/test/valkey/connection_lifecycle_test.rb
@@ -50,13 +50,6 @@ module ValkeyTests
     # when connecting to an unreachable host
     def test_connection_timeout_on_unavailable_host
       skip("connection lifecycle tests only run on standalone mode") if cluster_mode?
-      # DISABLED: the synchronous FFI connect path (create_client_from_uri) does
-      # not honor connection_timeout when the host is unreachable, so Valkey.new
-      # never returns and hangs the entire standalone suite (30-min CI cap on
-      # every matrix cell). The Ruby side forwards connection_timeout and
-      # reconnect_attempts: 0 correctly; the gap is in glide-core's sync client
-      # (the async Python/Node clients this test mirrors do enforce it).
-      # Re-enable once the native fix lands. See PR #114.
       skip("connect_timeout not enforced by the native sync client for an unreachable host; hangs CI (see PR #114)")
 
       connect_timeout = 1.0
@@ -69,7 +62,7 @@ module ValkeyTests
           host: "192.0.2.1",
           port: 6379,
           connect_timeout: connect_timeout,
-          reconnect_attempts: 0
+          reconnect_attempts: 1
         )
       end
       elapsed = monotonic_now - started
@@ -103,7 +96,7 @@ module ValkeyTests
 
       # A short connection timeout must fail while the server is blocked.
       assert_raises(Valkey::CannotConnectError) do
-        _new_client(connect_timeout: 0.1, reconnect_attempts: 0)
+        _new_client(connect_timeout: 0.1, reconnect_attempts: 1)
       end
 
       # A generous connection timeout should still connect once the block clears.

--- a/test/valkey/connection_lifecycle_test.rb
+++ b/test/valkey/connection_lifecycle_test.rb
@@ -62,6 +62,14 @@ module ValkeyTests
     # when connecting to an unreachable host
     def test_connection_timeout_on_unavailable_host
       skip("connection lifecycle tests only run on standalone mode") if cluster_mode?
+      # DISABLED: the synchronous FFI connect path (create_client_from_uri) does
+      # not honor connection_timeout when the host is unreachable, so Valkey.new
+      # never returns and hangs the entire standalone suite (30-min CI cap on
+      # every matrix cell). The Ruby side forwards connection_timeout and
+      # reconnect_attempts: 0 correctly; the gap is in glide-core's sync client
+      # (the async Python/Node clients this test mirrors do enforce it).
+      # Re-enable once the native fix lands. See PR #114.
+      skip("connect_timeout not enforced by the native sync client for an unreachable host; hangs CI (see PR #114)")
 
       connect_timeout = 1.0
       # 192.0.2.1 is TEST-NET-1 (RFC 5737), reserved and unroutable, so the
@@ -132,7 +140,7 @@ module ValkeyTests
     # Probes whether DEBUG SLEEP is permitted on the server (it requires
     # enable-debug-command). Uses the shared client and a zero-length sleep.
     def debug_sleep_available?
-      r.send_command(Valkey::RequestType::CUSTOM_COMMAND, ["DEBUG", "SLEEP", "0"])
+      r.send_command(Valkey::RequestType::CUSTOM_COMMAND, %w[DEBUG SLEEP 0])
       true
     rescue Valkey::CommandError
       false

--- a/test/valkey/failover_commands_test.rb
+++ b/test/valkey/failover_commands_test.rb
@@ -14,6 +14,8 @@ module ValkeyTests
     # should return "OK" and flip the connected primary's role to slave once
     # the coordinated failover to its replica completes.
     def test_failover_promotes_replica_and_returns_ok
+      skip("This sometimes hang. Unsure if it is a client bug. See https://github.com/valkey-io/valkey-glide-ruby/issues/117")
+
       with_standalone_replica do |primary|
         Timeout.timeout(FAILOVER_TEST_DEADLINE) do
           assert_equal "master", primary.info("replication")["role"]

--- a/test/valkey/failover_commands_test.rb
+++ b/test/valkey/failover_commands_test.rb
@@ -14,8 +14,6 @@ module ValkeyTests
     # should return "OK" and flip the connected primary's role to slave once
     # the coordinated failover to its replica completes.
     def test_failover_promotes_replica_and_returns_ok
-      skip("This sometimes hang. Unsure if it is a client bug. See https://github.com/valkey-io/valkey-glide-ruby/issues/117")
-
       with_standalone_replica do |primary|
         Timeout.timeout(FAILOVER_TEST_DEADLINE) do
           assert_equal "master", primary.info("replication")["role"]

--- a/test/valkey/failover_commands_test.rb
+++ b/test/valkey/failover_commands_test.rb
@@ -28,7 +28,7 @@ module ValkeyTests
       assert_equal ["ABORT"], capture_failover_args(abort: true, timeout: 5000)
     end
 
-    # should not emit "FORCE" unless a TO target is supplied
+    # should not send "FORCE" unless a TO target is supplied
     def test_failover_force_without_target_omits_force
       assert_equal [], capture_failover_args(force: true)
     end

--- a/test/valkey/failover_commands_test.rb
+++ b/test/valkey/failover_commands_test.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+# Integration test for the standalone FAILOVER command.
+# NOTE: FAILOVER is a standalone-only command.
+module ValkeyTests
+  module FailoverCommands
+    # should return "OK" and flip the connected primary's role to slave once
+    # the coordinated failover to its replica completes
+    def test_failover_promotes_replica_and_returns_ok
+      with_standalone_replica do |primary|
+        assert_equal "master", primary.info("replication")["role"]
+
+        assert_equal "OK", primary.failover
+
+        assert wait_for_role?(primary, "slave"),
+               "timed out waiting for the primary to become a replica (role:slave)"
+      end
+    end
+
+    # should raise a error when ABORT is requested but no failover is
+    # currently in progress
+    def test_failover_abort_with_no_failover_in_progress_raises
+      assert_raises(Valkey::CommandError) { r.failover(abort: true) }
+    end
+
+    # should send "ABORT" only
+    def test_failover_abort_sends_abort_only
+      assert_equal ["ABORT"], capture_failover_args(abort: true, timeout: 5000)
+    end
+
+    # should not emit "FORCE" unless a TO target is supplied
+    def test_failover_force_without_target_omits_force
+      assert_equal [], capture_failover_args(force: true)
+    end
+
+    # should build "TO host port FORCE TIMEOUT ms" in order for a full request
+    def test_failover_builds_full_arg_list_in_order
+      args = capture_failover_args(to: "127.0.0.1 6380", force: true, timeout: 5000)
+      assert_equal ["TO", "127.0.0.1", "6380", "FORCE", "TIMEOUT", "5000"], args
+    end
+
+    private
+
+    # Replace the send_command method used by failover() with a stub which captures the arguments and returns "OK".
+    # This allows us to see the arguments passed to the failover command without actually executing it.
+    def capture_failover_args(**options)
+      captured = nil
+      stub = lambda do |_request_type, args = [], &_block|
+        captured = args
+        "OK"
+      end
+      r.stub(:send_command, stub) { r.failover(**options) }
+      captured
+    end
+
+    # Start a standalone primary with one replica and yields a
+    # client connected to the primary. Cleans up afterward.
+    def with_standalone_replica
+      cluster = Valkey::TestCluster.new(
+        cluster_mode: false,
+        shard_count: 1,
+        replica_count: 1
+      )
+      primary_addr = cluster.addresses.first
+      client = Valkey.new(host: primary_addr[:host], port: primary_addr[:port], timeout: 5.0)
+      yield(client)
+    rescue Valkey::TestCluster::PythonNotFoundError, Valkey::TestCluster::ScriptNotFoundError => e
+      skip("requires python3 + valkey-glide submodule for replica setup: #{e.message}")
+    ensure
+      client&.close
+      cluster&.close
+    end
+
+    # Polls INFO REPLICATION until role matches (or times out).
+    def wait_for_role?(client, role, attempts: 60, interval: 0.5)
+      attempts.times do
+        return true if client.info("replication")["role"] == role
+
+        sleep(interval)
+      end
+      false
+    end
+  end
+end

--- a/test/valkey/failover_commands_test.rb
+++ b/test/valkey/failover_commands_test.rb
@@ -1,20 +1,35 @@
 # frozen_string_literal: true
 
+require "timeout"
+
 # Integration test for the standalone FAILOVER command.
 # NOTE: FAILOVER is a standalone-only command.
 module ValkeyTests
   module FailoverCommands
+    FAILOVER_TIMEOUT_MS = 10_000
+
+    # Wall-clock backstop, above the wait_for_role? budget (60 * 0.5s = 30s).
+    FAILOVER_TEST_DEADLINE = 45
+
     # should return "OK" and flip the connected primary's role to slave once
-    # the coordinated failover to its replica completes
+    # the coordinated failover to its replica completes.
     def test_failover_promotes_replica_and_returns_ok
       with_standalone_replica do |primary|
-        assert_equal "master", primary.info("replication")["role"]
+        Timeout.timeout(FAILOVER_TEST_DEADLINE) do
+          assert_equal "master", primary.info("replication")["role"]
 
-        assert_equal "OK", primary.failover
+          # FAILOVER's TIMEOUT bounds the wait server-side; without it the wait is
+          # "infinite" and the blocking command never returns. See
+          # https://valkey.io/commands/failover/
+          assert_equal "OK", primary.failover(timeout: FAILOVER_TIMEOUT_MS)
 
-        assert wait_for_role?(primary, "slave"),
-               "timed out waiting for the primary to become a replica (role:slave)"
+          assert wait_for_role?(primary, "slave"),
+                 "timed out waiting for the primary to become a replica (role:slave)"
+        end
       end
+    rescue Timeout::Error
+      flunk("failover did not complete within #{FAILOVER_TEST_DEADLINE}s " \
+            "(client likely hanged during the role transition)")
     end
 
     # should raise a error when ABORT is requested but no failover is


### PR DESCRIPTION
## Overview

This PR adds new tests for FAILOVER and CLUSTER FAILOVER commands. It also added some connection lifecycle tests. Some bugs fixes were added.

An issue was found and recorded
- #115 

## Related
Closes #104 
  
## Changes
  - [4eb8a25](https://github.com/valkey-io/valkey-glide-ruby/commit/4eb8a25812dc6b1f6682a091587bc129e8168607): Add FAILOVER tests and fix a FAILOVER args-construction bug; FORCE is now only emitted alongside TO, and ABORT is treated as mutually exclusive.
  - [6eadc7b](https://github.com/valkey-io/valkey-glide-ruby/commit/6eadc7b4611d05809c5d2b984a4a64a0e1891a1f): Implement CLUSTER FAILOVER and add test coverages.
  - [ac21761](https://github.com/valkey-io/valkey-glide-ruby/commit/ac21761855c111c435eaf18e9655ae77d189b8e7): Raise a typed Valkey::ConnectionError ("the client is closed") when the connection is nil, null, orhas a zero address, matching the sibling clients' closed-client behavior.
  - [99adc2f](https://github.com/valkey-io/valkey-glide-ruby/commit/99adc2f4fc7fda8e1957b013c814dfe3d3618a29): Added connection-lifecycle tests: command on a closed client, client recreation after close, connect timeout on an unavailable host, and connect timeout while the server is blocked.