### PR TITLE
feat(ruby): add missing core options

### DIFF
--- a/.github/json_matrices/build-matrix.json
+++ b/.github/json_matrices/build-matrix.json
@@ -16,5 +16,13 @@
         "TARGET": "aarch64-unknown-linux-gnu",
         "run": "always",
         "languages": ["ruby"]
+    },
+    {
+        "OS": "macos",
+        "NAMED_OS": "darwin",
+        "RUNNER": "macos-latest",
+        "ARCH": "arm64",
+        "TARGET": "aarch64-apple-darwin",
+        "languages": ["ruby"]
     }
 ]

--- a/.github/json_matrices/build-matrix.json
+++ b/.github/json_matrices/build-matrix.json
@@ -2,10 +2,11 @@
     {
         "OS": "ubuntu",
         "NAMED_OS": "linux",
-        "RUNNER": "ubuntu-latest",
+        "RUNNER": "ubuntu-24.04",
         "ARCH": "x64",
         "TARGET": "x86_64-unknown-linux-gnu",
-        "run": "always"
+        "run": "always",
+        "languages": ["ruby"]
     },
     {
         "OS": "ubuntu",
@@ -13,6 +14,7 @@
         "RUNNER": "ubuntu-24.04-arm",
         "ARCH": "arm64",
         "TARGET": "aarch64-unknown-linux-gnu",
-        "run": "always"
+        "run": "always",
+        "languages": ["ruby"]
     }
 ]

--- a/.github/json_matrices/engine-matrix.json
+++ b/.github/json_matrices/engine-matrix.json
@@ -1,0 +1,28 @@
+[
+    {
+        "type": "valkey",
+        "version": "9.0",
+        "run": "always"
+    },
+    {
+        "type": "valkey",
+        "version": "8.1"
+    },
+    {
+        "type": "valkey",
+        "version": "8.0"
+    },
+    {
+        "type": "valkey",
+        "version": "7.2"
+    },
+    {
+        "type": "redis",
+        "version": "7.0"
+    },
+    {
+        "type": "redis",
+        "version": "6.2",
+        "run": "always"
+    }
+]

--- a/.github/json_matrices/supported-languages-versions.json
+++ b/.github/json_matrices/supported-languages-versions.json
@@ -1,0 +1,7 @@
+[
+    {
+        "language": "ruby",
+        "versions": ["3.0", "3.1", "3.2", "3.3", "3.4"],
+        "always-run-versions": ["3.2", "3.4"]
+    }
+]

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,13 +1,57 @@
 name: CI
 
+run-name: ${{ inputs.name || format('{0} @ {1} {2}', github.ref_name, github.sha, toJson(inputs)) }}
+
 on:
+  pull_request:
+    paths:
+      - lib/**
+      - test/**
+      - valkey-glide/ffi/**
+      - .github/workflows/**
+      - .github/json_matrices/**
+      - Gemfile
+      - Gemfile.lock
+      - Rakefile
+      - valkey.gemspec
+
   push:
     branches:
       - main
+      - release-*
 
-  pull_request:
+  schedule:
+    - cron: "0 6 * * *"
 
   workflow_dispatch:
+    inputs:
+      full-matrix:
+        description: "Run the full matrix"
+        type: boolean
+        default: false
+      run-with-macos:
+        description: "Include macOS runners"
+        type: choice
+        options:
+          - "false"
+          - "use-self-hosted"
+          - "use-github"
+        default: "false"
+      name:
+        description: "Custom run name"
+        type: string
+        required: false
+
+  workflow_call:
+    inputs:
+      run-with-macos:
+        description: "Include macOS runners"
+        type: string
+        default: "false"
+
+concurrency:
+  group: ruby-${{ github.head_ref || github.ref }}-${{ toJson(inputs) }}
+  cancel-in-progress: true
 
 jobs:
   lint:
@@ -25,10 +69,48 @@ jobs:
       - name: Lint
         run: bundle exec rubocop
 
-  build-native-library:
-    name: Build Native Library
+  get-matrices:
+    name: Get Matrices
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    outputs:
+      engine-matrix-output: ${{ steps.create-matrices.outputs.engine-matrix-output }}
+      host-matrix-output: ${{ steps.create-matrices.outputs.host-matrix-output }}
+      version-matrix-output: ${{ steps.create-matrices.outputs.version-matrix-output }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Determine full matrix mode
+        id: full-matrix
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          FULL_MATRIX_INPUT: ${{ inputs.full-matrix }}
+        run: |
+          if [[ "$EVENT_NAME" == "schedule" ]] || \
+             [[ "$EVENT_NAME" == "workflow_call" ]] || \
+             [[ "$EVENT_NAME" == "workflow_dispatch" && "$FULL_MATRIX_INPUT" == "true" ]]; then
+            echo "run-full-matrix=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run-full-matrix=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create test matrices
+        id: create-matrices
+        uses: ./.github/workflows/create-test-matrices
+        with:
+          language-name: ruby
+          run-full-matrix: ${{ steps.full-matrix.outputs.run-full-matrix }}
+          run-with-macos: ${{ inputs.run-with-macos || 'false' }}
+
+  build-native-library:
+    name: Build Native Library / ${{ matrix.host.NAMED_OS }}-${{ matrix.host.ARCH }}
+    needs: [get-matrices]
+    runs-on: ${{ matrix.host.RUNNER }}
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        host: ${{ fromJson(needs.get-matrices.outputs.host-matrix-output) }}
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -40,7 +122,7 @@ jobs:
       - name: Install Rust
         uses: ./valkey-glide/.github/actions/install-rust
         with:
-          target: x86_64-unknown-linux-gnu
+          target: ${{ matrix.host.TARGET }}
 
       - name: Install protoc
         uses: ./valkey-glide/.github/actions/install-protoc
@@ -56,9 +138,9 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             valkey-glide/ffi/target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('valkey-glide/ffi/Cargo.lock') }}
+          key: ${{ matrix.host.TARGET }}-cargo-${{ hashFiles('valkey-glide/ffi/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-
+            ${{ matrix.host.TARGET }}-cargo-
 
       - name: Build native library
         working-directory: valkey-glide/ffi
@@ -70,202 +152,102 @@ jobs:
       - name: Upload native library
         uses: actions/upload-artifact@v4
         with:
-          name: native-lib-linux-x64
+          name: native-lib-${{ matrix.host.NAMED_OS }}-${{ matrix.host.ARCH }}
           path: valkey-glide/ffi/target/release/libglide_ffi.so
           if-no-files-found: error
 
-  standalone:
-    needs: [build-native-library]
-    runs-on: ubuntu-latest
-    name: Standalone / Ruby ${{ matrix.ruby }} Valkey ${{ matrix.valkey }}
-    timeout-minutes: 15
+  test-ruby:
+    name: Test / Ruby ${{ matrix.version }} / ${{ matrix.engine.type }} ${{ matrix.engine.version }} / ${{ matrix.host.ARCH }}
+    needs: [build-native-library, get-matrices]
+    runs-on: ${{ matrix.host.RUNNER }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        ruby:
-          - 3.4
-          - 3.3
-          - 3.2
-          - 3.1
-          - 3.0
-        valkey:
-          - 7.2.10
-          - 8
-          - 8.1
-
+        engine: ${{ fromJson(needs.get-matrices.outputs.engine-matrix-output) }}
+        version: ${{ fromJson(needs.get-matrices.outputs.version-matrix-output) }}
+        host: ${{ fromJson(needs.get-matrices.outputs.host-matrix-output) }}
     steps:
-      - uses: actions/checkout@v4
+      - name: Check out code
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
       - name: Download native library
         uses: actions/download-artifact@v4
         with:
-          name: native-lib-linux-x64
+          name: native-lib-${{ matrix.host.NAMED_OS }}-${{ matrix.host.ARCH }}
           path: valkey-glide/ffi/target/release/
-
-      - name: Copy modules for testing
-        run: |
-          echo "Copying modules for testing..."
-          mkdir -p test/fixtures
-
-          echo "Copying RedisJSON module for JSON commands testing..."
-          cp .github/files/librejson-v2.8.15.so test/fixtures/redisjson.so
-          chmod +x test/fixtures/redisjson.so
-          ls -lh test/fixtures/redisjson.so
-
-          echo "Copying RedisBloom module..."
-          cp .github/files/redisbloom-amd64-v2.6.12.so test/fixtures/redisbloom.so
-          chmod +x test/fixtures/redisbloom.so
-          ls -lh test/fixtures/redisbloom.so
-
-          echo "Copying RediSearch module for Vector Search commands testing..."
-          cp .github/files/redisearch-amd64-v2.10.24.so test/fixtures/redisearch.so
-          chmod +x test/fixtures/redisearch.so
-          ls -lh test/fixtures/redisearch.so
-
-      - name: Generate SSL certificates for testing
-        run: |
-          echo "Generating SSL certificates for SSL/TLS testing..."
-          ruby test/fixtures/ssl/generate_certs.rb
-          echo "SSL certificates generated:"
-          ls -lh test/fixtures/ssl/*.pem
-
-      - name: Start Valkey with MODULE commands enabled
-        run: |
-          echo "Starting Valkey ${{ matrix.valkey }} with MODULE commands enabled..."
-          docker run -d \
-            --name valkey-test \
-            -p 6379:6379 \
-            -v $(pwd)/test/fixtures:/tmp/modules:ro \
-            valkey/valkey:${{ matrix.valkey }} \
-            valkey-server --enable-module-command yes
-
-          echo "Waiting for Valkey to be ready..."
-          for i in {1..30}; do
-            if docker exec valkey-test valkey-cli ping > /dev/null 2>&1; then
-              echo "Valkey is ready!"
-              break
-            fi
-            echo "Waiting... ($i/30)"
-            sleep 1
-          done
-
-          echo "Verifying MODULE commands are enabled..."
-          docker exec valkey-test valkey-cli CONFIG GET enable-module-command
-
-          echo "Verifying module files are accessible..."
-          docker exec valkey-test ls -lh /tmp/modules/
-
-      - name: Start SSL-enabled Valkey on port 6380
-        run: |
-          echo "Creating Valkey SSL configuration..."
-          cat > /tmp/valkey-ssl.conf << 'EOF'
-          # Disable regular port, use TLS port only
-          port 0
-          tls-port 6380
-
-          # SSL/TLS certificate files
-          tls-cert-file /ssl/server-cert.pem
-          tls-key-file /ssl/server-key.pem
-          tls-ca-cert-file /ssl/ca-cert.pem
-
-          # Don't require client certificates (optional)
-          tls-auth-clients no
-
-          # Allow TLS v1.2 and v1.3
-          tls-protocols "TLSv1.2 TLSv1.3"
-          EOF
-
-          echo "SSL configuration created:"
-          cat /tmp/valkey-ssl.conf
-
-          echo "Verifying SSL certificate files exist..."
-          ls -lh $(pwd)/test/fixtures/ssl/*.pem
-
-          echo "Starting SSL-enabled Valkey on port 6380..."
-          docker run -d \
-            --name valkey-ssl \
-            -p 6380:6380 \
-            -v $(pwd)/test/fixtures/ssl:/ssl:ro \
-            -v /tmp/valkey-ssl.conf:/etc/valkey-ssl.conf:ro \
-            valkey/valkey:${{ matrix.valkey }} \
-            valkey-server /etc/valkey-ssl.conf
-
-          echo "Waiting for container to start..."
-          sleep 2
-
-          echo "Checking if container is running..."
-          docker ps -a | grep valkey-ssl || echo "Container not found!"
-
-          echo "Checking container logs..."
-          docker logs valkey-ssl || echo "Could not get logs"
-
-          echo "Verifying SSL cert files are accessible inside container..."
-          docker exec valkey-ssl ls -lh /ssl/ || echo "Cannot access /ssl/ directory"
-          docker exec valkey-ssl cat /etc/valkey-ssl.conf || echo "Cannot read config file"
-
-          echo "Waiting for SSL Valkey to be ready..."
-          for i in {1..30}; do
-            if docker exec valkey-ssl valkey-cli --tls --insecure -p 6380 ping > /dev/null 2>&1; then
-              echo "SSL Valkey is ready!"
-              break
-            fi
-            echo "Waiting... ($i/30)"
-            sleep 1
-          done
-
-          echo "Verifying SSL connection from host..."
-          docker exec valkey-ssl valkey-cli --tls --insecure -p 6380 ping || echo "SSL verification failed"
-
-          echo "Testing connection from host machine..."
-          docker run --rm --network host valkey/valkey:${{ matrix.valkey }} valkey-cli --tls --insecure -p 6380 ping || echo "Host connection test failed"
-
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ matrix.ruby }}
-          bundler-cache: true
-
-      - name: Run standalone tests
-        run: bundle exec rake test:standalone
-
-      - name: Stop Valkey containers
-        if: always()
-        run: |
-          docker stop valkey-test && docker rm valkey-test || true
-          docker stop valkey-ssl && docker rm valkey-ssl || true
-
-  cluster:
-    needs: [build-native-library]
-    runs-on: ubuntu-latest
-    name: Cluster / Ruby ${{ matrix.ruby }}
-    timeout-minutes: 20
-    strategy:
-      fail-fast: false
-      matrix:
-        ruby:
-          - 3.4
-          - 3.3
-          - 3.2
-          - 3.1
-          - 3.0
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 
-      - name: Install Valkey
+      - name: Install Valkey engine
         uses: ./valkey-glide/.github/actions/install-engine
         with:
-          engine-version: "8.0"
-          target: x86_64-unknown-linux-gnu
+          engine-version: ${{ matrix.engine.version }}
+          target: ${{ matrix.host.TARGET }}
+
+      - name: Start standalone server via cluster_manager.py
+        run: |
+          python3 valkey-glide/utils/cluster_manager.py start -r 0 -p 6379 --prefix standalone
+          echo "Standalone server started on port 6379"
+
+      - name: Start TLS server via cluster_manager.py
+        run: |
+          python3 valkey-glide/utils/cluster_manager.py --tls start -r 0 -p 6380 --prefix tls-standalone
+          echo "TLS server started on port 6380"
+          echo "TLS_CERT_DIR=$(pwd)/valkey-glide/utils/tls_crts" >> $GITHUB_ENV
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.version }}
+          bundler-cache: true
+
+      - name: Run tests
+        run: bundle exec rake test
+
+      - name: Upload test artifacts
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-report-ruby-${{ matrix.version }}-${{ matrix.engine.type }}-${{ matrix.engine.version }}-${{ matrix.host.NAMED_OS }}-${{ matrix.host.ARCH }}
+          path: |
+            test/reports/
+            tmp/test-results/
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: Upload cluster logs on failure
+        if: failure()
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: cluster-logs-ruby-${{ matrix.version }}-${{ matrix.engine.type }}-${{ matrix.engine.version }}-${{ matrix.host.NAMED_OS }}-${{ matrix.host.ARCH }}
+          path: valkey-glide/utils/clusters/
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: Stop servers
+        if: always()
+        run: |
+          python3 valkey-glide/utils/cluster_manager.py stop --prefix standalone || true
+          python3 valkey-glide/utils/cluster_manager.py --tls stop --prefix tls-standalone || true
+
+  module-tests:
+    name: Module Tests
+    needs: [build-native-library]
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Download native library
         uses: actions/download-artifact@v4
@@ -273,20 +255,37 @@ jobs:
           name: native-lib-linux-x64
           path: valkey-glide/ffi/target/release/
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Valkey engine
+        uses: ./valkey-glide/.github/actions/install-engine
+        with:
+          engine-version: "9.0"
+          target: x86_64-unknown-linux-gnu
+
+      - name: Start module servers via Docker
+        uses: ./valkey-glide/.github/actions/start-valkey-docker
+        with:
+          engine-version: "9.0"
+
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ matrix.ruby }}
+          ruby-version: "3.4"
           bundler-cache: true
 
-      - name: Run cluster tests
-        run: bundle exec rake test:cluster
-        timeout-minutes: 25
+      - name: Run module tests
+        run: bundle exec ruby -Itest -Ilib test/standalone/commands_test.rb -n '/TestStandaloneModuleCommands/'
+        env:
+          STANDALONE_ENDPOINTS: ${{ env.MODULES_STANDALONE_ENDPOINT }}
 
-      - name: Upload cluster logs on failure
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: cluster-logs-${{ matrix.ruby }}
-          path: valkey-glide/utils/clusters/
-          retention-days: 7
+      - name: Stop containers
+        if: always()
+        run: |
+          docker stop valkey-modules-standalone && docker rm valkey-modules-standalone || true
+          for port in $(seq 8001 8006); do
+            docker stop "valkey-modules-cluster-${port}" && docker rm "valkey-modules-cluster-${port}" || true
+          done

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -94,13 +94,27 @@ jobs:
             echo "run-full-matrix=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Determine macOS runner mode
+        id: macos-mode
+        env:
+          RUN_WITH_MACOS: ${{ inputs.run-with-macos || 'false' }}
+          RUN_FULL_MATRIX: ${{ steps.full-matrix.outputs.run-full-matrix }}
+        run: |
+          if [[ "$RUN_WITH_MACOS" != "false" ]]; then
+            echo "run-with-macos=$RUN_WITH_MACOS" >> "$GITHUB_OUTPUT"
+          elif [[ "$RUN_FULL_MATRIX" == "true" ]]; then
+            echo "run-with-macos=use-github" >> "$GITHUB_OUTPUT"
+          else
+            echo "run-with-macos=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Create test matrices
         id: create-matrices
         uses: ./.github/workflows/create-test-matrices
         with:
           language-name: ruby
           run-full-matrix: ${{ steps.full-matrix.outputs.run-full-matrix }}
-          run-with-macos: ${{ inputs.run-with-macos || 'false' }}
+          run-with-macos: ${{ steps.macos-mode.outputs.run-with-macos }}
 
   build-native-library:
     name: Build Native Library / ${{ matrix.host.NAMED_OS }}-${{ matrix.host.ARCH }}
@@ -153,11 +167,11 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: native-lib-${{ matrix.host.NAMED_OS }}-${{ matrix.host.ARCH }}
-          path: valkey-glide/ffi/target/release/libglide_ffi.so
+          path: valkey-glide/ffi/target/release/libglide_ffi.${{ matrix.host.OS == 'macos' && 'dylib' || 'so' }}
           if-no-files-found: error
 
   test-ruby:
-    name: Test / Ruby ${{ matrix.version }} / ${{ matrix.engine.type }} ${{ matrix.engine.version }} / ${{ matrix.host.ARCH }}
+    name: Test / Ruby ${{ matrix.version }} / ${{ matrix.engine.type }} ${{ matrix.engine.version }} / ${{ matrix.host.NAMED_OS }}-${{ matrix.host.ARCH }}
     needs: [build-native-library, get-matrices]
     runs-on: ${{ matrix.host.RUNNER }}
     timeout-minutes: 30
@@ -196,6 +210,7 @@ jobs:
           echo "Standalone server started on port 6379"
 
       - name: Start TLS server via cluster_manager.py
+        if: matrix.host.OS != 'macos'
         run: |
           python3 valkey-glide/utils/cluster_manager.py --tls start -r 0 -p 6380 --prefix tls-standalone
           echo "TLS server started on port 6380"
@@ -209,6 +224,8 @@ jobs:
 
       - name: Run tests
         run: bundle exec rake test
+        env:
+          SKIP_TLS_TESTS: ${{ matrix.host.OS == 'macos' && 'true' || '' }}
 
       - name: Upload test artifacts
         if: always()
@@ -236,7 +253,10 @@ jobs:
         if: always()
         run: |
           python3 valkey-glide/utils/cluster_manager.py stop --prefix standalone || true
-          python3 valkey-glide/utils/cluster_manager.py --tls stop --prefix tls-standalone || true
+          # Stop TLS server (skip on macOS where TLS setup is unavailable)
+          if [[ "${{ matrix.host.OS }}" != "macos" ]]; then
+            python3 valkey-glide/utils/cluster_manager.py --tls stop --prefix tls-standalone || true
+          fi
 
   module-tests:
     name: Module Tests

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -93,6 +93,10 @@ jobs:
           version: "29.1"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Install openssl (macOS)
+        if: matrix.host.OS == 'macos'
+        run: brew install openssl
+
       - name: Build native library
         working-directory: valkey-glide/ffi
         env:
@@ -105,7 +109,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: native-lib-${{ matrix.host.TARGET }}
-          path: valkey-glide/ffi/target/release/libglide_ffi.so
+          path: valkey-glide/ffi/target/release/libglide_ffi.${{ matrix.host.OS == 'macos' && 'dylib' || 'so' }}
           if-no-files-found: error
 
   build-and-publish-gem:
@@ -139,8 +143,16 @@ jobs:
           for target in $(echo '${{ env.PLATFORM_MATRIX }}' | jq -r '.[].TARGET'); do
             echo "Creating directory for $target"
             mkdir -p "lib/valkey/native/$target"
-            echo "Copying native library for $target"
-            cp "native-libs/native-lib-$target/libglide_ffi.so" "lib/valkey/native/$target/"
+
+            # Determine correct file extension based on target
+            if [[ "$target" == *"apple-darwin"* ]]; then
+              LIB_EXT="dylib"
+            else
+              LIB_EXT="so"
+            fi
+
+            echo "Copying native library for $target (extension: $LIB_EXT)"
+            cp "native-libs/native-lib-$target/libglide_ffi.$LIB_EXT" "lib/valkey/native/$target/"
           done
 
           echo "Native libraries organized:"
@@ -166,10 +178,31 @@ jobs:
       - name: Verify gem contents
         run: |
           gem unpack ${{ steps.build-gem.outputs.GEM_FILE }} --target=gem-contents
-          echo "Gem contents:"
-          find gem-contents -type f | head -50
-          echo ""
-          echo "Native libraries in gem:"
+
+          # Find the unpacked gem directory (gem unpack creates a subdirectory)
+          GEM_DIR=$(find gem-contents -maxdepth 1 -type d | tail -1)
+          echo "Unpacked gem directory: $GEM_DIR"
+
+          # Verify all platform libraries are present
+          MISSING=""
+          for target in $(echo '${{ env.PLATFORM_MATRIX }}' | jq -r '.[].TARGET'); do
+            if [[ "$target" == *"apple-darwin"* ]]; then
+              LIB_EXT="dylib"
+            else
+              LIB_EXT="so"
+            fi
+            LIB_PATH="$GEM_DIR/lib/valkey/native/$target/libglide_ffi.$LIB_EXT"
+            if [[ ! -f "$LIB_PATH" ]]; then
+              MISSING="$MISSING\n  - $target (expected: $LIB_PATH)"
+            fi
+          done
+
+          if [[ -n "$MISSING" ]]; then
+            echo "ERROR: Missing native libraries for platforms:$MISSING"
+            exit 1
+          fi
+
+          echo "All platform libraries verified present"
           find gem-contents -name "libglide_ffi.*" -exec ls -lh {} \;
 
       - name: Upload gem artifact
@@ -178,6 +211,7 @@ jobs:
           name: ruby-gem
           path: "*.gem"
           if-no-files-found: error
+          retention-days: 7
 
       - name: Publish to RubyGems
         id: publish
@@ -225,11 +259,21 @@ jobs:
           gem install ruby-progressbar
           gem install rake
 
-      - name: Start Valkey
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Valkey engine
+        uses: ./valkey-glide/.github/actions/install-engine
+        with:
+          engine-version: "9.0"
+          target: ${{ matrix.host.TARGET }}
+
+      - name: Start standalone server via cluster_manager.py
         run: |
-          docker run -d --name valkey-test -p 6379:6379 valkey/valkey:8
-          sleep 5
-          docker exec valkey-test valkey-cli ping
+          python3 valkey-glide/utils/cluster_manager.py start -r 0 -p 6379 --prefix standalone
+          echo "Standalone server started on port 6379"
 
       - name: Download gem artifact (unpublished)
         if: ${{ needs.build-and-publish-gem.outputs.published != 'true' }}
@@ -284,4 +328,5 @@ jobs:
 
       - name: Stop Valkey
         if: always()
-        run: docker stop valkey-test && docker rm valkey-test || true
+        run: |
+          python3 valkey-glide/utils/cluster_manager.py stop --prefix standalone || true

--- a/.github/workflows/create-test-matrices/action.yml
+++ b/.github/workflows/create-test-matrices/action.yml
@@ -1,0 +1,130 @@
+name: Create Test Matrices
+description: "Filters JSON matrix files to produce engine, host, and language version matrices based on full/reduced mode"
+
+inputs:
+  language-name:
+    description: "The language to filter for (e.g., 'ruby')"
+    required: true
+  run-full-matrix:
+    description: "Whether to run the full matrix (true) or reduced matrix (false)"
+    required: true
+  run-with-macos:
+    description: "Include macOS runners: 'false', 'use-self-hosted', or 'use-github'"
+    required: false
+    default: "false"
+
+outputs:
+  engine-matrix-output:
+    description: "Filtered engine versions as a JSON array"
+    value: ${{ steps.generate-matrices.outputs.engine-matrix-output }}
+  host-matrix-output:
+    description: "Filtered host/runner entries as a JSON array"
+    value: ${{ steps.generate-matrices.outputs.host-matrix-output }}
+  version-matrix-output:
+    description: "Filtered language versions as a JSON array"
+    value: ${{ steps.generate-matrices.outputs.version-matrix-output }}
+
+runs:
+  using: composite
+  steps:
+    - name: Generate matrices
+      id: generate-matrices
+      shell: bash
+      env:
+        RUN_FULL_MATRIX: ${{ inputs.run-full-matrix }}
+        LANGUAGE_NAME: ${{ inputs.language-name }}
+        RUN_WITH_MACOS: ${{ inputs.run-with-macos }}
+      run: |
+        # Resolve path to JSON matrix files
+        MATRICES_DIR="${GITHUB_WORKSPACE}/.github/json_matrices"
+
+        # --- Engine Matrix ---
+        ENGINE_FILE="${MATRICES_DIR}/engine-matrix.json"
+        if [[ ! -f "$ENGINE_FILE" ]]; then
+          echo "ERROR: Engine matrix file not found: $ENGINE_FILE"
+          exit 1
+        fi
+
+        if [[ "$RUN_FULL_MATRIX" == "true" ]]; then
+          ENGINE_MATRIX=$(jq -c '.' "$ENGINE_FILE")
+        else
+          ENGINE_MATRIX=$(jq -c '[.[] | select(.run == "always")]' "$ENGINE_FILE")
+        fi
+
+        # --- Host Matrix ---
+        HOST_FILE="${MATRICES_DIR}/build-matrix.json"
+        if [[ ! -f "$HOST_FILE" ]]; then
+          echo "ERROR: Build matrix file not found: $HOST_FILE"
+          exit 1
+        fi
+
+        # Filter by language
+        HOST_MATRIX=$(jq -c --arg lang "$LANGUAGE_NAME" \
+          '[.[] | select(.languages | index($lang))]' "$HOST_FILE")
+
+        # Handle macOS option
+        if [[ "$RUN_WITH_MACOS" == "use-github" ]]; then
+          MACOS_ENTRY="{\"OS\":\"macos\",\"NAMED_OS\":\"darwin\",\"RUNNER\":\"macos-latest\",\"ARCH\":\"arm64\",\"TARGET\":\"aarch64-apple-darwin\",\"languages\":[\"$LANGUAGE_NAME\"],\"run\":\"always\"}"
+          HOST_MATRIX=$(echo "$HOST_MATRIX" | jq -c --argjson macos "$MACOS_ENTRY" '. + [$macos]')
+        fi
+
+        # --- Version Matrix ---
+        VERSIONS_FILE="${MATRICES_DIR}/supported-languages-versions.json"
+        if [[ ! -f "$VERSIONS_FILE" ]]; then
+          echo "ERROR: Supported languages versions file not found: $VERSIONS_FILE"
+          exit 1
+        fi
+
+        LANG_ENTRY=$(jq -c --arg lang "$LANGUAGE_NAME" \
+          '.[] | select(.language == $lang)' "$VERSIONS_FILE")
+
+        if [[ -z "$LANG_ENTRY" ]]; then
+          echo "ERROR: Language '$LANGUAGE_NAME' not found in $VERSIONS_FILE"
+          exit 1
+        fi
+
+        if [[ "$RUN_FULL_MATRIX" == "true" ]]; then
+          VERSION_MATRIX=$(echo "$LANG_ENTRY" | jq -c '.versions')
+        else
+          VERSION_MATRIX=$(echo "$LANG_ENTRY" | jq -c '."always-run-versions"')
+        fi
+
+        # --- Set outputs ---
+        echo "engine-matrix-output=$ENGINE_MATRIX" >> "$GITHUB_OUTPUT"
+        echo "host-matrix-output=$HOST_MATRIX" >> "$GITHUB_OUTPUT"
+        echo "version-matrix-output=$VERSION_MATRIX" >> "$GITHUB_OUTPUT"
+
+        echo "Engine matrix: $ENGINE_MATRIX"
+        echo "Host matrix: $HOST_MATRIX"
+        echo "Version matrix: $VERSION_MATRIX"
+
+    - name: Validate matrices are non-empty
+      shell: bash
+      run: |
+        ENGINE_MATRIX='${{ steps.generate-matrices.outputs.engine-matrix-output }}'
+        HOST_MATRIX='${{ steps.generate-matrices.outputs.host-matrix-output }}'
+        VERSION_MATRIX='${{ steps.generate-matrices.outputs.version-matrix-output }}'
+
+        FAILED=0
+
+        if [[ $(echo "$ENGINE_MATRIX" | jq 'length') -eq 0 ]]; then
+          echo "ERROR: Engine matrix is empty"
+          FAILED=1
+        fi
+
+        if [[ $(echo "$HOST_MATRIX" | jq 'length') -eq 0 ]]; then
+          echo "ERROR: Host matrix is empty"
+          FAILED=1
+        fi
+
+        if [[ $(echo "$VERSION_MATRIX" | jq 'length') -eq 0 ]]; then
+          echo "ERROR: Version matrix is empty"
+          FAILED=1
+        fi
+
+        if [[ $FAILED -eq 1 ]]; then
+          echo "Matrix validation failed: one or more matrices are empty"
+          exit 1
+        fi
+
+        echo "All matrices validated successfully"

--- a/.github/workflows/create-test-matrices/action.yml
+++ b/.github/workflows/create-test-matrices/action.yml
@@ -58,14 +58,23 @@ runs:
           exit 1
         fi
 
-        # Filter by language
+        # Filter by language and exclude macOS entries (macOS is handled separately below)
         HOST_MATRIX=$(jq -c --arg lang "$LANGUAGE_NAME" \
-          '[.[] | select(.languages | index($lang))]' "$HOST_FILE")
+          '[.[] | select((.languages | index($lang)) and .OS != "macos")]' "$HOST_FILE")
 
         # Handle macOS option
         if [[ "$RUN_WITH_MACOS" == "use-github" ]]; then
-          MACOS_ENTRY="{\"OS\":\"macos\",\"NAMED_OS\":\"darwin\",\"RUNNER\":\"macos-latest\",\"ARCH\":\"arm64\",\"TARGET\":\"aarch64-apple-darwin\",\"languages\":[\"$LANGUAGE_NAME\"],\"run\":\"always\"}"
+          # Include macOS entries from build-matrix.json with matching runner
+          MAC_ENTRIES=$(jq --arg lang "$LANGUAGE_NAME" -c \
+            '[.[] | select(.OS == "macos" and (.languages | index($lang)))]' "$HOST_FILE")
+          HOST_MATRIX=$(echo "$HOST_MATRIX" | jq -c --argjson mac "$MAC_ENTRIES" '. + $mac')
+        elif [[ "$RUN_WITH_MACOS" == "use-self-hosted" ]]; then
+          # Override RUNNER with self-hosted label array
+          MACOS_ENTRY='{"OS":"macos","NAMED_OS":"darwin","RUNNER":["self-hosted","macOS","ARM64","ephemeral"],"ARCH":"arm64","TARGET":"aarch64-apple-darwin","languages":["'"$LANGUAGE_NAME"'"]}'
           HOST_MATRIX=$(echo "$HOST_MATRIX" | jq -c --argjson macos "$MACOS_ENTRY" '. + [$macos]')
+        elif [[ "$RUN_WITH_MACOS" != "false" ]]; then
+          echo "ERROR: Invalid run-with-macos value: '$RUN_WITH_MACOS'. Expected 'false', 'use-github', or 'use-self-hosted'."
+          exit 1
         fi
 
         # --- Version Matrix ---

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -58,7 +58,7 @@ valkey-glide-ruby/
 - **Bundler**
 - **git**
 - **Valkey** or Redis OSS (for integration tests)
-- **Docker** (optional; matches CI setup)
+- **Docker** (optional; only needed for module tests with `valkey-bundle` image)
 
 To **build** the native FFI library from source:
 
@@ -188,21 +188,25 @@ Default test configuration (see `test/test_helper.rb`):
 |----------|---------|---------|
 | `VALKEY_PORT` | `6379` | Plain TCP |
 | `VALKEY_SSL_PORT` | `6380` | TLS (optional) |
+| `TLS_CERT_DIR` | `valkey-glide/utils/tls_crts` | Path to TLS certs (set by CI) |
 | `TIMEOUT` | `5.0` | Client timeout |
 | DB | `15` | Test database |
 
 ```bash
-# Example: Docker standalone (matches CI)
-docker run -d --name valkey-test -p 6379:6379 valkey/valkey:8 \
-  valkey-server --enable-module-command yes
+# Preferred: use cluster_manager.py (same as CI and all other GLIDE clients)
+python3 valkey-glide/utils/cluster_manager.py start -r 0 -p 6379 --prefix standalone
+
+# Alternative: Docker standalone
+docker run -d --name valkey-test -p 6379:6379 valkey/valkey:8 valkey-server
 ```
 
 ### Start Valkey Cluster
 
-Cluster tests expect six nodes on `127.0.0.1:7000`–`7005`. CI uses `grokzen/redis-cluster:7.0.15`.
+Cluster tests auto-start via `cluster_manager.py` (the `TestCluster` class handles lifecycle).
+You can also start manually:
 
 ```bash
-docker run -d --name redis-cluster -p 7000-7005:7000-7005 grokzen/redis-cluster:7.0.15
+python3 valkey-glide/utils/cluster_manager.py start --cluster-mode --prefix cluster
 ```
 
 ### Run Tests
@@ -222,21 +226,33 @@ CI=1 bundle exec rake test:standalone
 
 ### SSL Tests
 
-Generate test certificates:
+The preferred approach (matching CI and all other GLIDE clients) uses `cluster_manager.py`:
+
+```bash
+# Start a TLS-only server on port 6380 (generates certs in valkey-glide/utils/tls_crts/)
+python3 valkey-glide/utils/cluster_manager.py --tls start -r 0 -p 6380 --prefix tls-standalone
+
+# Point tests at the generated certs
+export TLS_CERT_DIR=$(pwd)/valkey-glide/utils/tls_crts
+
+# Run tests
+bundle exec rake test:standalone
+
+# Stop the TLS server
+python3 valkey-glide/utils/cluster_manager.py --tls stop --prefix tls-standalone
+```
+
+Alternatively, for local development without Python, generate certs and start manually:
 
 ```bash
 ruby test/fixtures/ssl/generate_certs.rb
+# Then start a TLS Valkey server on port 6380 using those certs
 ```
-
-Start TLS Valkey on port 6380 (see `.github/workflows/CI.yml` for a full Docker example).
 
 ### Module Tests (JSON, Bloom, Search)
 
-CI copies prebuilt modules into `test/fixtures/`:
-
-- `redisjson.so` — JSON commands
-- `redisbloom.so` — Bloom filters
-- `redisearch.so` — Vector / FT commands
+CI uses the shared `start-valkey-docker` action with `valkey/valkey-bundle:9.1` (modules pre-loaded).
+Tests connect via `STANDALONE_ENDPOINTS` env var.
 
 Load modules when starting Valkey if you run module-specific tests locally.
 
@@ -427,7 +443,7 @@ ruby -e "require 'valkey'; c = Valkey.new; puts c.ping; c.close"
 | `LoadError` / FFI library not found | Confirm `lib/valkey/libglide_ffi.{so,dylib}` exists and matches your OS/arch. |
 | Wrong architecture after FFI rebuild | Rebuild `glide-ffi` on the target platform; do not copy Linux `.so` to macOS. |
 | Cluster tests flaky | Wait for `cluster_state:ok`; increase `TIMEOUT` env var. |
-| SSL test failures | Regenerate certs: `ruby test/fixtures/ssl/generate_certs.rb`. |
+| SSL test failures | Use `cluster_manager.py --tls` (see SSL Tests above), or regenerate local certs: `ruby test/fixtures/ssl/generate_certs.rb`. |
 | Pipeline / MULTI crashes | Transaction commands in `pipelined` use sequential fallback by design. |
 
 ## Recommended Editor Extensions

--- a/README.md
+++ b/README.md
@@ -153,6 +153,11 @@ end
 | `protocol` | `:resp2` (default) or `:resp3` |
 | `client_name` | `CLIENT SETNAME` value |
 | `reconnect_attempts`, `reconnect_delay`, `reconnect_delay_max` | Connection retry strategy |
+| `read_from` *(GLIDE-native)* | Read routing: `:primary`, `:prefer_replica`, `:lowest_latency`, `:az_affinity`, `:az_affinity_replicas_and_primary` (or the exact-match GLIDE strings, e.g. `"PreferReplica"`) |
+| `client_az` *(GLIDE-native)* | Availability-zone identifier for `:az_affinity` / `:az_affinity_replicas_and_primary` routing (e.g. `"us-west-2a"`) |
+| `inflight_requests_limit` *(GLIDE-native)* | Maximum concurrent in-flight requests (non-negative integer) |
+| `lazy_connect` *(GLIDE-native)* | Delay the actual connection until the first command is sent |
+| `periodic_checks` *(GLIDE-native)* | Cluster topology health checks: `{ manual_interval: { duration_in_sec: N } }` or `{ disabled: true }`. Accepted (as a no-op) on standalone connections. |
 
 ```ruby
 client = Valkey.new(

--- a/lib/valkey.rb
+++ b/lib/valkey.rb
@@ -243,13 +243,12 @@ class Valkey
   end
 
   def send_command(command_type, command_args = [], &block)
-    # Validate connection
-    if @connection.nil?
-      raise "Connection is nil"
-    elsif @connection.null?
-      raise "Connection pointer is null"
-    elsif @connection.address.zero?
-      raise "Connection address is 0"
+    # Validate connection. A nil/null pointer means the client was closed (or
+    # never established a usable connection); surface it as a typed error with
+    # the same "the client is closed" wording the sibling GLIDE clients use
+    # (Go ClosingError, Node/Java ClosingException).
+    if @connection.nil? || @connection.null? || @connection.address.zero?
+      raise ConnectionError, "the client is closed"
     end
 
     channel = 0

--- a/lib/valkey.rb
+++ b/lib/valkey.rb
@@ -128,6 +128,39 @@ class Valkey
     results
   end
 
+  # Builds the `periodic_checks` extra_options_json value from the `periodic_checks:`
+  # constructor option. Accepts either `{ manual_interval: { duration_in_sec: N } }` or
+  # `{ disabled: true }`, matching the shape GLIDE's native core expects.
+  def build_periodic_checks(periodic_checks)
+    unless periodic_checks.is_a?(Hash)
+      raise ArgumentError, "periodic_checks must be a Hash, got: #{periodic_checks.class}"
+    end
+
+    if periodic_checks.key?(:disabled) || periodic_checks.key?("disabled")
+      disabled = periodic_checks[:disabled] || periodic_checks["disabled"]
+      unless [true, false].include?(disabled)
+        raise ArgumentError, "periodic_checks disabled must be a boolean, got: #{disabled.class}"
+      end
+
+      return { "disabled" => disabled }
+    end
+
+    manual_interval = periodic_checks[:manual_interval] || periodic_checks["manual_interval"]
+    raise ArgumentError, "periodic_checks must contain :manual_interval or :disabled" unless manual_interval.is_a?(Hash)
+
+    duration_in_sec = manual_interval[:duration_in_sec] || manual_interval["duration_in_sec"]
+    unless duration_in_sec.is_a?(Integer)
+      raise ArgumentError,
+            "periodic_checks manual_interval duration_in_sec must be an integer, got: #{duration_in_sec.class}"
+    end
+    if duration_in_sec.negative?
+      raise ArgumentError,
+            "periodic_checks manual_interval duration_in_sec must be non-negative, got: #{duration_in_sec}"
+    end
+
+    { "manual_interval" => { "duration_in_sec" => duration_in_sec } }
+  end
+
   def build_command_args(command_args)
     # For empty arrays, pass NULL pointers as per Rust FFI contract
     # This matches Go's approach which successfully uses nil pointers
@@ -416,6 +449,55 @@ class Valkey
 
     # Client name (user-configurable)
     json_options["client_name"] = options[:client_name] if options[:client_name]
+
+    # Read routing preference (which node(s) to read from)
+    if options.key?(:read_from)
+      json_options["read_from"] = case options[:read_from]
+                                  when :primary, "Primary"
+                                    "Primary"
+                                  when :prefer_replica, "PreferReplica"
+                                    "PreferReplica"
+                                  when :lowest_latency, "LowestLatency"
+                                    "LowestLatency"
+                                  when :az_affinity, "AZAffinity"
+                                    "AZAffinity"
+                                  when :az_affinity_replicas_and_primary, "AZAffinityReplicasAndPrimary"
+                                    "AZAffinityReplicasAndPrimary"
+                                  else
+                                    raise ArgumentError, "Invalid read_from value: #{options[:read_from].inspect}"
+                                  end
+    end
+
+    # Client availability zone (for AZAffinity / AZAffinityReplicasAndPrimary read_from routing)
+    if options[:client_az]
+      unless options[:client_az].is_a?(String)
+        raise ArgumentError, "client_az must be a string, got: #{options[:client_az].class}"
+      end
+
+      json_options["client_az"] = options[:client_az]
+    end
+
+    # Maximum number of concurrent in-flight requests
+    if options.key?(:inflight_requests_limit)
+      inflight_requests_limit = options[:inflight_requests_limit]
+      unless inflight_requests_limit.is_a?(Integer)
+        raise ArgumentError,
+              "inflight_requests_limit must be an integer, got: #{inflight_requests_limit.class}"
+      end
+      if inflight_requests_limit.negative?
+        raise ArgumentError,
+              "inflight_requests_limit must be non-negative, got: #{inflight_requests_limit}"
+      end
+
+      json_options["inflight_requests_limit"] = inflight_requests_limit
+    end
+
+    # Lazy connect: delay the actual connection until the first command is sent
+    json_options["lazy_connect"] = true if options[:lazy_connect]
+
+    # Periodic topology-refresh checks. Cluster-only in effect (create_cluster_client),
+    # but accepted (and ignored) on standalone connections without error.
+    json_options["periodic_checks"] = build_periodic_checks(options[:periodic_checks]) if options.key?(:periodic_checks)
 
     # TLS/SSL certificates
     root_certs = []

--- a/lib/valkey.rb
+++ b/lib/valkey.rb
@@ -137,7 +137,7 @@ class Valkey
     end
 
     if periodic_checks.key?(:disabled) || periodic_checks.key?("disabled")
-      disabled = periodic_checks[:disabled] || periodic_checks["disabled"]
+      disabled = periodic_checks.key?(:disabled) ? periodic_checks[:disabled] : periodic_checks["disabled"]
       unless [true, false].include?(disabled)
         raise ArgumentError, "periodic_checks disabled must be a boolean, got: #{disabled.class}"
       end

--- a/lib/valkey.rb
+++ b/lib/valkey.rb
@@ -247,9 +247,7 @@ class Valkey
     # never established a usable connection); surface it as a typed error with
     # the same "the client is closed" wording the sibling GLIDE clients use
     # (Go ClosingError, Node/Java ClosingException).
-    if @connection.nil? || @connection.null? || @connection.address.zero?
-      raise ConnectionError, "the client is closed"
-    end
+    raise ConnectionError, "the client is closed" if @connection.nil? || @connection.null? || @connection.address.zero?
 
     channel = 0
     route = ""

--- a/lib/valkey/commands/cluster_commands.rb
+++ b/lib/valkey/commands/cluster_commands.rb
@@ -71,13 +71,30 @@ class Valkey
         send_command(RequestType::CLUSTER_DEL_SLOTS_RANGE, [start_slot, end_slot])
       end
 
+      # Valid modes for CLUSTER FAILOVER: FORCE, TAKEOVER.
+      CLUSTER_FAILOVER_MODES = %i[force takeover].freeze
+
       # Force a failover of the cluster.
       #
-      # @param [String] force force the failover
+      # Must be sent to a replica node. Without a mode, performs a coordinated
+      # failover (the primary is asked to pause clients and hand over). +:force+
+      # promotes the replica without coordinating with the primary (useful when
+      # the primary is unreachable); +:takeover+ promotes it without any cluster
+      # consensus (most aggressive — risks data loss / split brain).
+      #
+      # @param [Symbol, nil] mode optional failover mode: +:force+ or +:takeover+
       # @return [String] `"OK"`
-      def cluster_failover(force = nil)
+      # @raise [ArgumentError] if +mode+ is not nil, +:force+, or +:takeover+
+      # @see https://valkey.io/commands/cluster-failover/
+      def cluster_failover(mode = nil)
         args = []
-        args << "FORCE" if force
+        unless mode.nil?
+          unless CLUSTER_FAILOVER_MODES.include?(mode)
+            raise ArgumentError, "invalid CLUSTER FAILOVER mode #{mode.inspect}: expected :force or :takeover"
+          end
+
+          args << mode.to_s.upcase
+        end
         send_command(RequestType::CLUSTER_FAILOVER, args)
       end
 

--- a/lib/valkey/commands/connection_commands.rb
+++ b/lib/valkey/commands/connection_commands.rb
@@ -299,8 +299,9 @@ class Valkey
           when :redirect
             args << "REDIRECT" << value.to_s
           when :prefix
-            args << "PREFIX"
-            Array(value).each { |prefix| args << prefix }
+            # Valkey requires the PREFIX keyword before each prefix value,
+            # e.g. PREFIX foo PREFIX bar.
+            Array(value).each { |prefix| args << "PREFIX" << prefix }
           when :bcast
             args << "BCAST" if value
           when :optin

--- a/lib/valkey/commands/connection_commands.rb
+++ b/lib/valkey/commands/connection_commands.rb
@@ -136,8 +136,10 @@ class Valkey
 
         send_command(RequestType::CLIENT_LIST, args) do |reply|
           reply.lines.map do |line|
-            entries = line.chomp.split(/[ =]/)
-            entries.each_slice(2).to_a.to_h
+            line.chomp.split.each_with_object({}) do |pair, hash|
+              key, value = pair.split("=", 2)
+              hash[key] = value || ""
+            end
           end
         end
       end

--- a/lib/valkey/commands/connection_commands.rb
+++ b/lib/valkey/commands/connection_commands.rb
@@ -94,7 +94,7 @@ class Valkey
       #   client(:set_name, "my_app")  # => "OK"
       #   client(:list)                # => [{"id" => "1", ...}, ...]
       def client(subcommand, *args)
-        send("client_#{subcommand.to_s.downcase}", *args)
+        public_send("client_#{subcommand.to_s.downcase}", *args)
       end
 
       # Get the current client's ID.
@@ -289,6 +289,12 @@ class Valkey
       def client_no_touch(mode)
         send_command(RequestType::CLIENT_NO_TOUCH, [mode.to_s.upcase])
       end
+
+      # Client-side caching commands are intentionally private.
+      #
+      # GLIDE's managed client-side caching is not yet implemented in the Ruby client
+      # These commands are not meant to be called directly and will be kept private.
+      private :client_tracking, :client_caching, :client_tracking_info, :client_getredir
 
       private
 

--- a/lib/valkey/commands/server_commands.rb
+++ b/lib/valkey/commands/server_commands.rb
@@ -499,13 +499,19 @@ class Valkey
       # @see https://valkey.io/commands/failover/
       def failover(to: nil, force: false, abort: false, timeout: nil)
         args = []
-        if to
-          host, port = to.split
-          args << "TO" << host << port
+        if abort
+          # ABORT is mutually exclusive: cancels an ongoing failover and
+          # ignores any other arguments (matches the core GLIDE clients).
+          args << "ABORT"
+        else
+          if to
+            host, port = to.split
+            args << "TO" << host << port
+            # FORCE is only valid in combination with TO.
+            args << "FORCE" if force
+          end
+          args << "TIMEOUT" << timeout.to_s if timeout
         end
-        args << "FORCE" if force
-        args << "ABORT" if abort
-        args << "TIMEOUT" << timeout.to_s if timeout
         send_command(RequestType::FAIL_OVER, args)
       end
 

--- a/test/cluster/cluster_commands_test.rb
+++ b/test/cluster/cluster_commands_test.rb
@@ -30,6 +30,7 @@ class TestClusterCommands < Minitest::Test
 
   # ValkeyTests modules without conflicting setup methods
   include ValkeyTests::Bitpos
+  include ValkeyTests::ConnectionConfig
   include ValkeyTests::GenericCommands
   include ValkeyTests::Scanning
   include ValkeyTests::ScriptingCommands

--- a/test/lint/cluster_commands.rb
+++ b/test/lint/cluster_commands.rb
@@ -282,40 +282,44 @@ module Lint
       pass "Cluster setslot correctly failed with invalid parameters"
     end
 
-    def test_cluster_failover_on_cluster
-      # Test cluster failover (only works on replica nodes)
-      result = r.cluster_failover
-      # This will fail on master nodes, which is expected
-      case result
-      when "OK"
-        pass "Cluster failover succeeded as expected"
-      when false
-        pass "Cluster failover returned false (not ready for failover)"
-      when Valkey::CommandError
-        pass "Cluster failover correctly failed as expected"
-      else
-        flunk "Unexpected result from cluster_failover: #{result.inspect}"
-      end
-    rescue Valkey::CommandError => e
-      # Expected to fail on master nodes - accept any error message
-      pass "Cluster failover correctly failed on master node as expected: #{e.message}"
+    # CLUSTER FAILOVER must run on a replica and, on default routing, may be
+    # sent to a replica and trigger a *real* failover — which would destabilize
+    # the shared test cluster. So instead of issuing it live, we stub
+    # send_command and assert the arguments the client builds.
+    #
+    # should send "CLUSTER FAILOVER" with no extra args for a coordinated failover
+    def test_cluster_failover_coordinated_sends_no_args
+      assert_equal [], capture_cluster_failover_args
     end
 
-    def test_cluster_force_failover
-      # Test cluster failover with force option - should still fail on master
-      result = r.cluster_failover("FORCE")
-      # This might return false or raise an error on master nodes
-      case result
-      when "OK"
-        pass "Cluster force failover succeeded as expected"
-      when false
-        pass "Cluster force failover returned false (not ready for failover)"
-      else
-        flunk "Unexpected result from cluster force failover: #{result.inspect}"
+    # should append "FORCE" for the :force mode
+    def test_cluster_failover_force_sends_force_arg
+      assert_equal ["FORCE"], capture_cluster_failover_args(:force)
+    end
+
+    # should append "TAKEOVER" for the :takeover mode
+    def test_cluster_failover_takeover_sends_takeover_arg
+      assert_equal ["TAKEOVER"], capture_cluster_failover_args(:takeover)
+    end
+
+    # should raise ArgumentError for an unrecognized mode (incl. strings/booleans)
+    def test_cluster_failover_invalid_mode_raises
+      assert_raises(ArgumentError) { r.cluster_failover(:bogus) }
+      assert_raises(ArgumentError) { r.cluster_failover("FORCE") }
+      assert_raises(ArgumentError) { r.cluster_failover(true) }
+    end
+
+    # Invokes cluster_failover while intercepting send_command, and returns the
+    # argument array the client would have sent — without issuing a real
+    # failover against the cluster.
+    def capture_cluster_failover_args(*mode)
+      captured = nil
+      recorder = lambda do |_request_type, args = [], &_block|
+        captured = args
+        "OK"
       end
-    rescue Valkey::CommandError => e
-      # Expected to fail on master nodes even with force - accept any error message
-      pass "Cluster force failover correctly failed on master node as expected: #{e.message}"
+      r.stub(:send_command, recorder) { r.cluster_failover(*mode) }
+      captured
     end
 
     def test_cluster_set_config_epoch

--- a/test/lint/connection_commands.rb
+++ b/test/lint/connection_commands.rb
@@ -150,11 +150,6 @@ module Lint
       end
     end
 
-    def test_client_getredir
-      redir = r.client_getredir
-      assert_kind_of Integer, redir
-    end
-
     def test_hello_default
       result = r.hello
       # Backend returns array in current implementation
@@ -206,93 +201,6 @@ module Lint
         sleep(0.05) # 50ms between retries
       end
       assert_nil r.client_get_name
-    end
-
-    def test_client_caching
-      # In cluster mode, CLIENT TRACKING and CLIENT CACHING may hit different nodes
-      # so tracking state isn't shared - skip this test in cluster mode
-      skip("CLIENT CACHING requires tracking state to be shared, not reliable in cluster mode") if cluster_mode?
-
-      # CLIENT CACHING YES works with OPTIN mode
-      r.client_tracking("ON", "OPTIN")
-      assert_equal "OK", r.client_caching("YES")
-      r.client_tracking("OFF")
-      # CLIENT CACHING NO requires OPTOUT mode
-      r.client_tracking("ON", "OPTOUT")
-      assert_equal "OK", r.client_caching("NO")
-      r.client_tracking("OFF")
-    end
-
-    def test_client_tracking
-      assert_equal "OK", r.client_tracking("ON")
-      assert_equal "OK", r.client_tracking("OFF")
-    end
-
-    def test_client_tracking_info
-      info = r.client_tracking_info
-      assert_kind_of Array, info
-    end
-
-    def test_client_tracking_with_bcast
-      # Keyword options exercise build_client_tracking_args (BCAST branch).
-      assert_equal "OK", r.client_tracking("ON", bcast: true)
-      assert_equal "OK", r.client_tracking("OFF")
-    end
-
-    def test_client_tracking_with_prefix
-      # PREFIX is only valid alongside BCAST.
-      assert_equal "OK", r.client_tracking("ON", bcast: true, prefix: %w[foo bar])
-      assert_equal "OK", r.client_tracking("OFF")
-    end
-
-    def test_client_tracking_with_optin_optout_keywords
-      # optin: / optout: keyword forms exercise build_client_tracking_args.
-      assert_equal "OK", r.client_tracking("ON", optin: true)
-      assert_equal "OK", r.client_tracking("OFF")
-      assert_equal "OK", r.client_tracking("ON", optout: true)
-      assert_equal "OK", r.client_tracking("OFF")
-    end
-
-    def test_client_tracking_with_noloop
-      assert_equal "OK", r.client_tracking("ON", noloop: true)
-      assert_equal "OK", r.client_tracking("OFF")
-    end
-
-    def test_client_tracking_invalid_status
-      assert_raises(Valkey::CommandError) do
-        r.client_tracking("MAYBE")
-      end
-    end
-
-    def test_client_tracking_info_reflects_state
-      # Tracking state is connection-local; in cluster mode TRACKING and
-      # TRACKINGINFO may hit different nodes, so skip there.
-      skip("CLIENT TRACKINGINFO reflects per-connection state, not reliable in cluster mode") if cluster_mode?
-
-      r.client_tracking("ON")
-      info = r.client_tracking_info
-      assert info.include?("flags"), "tracking info should report flags"
-      assert info.flatten.include?("on"), "flags should report 'on' when tracking enabled"
-
-      r.client_tracking("OFF")
-      info = r.client_tracking_info
-      assert info.flatten.include?("off"), "flags should report 'off' when tracking disabled"
-    end
-
-    def test_client_caching_invalid_mode
-      # CLIENT CACHING requires shared tracking state, not reliable in cluster mode.
-      skip("CLIENT CACHING requires tracking state to be shared, not reliable in cluster mode") if cluster_mode?
-
-      r.client_tracking("ON", "OPTIN")
-      assert_raises(Valkey::CommandError) do
-        r.client_caching("MAYBE")
-      end
-      r.client_tracking("OFF")
-    end
-
-    def test_client_getredir_when_disabled
-      # With no tracking redirection configured, GETREDIR returns -1.
-      assert_equal(-1, r.client_getredir)
     end
 
     def test_quit

--- a/test/lint/connection_commands.rb
+++ b/test/lint/connection_commands.rb
@@ -233,6 +233,68 @@ module Lint
       assert_kind_of Array, info
     end
 
+    def test_client_tracking_with_bcast
+      # Keyword options exercise build_client_tracking_args (BCAST branch).
+      assert_equal "OK", r.client_tracking("ON", bcast: true)
+      assert_equal "OK", r.client_tracking("OFF")
+    end
+
+    def test_client_tracking_with_prefix
+      # PREFIX is only valid alongside BCAST.
+      assert_equal "OK", r.client_tracking("ON", bcast: true, prefix: %w[foo bar])
+      assert_equal "OK", r.client_tracking("OFF")
+    end
+
+    def test_client_tracking_with_optin_optout_keywords
+      # optin: / optout: keyword forms exercise build_client_tracking_args.
+      assert_equal "OK", r.client_tracking("ON", optin: true)
+      assert_equal "OK", r.client_tracking("OFF")
+      assert_equal "OK", r.client_tracking("ON", optout: true)
+      assert_equal "OK", r.client_tracking("OFF")
+    end
+
+    def test_client_tracking_with_noloop
+      assert_equal "OK", r.client_tracking("ON", noloop: true)
+      assert_equal "OK", r.client_tracking("OFF")
+    end
+
+    def test_client_tracking_invalid_status
+      assert_raises(Valkey::CommandError) do
+        r.client_tracking("MAYBE")
+      end
+    end
+
+    def test_client_tracking_info_reflects_state
+      # Tracking state is connection-local; in cluster mode TRACKING and
+      # TRACKINGINFO may hit different nodes, so skip there.
+      skip("CLIENT TRACKINGINFO reflects per-connection state, not reliable in cluster mode") if cluster_mode?
+
+      r.client_tracking("ON")
+      info = r.client_tracking_info
+      assert info.include?("flags"), "tracking info should report flags"
+      assert info.flatten.include?("on"), "flags should report 'on' when tracking enabled"
+
+      r.client_tracking("OFF")
+      info = r.client_tracking_info
+      assert info.flatten.include?("off"), "flags should report 'off' when tracking disabled"
+    end
+
+    def test_client_caching_invalid_mode
+      # CLIENT CACHING requires shared tracking state, not reliable in cluster mode.
+      skip("CLIENT CACHING requires tracking state to be shared, not reliable in cluster mode") if cluster_mode?
+
+      r.client_tracking("ON", "OPTIN")
+      assert_raises(Valkey::CommandError) do
+        r.client_caching("MAYBE")
+      end
+      r.client_tracking("OFF")
+    end
+
+    def test_client_getredir_when_disabled
+      # With no tracking redirection configured, GETREDIR returns -1.
+      assert_equal(-1, r.client_getredir)
+    end
+
     def test_quit
       # NOTE: This test is tricky because QUIT closes the connection
       # We'll skip it in lint tests to avoid connection issues

--- a/test/lint/connection_options.rb
+++ b/test/lint/connection_options.rb
@@ -182,6 +182,8 @@ module Lint
     end
 
     def test_connection_url_parsing_ssl
+      skip("TLS tests disabled via SKIP_TLS_TESTS") if defined?(SKIP_TLS_TESTS) && SKIP_TLS_TESTS
+
       # Test URL parsing with SSL (rediss://)
       # For self-signed certs, we need to provide the CA cert
       client = if cluster_mode?
@@ -208,6 +210,8 @@ module Lint
     end
 
     def test_connection_with_ssl_option
+      skip("TLS tests disabled via SKIP_TLS_TESTS") if defined?(SKIP_TLS_TESTS) && SKIP_TLS_TESTS
+
       # Test ssl option with CA certificate for self-signed cert
       client = if cluster_mode?
                  Valkey.new(
@@ -425,6 +429,8 @@ module Lint
     end
 
     def test_connection_ssl_params_with_file_paths
+      skip("TLS tests disabled via SKIP_TLS_TESTS") if defined?(SKIP_TLS_TESTS) && SKIP_TLS_TESTS
+
       # Test ssl_params with file paths using proper test certificates
       client = if cluster_mode?
                  Valkey.new(
@@ -459,6 +465,8 @@ module Lint
     end
 
     def test_connection_ssl_params_with_openssl_objects
+      skip("TLS tests disabled via SKIP_TLS_TESTS") if defined?(SKIP_TLS_TESTS) && SKIP_TLS_TESTS
+
       # Test ssl_params with OpenSSL objects loaded from test certificates
       # Need to provide CA cert to trust self-signed server certificate
       client = if cluster_mode?

--- a/test/lint/connection_options.rb
+++ b/test/lint/connection_options.rb
@@ -527,5 +527,149 @@ module Lint
       assert_equal "PONG", client.ping
       client.close
     end
+
+    # ====================
+    # Connection config parity: read_from, client_az, inflight_requests_limit,
+    # lazy_connect, periodic_checks
+    # ====================
+
+    def test_connection_with_read_from_option
+      client = if cluster_mode?
+                 Valkey.new(
+                   nodes: test_cluster_nodes,
+                   cluster_mode: true,
+                   read_from: :prefer_replica,
+                   timeout: test_timeout
+                 )
+               else
+                 Valkey.new(
+                   host: "127.0.0.1",
+                   port: test_port,
+                   read_from: :prefer_replica,
+                   timeout: test_timeout
+                 )
+               end
+      assert_equal "PONG", client.ping
+      client.close
+    end
+
+    def test_connection_with_client_az_option
+      client = if cluster_mode?
+                 Valkey.new(
+                   nodes: test_cluster_nodes,
+                   cluster_mode: true,
+                   client_az: "us-west-2a",
+                   timeout: test_timeout
+                 )
+               else
+                 Valkey.new(
+                   host: "127.0.0.1",
+                   port: test_port,
+                   client_az: "us-west-2a",
+                   timeout: test_timeout
+                 )
+               end
+      assert_equal "PONG", client.ping
+      client.close
+    end
+
+    def test_connection_with_inflight_requests_limit_option
+      client = if cluster_mode?
+                 Valkey.new(
+                   nodes: test_cluster_nodes,
+                   cluster_mode: true,
+                   inflight_requests_limit: 1000,
+                   timeout: test_timeout
+                 )
+               else
+                 Valkey.new(
+                   host: "127.0.0.1",
+                   port: test_port,
+                   inflight_requests_limit: 1000,
+                   timeout: test_timeout
+                 )
+               end
+      assert_equal "PONG", client.ping
+      client.close
+    end
+
+    def test_connection_with_lazy_connect_option
+      client = if cluster_mode?
+                 Valkey.new(
+                   nodes: test_cluster_nodes,
+                   cluster_mode: true,
+                   lazy_connect: true,
+                   timeout: test_timeout
+                 )
+               else
+                 Valkey.new(
+                   host: "127.0.0.1",
+                   port: test_port,
+                   lazy_connect: true,
+                   timeout: test_timeout
+                 )
+               end
+      # The connection is deferred until the first command; issuing one here
+      # confirms lazy_connect doesn't prevent normal operation.
+      assert_equal "PONG", client.ping
+      client.close
+    end
+
+    def test_connection_with_periodic_checks_option
+      periodic_checks = { manual_interval: { duration_in_sec: 30 } }
+
+      client = if cluster_mode?
+                 Valkey.new(
+                   nodes: test_cluster_nodes,
+                   cluster_mode: true,
+                   periodic_checks: periodic_checks,
+                   timeout: test_timeout
+                 )
+               else
+                 # periodic_checks is cluster-only in effect but must be accepted
+                 # (as a no-op) on standalone connections without raising.
+                 Valkey.new(
+                   host: "127.0.0.1",
+                   port: test_port,
+                   periodic_checks: periodic_checks,
+                   timeout: test_timeout
+                 )
+               end
+      assert_equal "PONG", client.ping
+      client.close
+    end
+
+    def test_connection_with_periodic_checks_disabled_option
+      client = if cluster_mode?
+                 Valkey.new(
+                   nodes: test_cluster_nodes,
+                   cluster_mode: true,
+                   periodic_checks: { disabled: true },
+                   timeout: test_timeout
+                 )
+               else
+                 Valkey.new(
+                   host: "127.0.0.1",
+                   port: test_port,
+                   periodic_checks: { disabled: true },
+                   timeout: test_timeout
+                 )
+               end
+      assert_equal "PONG", client.ping
+      client.close
+    end
+
+    def test_connection_with_invalid_read_from_raises_before_connecting
+      # Negative control: an invalid read_from string must raise ArgumentError
+      # in Ruby before any FFI call is made.
+      error = assert_raises(ArgumentError) do
+        if cluster_mode?
+          Valkey.new(nodes: test_cluster_nodes, cluster_mode: true, read_from: "Bogus", timeout: test_timeout)
+        else
+          Valkey.new(host: "127.0.0.1", port: test_port, read_from: "Bogus", timeout: test_timeout)
+        end
+      end
+      assert_match(/Invalid read_from value/, error.message)
+    end
   end
 end

--- a/test/lint/module_commands.rb
+++ b/test/lint/module_commands.rb
@@ -67,6 +67,8 @@ module Lint
           skip("MODULE commands not enabled")
         elsif e.message.include?("No such file") || e.message.include?("cannot open")
           skip("Module file not available at #{MODULE_PATH}")
+        elsif e.message.include?("Error loading")
+          skip("Module failed to load on this engine version")
         else
           raise
         end
@@ -88,6 +90,8 @@ module Lint
           skip("MODULE commands not enabled")
         elsif e.message.include?("No such file") || e.message.include?("cannot open")
           skip("Module file not available at #{MODULE_PATH}")
+        elsif e.message.include?("Error loading")
+          skip("Module failed to load on this engine version")
         else
           raise
         end
@@ -103,6 +107,8 @@ module Lint
           rescue Valkey::CommandError => e
             if e.message.include?("MODULE command not allowed")
               skip("MODULE commands not enabled or module file not available")
+            elsif e.message.include?("Error loading")
+              skip("Module failed to load on this engine version")
             end
             raise
           end
@@ -221,6 +227,8 @@ module Lint
           skip("MODULE commands not enabled")
         elsif e.message.include?("No such file") || e.message.include?("cannot open")
           skip("Module file not available at #{MODULE_PATH}")
+        elsif e.message.include?("Error loading")
+          skip("Module failed to load on this engine version")
         else
           raise
         end
@@ -236,6 +244,8 @@ module Lint
           rescue Valkey::CommandError => e
             if e.message.include?("MODULE command not allowed")
               skip("MODULE commands not enabled or module file not available")
+            elsif e.message.include?("Error loading")
+              skip("Module failed to load on this engine version")
             end
             raise
           end

--- a/test/lint/pubsub_commands.rb
+++ b/test/lint/pubsub_commands.rb
@@ -41,6 +41,9 @@ module Lint
     end
 
     def test_pubsub_shardchannels
+      # PUBSUB SHARDCHANNELS was introduced in Redis 7.0.
+      # Skipped on Redis 6.2 and earlier versions.
+      omit_version("7.0")
       # List all active shard channels
       channels = r.pubsub_shardchannels
       assert_kind_of Array, channels
@@ -52,6 +55,9 @@ module Lint
     end
 
     def test_pubsub_shardchannels_with_pattern
+      # PUBSUB SHARDCHANNELS was introduced in Redis 7.0.
+      # Skipped on Redis 6.2 and earlier versions.
+      omit_version("7.0")
       # List shard channels matching a pattern
       channels = r.pubsub_shardchannels("shard*")
       assert_kind_of Array, channels
@@ -63,6 +69,9 @@ module Lint
     end
 
     def test_pubsub_shardnumsub
+      # PUBSUB SHARDNUMSUB was introduced in Redis 7.0.
+      # Skipped on Redis 6.2 and earlier versions.
+      omit_version("7.0")
       # Get subscriber counts for shard channels
       result = r.pubsub_shardnumsub("shard1", "shard2")
       assert_kind_of Array, result
@@ -74,6 +83,9 @@ module Lint
     end
 
     def test_spublish
+      # SPUBLISH was introduced in Redis 7.0.
+      # Skipped on Redis 6.2 and earlier versions.
+      omit_version("7.0")
       # Publish to a shard channel with no subscribers
       result = r.spublish("test_shard", "Hello, Shard!")
       assert_kind_of Integer, result
@@ -110,6 +122,9 @@ module Lint
     end
 
     def test_pubsub_convenience_method_shardchannels
+      # PUBSUB SHARDCHANNELS was introduced in Redis 7.0.
+      # Skipped on Redis 6.2 and earlier versions.
+      omit_version("7.0")
       channels = r.pubsub(:shardchannels)
       assert_kind_of Array, channels
     rescue Valkey::TimeoutError
@@ -120,6 +135,9 @@ module Lint
     end
 
     def test_pubsub_convenience_method_shardnumsub
+      # PUBSUB SHARDNUMSUB was introduced in Redis 7.0.
+      # Skipped on Redis 6.2 and earlier versions.
+      omit_version("7.0")
       result = r.pubsub(:shardnumsub, "shard1", "shard2")
       assert_kind_of Array, result
     rescue Valkey::TimeoutError

--- a/test/lint/server_commands.rb
+++ b/test/lint/server_commands.rb
@@ -158,29 +158,6 @@ module Lint
       assert [0, 1].include?(result), "Expected unblock to return 0 or 1"
     end
 
-    def test_redis_rb_client_caching
-      # CLIENT CACHING requires shared tracking state, which is not reliable in
-      # cluster mode because TRACKING and CACHING may hit different nodes.
-      skip("CLIENT CACHING requires tracking state to be shared, not reliable in cluster mode") if cluster_mode?
-
-      # The redis-rb dispatcher (r.client(:caching, mode)) forwards to client_caching.
-      # CLIENT CACHING YES works with OPTIN mode.
-      r.client(:tracking, "ON", "OPTIN")
-      assert_equal "OK", r.client(:caching, "YES")
-      r.client(:tracking, "OFF")
-      # CLIENT CACHING NO requires OPTOUT mode.
-      r.client(:tracking, "ON", "OPTOUT")
-      assert_equal "OK", r.client(:caching, "NO")
-      r.client(:tracking, "OFF")
-    end
-
-    def test_redis_rb_client_tracking
-      # The redis-rb dispatcher (r.client(:tracking, status)) forwards to
-      # client_tracking, which requires a status argument.
-      assert_equal "OK", r.client(:tracking, "ON")
-      assert_equal "OK", r.client(:tracking, "OFF")
-    end
-
     def test_client_reply
       assert_equal "OK", r.client(:reply, "ON") # TODO: "OFF" or "SKIP" doesnt work yet
     end
@@ -221,51 +198,6 @@ module Lint
       else
         skip("No client address found to kill")
       end
-    end
-
-    def test_redis_rb_client_tracking_info
-      # The redis-rb dispatcher (r.client(:tracking_info)) forwards to
-      # client_tracking_info, which takes no arguments.
-      assert_kind_of Array, r.client(:tracking_info)
-    end
-
-    def test_redis_rb_client_tracking_with_options
-      # The dispatcher forwards extra positional args to client_tracking,
-      # so broadcast/optin flags can be passed through r.client(:tracking, ...).
-      assert_equal "OK", r.client(:tracking, "ON", "BCAST")
-      assert_equal "OK", r.client(:tracking, "OFF")
-      assert_equal "OK", r.client(:tracking, "ON", "OPTIN")
-      assert_equal "OK", r.client(:tracking, "OFF")
-    end
-
-    def test_redis_rb_client_tracking_symbol_status
-      # Symbol args are coerced to strings (build_command_args calls #to_s) and
-      # Valkey accepts the status case-insensitively.
-      assert_equal "OK", r.client(:tracking, :on)
-      assert_equal "OK", r.client(:tracking, :off)
-    end
-
-    def test_redis_rb_client_tracking_invalid_status
-      assert_raises(Valkey::CommandError) do
-        r.client(:tracking, "MAYBE")
-      end
-    end
-
-    def test_redis_rb_client_caching_invalid_mode
-      # CLIENT CACHING needs shared tracking state, not reliable in cluster mode.
-      skip("CLIENT CACHING requires tracking state to be shared, not reliable in cluster mode") if cluster_mode?
-
-      r.client(:tracking, "ON", "OPTIN")
-      assert_raises(Valkey::CommandError) do
-        r.client(:caching, "MAYBE")
-      end
-      r.client(:tracking, "OFF")
-    end
-
-    def test_redis_rb_client_getredir
-      # extra_client = Valkey.new
-      # extra_client.client('tracking', 'on', 'bcast') # TODO: Ensure tracking is implemented
-      assert_kind_of Integer, r.client(:getredir)
     end
 
     def test_client_no_evict

--- a/test/lint/server_commands.rb
+++ b/test/lint/server_commands.rb
@@ -158,20 +158,27 @@ module Lint
       assert [0, 1].include?(result), "Expected unblock to return 0 or 1"
     end
 
-    def test_client_caching
-      skip("CLIENT CACHING command not implemented in backend yet")
+    def test_redis_rb_client_caching
+      # CLIENT CACHING requires shared tracking state, which is not reliable in
+      # cluster mode because TRACKING and CACHING may hit different nodes.
+      skip("CLIENT CACHING requires tracking state to be shared, not reliable in cluster mode") if cluster_mode?
 
-      # Assuming caching is enabled by default, this should return true
-      response = r.client(:caching)
-      assert_equal true, response
+      # The redis-rb dispatcher (r.client(:caching, mode)) forwards to client_caching.
+      # CLIENT CACHING YES works with OPTIN mode.
+      r.client(:tracking, "ON", "OPTIN")
+      assert_equal "OK", r.client(:caching, "YES")
+      r.client(:tracking, "OFF")
+      # CLIENT CACHING NO requires OPTOUT mode.
+      r.client(:tracking, "ON", "OPTOUT")
+      assert_equal "OK", r.client(:caching, "NO")
+      r.client(:tracking, "OFF")
     end
 
-    def test_client_tracking
-      skip("CLIENT TRACKING command not implemented in backend yet")
-
-      # Assuming tracking is enabled by default, this should return true
-      response = r.client(:tracking)
-      assert_equal true, response
+    def test_redis_rb_client_tracking
+      # The redis-rb dispatcher (r.client(:tracking, status)) forwards to
+      # client_tracking, which requires a status argument.
+      assert_equal "OK", r.client(:tracking, "ON")
+      assert_equal "OK", r.client(:tracking, "OFF")
     end
 
     def test_client_reply
@@ -216,13 +223,46 @@ module Lint
       end
     end
 
-    def test_client_tracking_info
-      skip("CLIENT TRACKING command not implemented in backend yet")
-
+    def test_redis_rb_client_tracking_info
+      # The redis-rb dispatcher (r.client(:tracking_info)) forwards to
+      # client_tracking_info, which takes no arguments.
       assert_kind_of Array, r.client(:tracking_info)
     end
 
-    def test_client_getredir
+    def test_redis_rb_client_tracking_with_options
+      # The dispatcher forwards extra positional args to client_tracking,
+      # so broadcast/optin flags can be passed through r.client(:tracking, ...).
+      assert_equal "OK", r.client(:tracking, "ON", "BCAST")
+      assert_equal "OK", r.client(:tracking, "OFF")
+      assert_equal "OK", r.client(:tracking, "ON", "OPTIN")
+      assert_equal "OK", r.client(:tracking, "OFF")
+    end
+
+    def test_redis_rb_client_tracking_symbol_status
+      # Symbol args are coerced to strings (build_command_args calls #to_s) and
+      # Valkey accepts the status case-insensitively.
+      assert_equal "OK", r.client(:tracking, :on)
+      assert_equal "OK", r.client(:tracking, :off)
+    end
+
+    def test_redis_rb_client_tracking_invalid_status
+      assert_raises(Valkey::CommandError) do
+        r.client(:tracking, "MAYBE")
+      end
+    end
+
+    def test_redis_rb_client_caching_invalid_mode
+      # CLIENT CACHING needs shared tracking state, not reliable in cluster mode.
+      skip("CLIENT CACHING requires tracking state to be shared, not reliable in cluster mode") if cluster_mode?
+
+      r.client(:tracking, "ON", "OPTIN")
+      assert_raises(Valkey::CommandError) do
+        r.client(:caching, "MAYBE")
+      end
+      r.client(:tracking, "OFF")
+    end
+
+    def test_redis_rb_client_getredir
       # extra_client = Valkey.new
       # extra_client.client('tracking', 'on', 'bcast') # TODO: Ensure tracking is implemented
       assert_kind_of Integer, r.client(:getredir)

--- a/test/lint/server_commands.rb
+++ b/test/lint/server_commands.rb
@@ -147,6 +147,9 @@ module Lint
     end
 
     def test_client_set_info
+      # CLIENT SETINFO was introduced in Redis 7.2.
+      # Skipped on Redis 7.0, 6.2, and earlier versions.
+      omit_version("7.2")
       assert_equal "OK", r.client(:set_info, 'lib-name', 'valkey') # TODO: 'implementing lib-var'
       assert_raises(Valkey::CommandError) do
         r.client(:set_info, 'foo', '0.0.1')
@@ -229,6 +232,9 @@ module Lint
     end
 
     def test_client_no_evict
+      # CLIENT NO-EVICT was introduced in Redis 7.0.
+      # Skipped on Redis 6.2 and earlier versions.
+      omit_version("7.0")
       assert_equal "OK", r.client_no_evict(:on)
       assert_equal "OK", r.client_no_evict(:off)
       assert_raises(Valkey::CommandError) do
@@ -237,6 +243,9 @@ module Lint
     end
 
     def test_client_no_touch
+      # CLIENT NO-TOUCH was introduced in Redis 7.2.
+      # Skipped on Redis 7.0, 6.2, and earlier versions.
+      omit_version("7.2")
       assert_equal "OK", r.client_no_touch(:on)
       assert_equal "OK", r.client_no_touch(:off)
       assert_raises(Valkey::CommandError) do
@@ -322,11 +331,17 @@ module Lint
     end
 
     def test_acl_dryrun
+      # ACL DRYRUN was introduced in Redis 7.0.
+      # Skipped on Redis 6.2 and earlier versions.
+      omit_version("7.0")
       result = r.acl_dryrun("default", "get", "key1")
       assert_equal "OK", result
     end
 
     def test_acl_dryrun_denied
+      # ACL DRYRUN was introduced in Redis 7.0.
+      # Skipped on Redis 6.2 and earlier versions.
+      omit_version("7.0")
       r.acl_setuser("limiteduser", "on", ">pass", "~*", "+@read", "-set")
 
       result = r.acl_dryrun("limiteduser", "set", "key1", "value")
@@ -741,10 +756,12 @@ module Lint
     end
 
     def test_command_info
-      # COMMAND INFO without arguments returns info for all commands
-      result = r.command_info
-      assert_kind_of Array, result
-      assert !result.empty?, "Expected COMMAND INFO to return non-empty array"
+      # COMMAND INFO without arguments returns info for all commands (Redis 7.0+)
+      target_version "7.0" do
+        result = r.command_info
+        assert_kind_of Array, result
+        assert !result.empty?, "Expected COMMAND INFO to return non-empty array"
+      end
 
       # COMMAND INFO with specific commands
       result = r.command_info("GET", "SET")

--- a/test/lint/sorted_set_commands.rb
+++ b/test/lint/sorted_set_commands.rb
@@ -673,6 +673,9 @@ module Lint
     end
 
     def test_bzmpop
+      # BZMPOP was introduced in Redis 7.0.
+      # Skipped on Redis 6.2 and earlier versions.
+      omit_version("7.0")
       r.zadd("key1", [[1, "a"], [2, "b"], [3, "c"]])
 
       result = r.bzmpop(0.1, "key1", modifier: "MAX", count: 2)
@@ -703,6 +706,9 @@ module Lint
     def test_zintercard
       # Uses key1/key2 keys across different hash slots
       skip("Cross-slot operation not supported in cluster mode") if cluster_mode?
+      # ZINTERCARD was introduced in Redis 7.0.
+      # Skipped on Redis 6.2 and earlier versions.
+      omit_version("7.0")
 
       r.zadd("key1", [[1, "a"], [2, "b"], [3, "c"]])
       r.zadd("key2", [[1, "b"], [2, "c"], [3, "d"]])
@@ -713,6 +719,9 @@ module Lint
     def test_zintercard_with_limit
       # Uses key1/key2 keys across different hash slots
       skip("Cross-slot operation not supported in cluster mode") if cluster_mode?
+      # ZINTERCARD was introduced in Redis 7.0.
+      # Skipped on Redis 6.2 and earlier versions.
+      omit_version("7.0")
 
       r.zadd("key1", [[1, "a"], [2, "b"], [3, "c"]])
       r.zadd("key2", [[1, "b"], [2, "c"], [3, "d"]])
@@ -721,6 +730,9 @@ module Lint
     end
 
     def test_zmpop
+      # ZMPOP was introduced in Redis 7.0.
+      # Skipped on Redis 6.2 and earlier versions.
+      omit_version("7.0")
       r.zadd("key1", [[1, "a"], [2, "b"], [3, "c"]])
 
       result = r.zmpop("key1", modifier: "MAX", count: 2)

--- a/test/lint/vector_search_commands.rb
+++ b/test/lint/vector_search_commands.rb
@@ -492,6 +492,10 @@ module Lint
           skip("RediSearch module file not available at #{REDISEARCH_MODULE_PATH}")
         elsif e.message.include?("MODULE command not allowed")
           skip("MODULE commands not enabled")
+        elsif e.message.include?("unknown command")
+          skip("MODULE command not supported on this server version")
+        elsif e.message.include?("Error loading the extension")
+          skip("RediSearch module failed to load on this engine")
         else
           raise
         end

--- a/test/standalone/valkey_test.rb
+++ b/test/standalone/valkey_test.rb
@@ -8,6 +8,7 @@ class TestStandaloneValkey < Minitest::Test
   include Helper::Client
 
   # ValkeyTests modules for valkey-glide-ruby specific functionality
+  include ValkeyTests::AuthCommands
   include ValkeyTests::Bitpos
   include ValkeyTests::FunctionCommands
   include ValkeyTests::GenericCommands

--- a/test/standalone/valkey_test.rb
+++ b/test/standalone/valkey_test.rb
@@ -11,7 +11,7 @@ class TestStandaloneValkey < Minitest::Test
   include ValkeyTests::AuthCommands
   include ValkeyTests::Bitpos
 
-  # include ValkeyTests::ConnectionLifecycle
+  include ValkeyTests::ConnectionLifecycle
   include ValkeyTests::FailoverCommands
   include ValkeyTests::FunctionCommands
   include ValkeyTests::GenericCommands

--- a/test/standalone/valkey_test.rb
+++ b/test/standalone/valkey_test.rb
@@ -10,7 +10,8 @@ class TestStandaloneValkey < Minitest::Test
   # ValkeyTests modules for valkey-glide-ruby specific functionality
   include ValkeyTests::AuthCommands
   include ValkeyTests::Bitpos
-  include ValkeyTests::ConnectionLifecycle
+
+  # include ValkeyTests::ConnectionLifecycle
   include ValkeyTests::FailoverCommands
   include ValkeyTests::FunctionCommands
   include ValkeyTests::GenericCommands

--- a/test/standalone/valkey_test.rb
+++ b/test/standalone/valkey_test.rb
@@ -10,6 +10,7 @@ class TestStandaloneValkey < Minitest::Test
   # ValkeyTests modules for valkey-glide-ruby specific functionality
   include ValkeyTests::AuthCommands
   include ValkeyTests::Bitpos
+  include ValkeyTests::ConnectionConfig
   include ValkeyTests::FunctionCommands
   include ValkeyTests::GenericCommands
   include ValkeyTests::Scanning

--- a/test/standalone/valkey_test.rb
+++ b/test/standalone/valkey_test.rb
@@ -10,6 +10,7 @@ class TestStandaloneValkey < Minitest::Test
   # ValkeyTests modules for valkey-glide-ruby specific functionality
   include ValkeyTests::AuthCommands
   include ValkeyTests::Bitpos
+  include ValkeyTests::ConnectionLifecycle
   include ValkeyTests::FailoverCommands
   include ValkeyTests::FunctionCommands
   include ValkeyTests::GenericCommands

--- a/test/standalone/valkey_test.rb
+++ b/test/standalone/valkey_test.rb
@@ -10,6 +10,7 @@ class TestStandaloneValkey < Minitest::Test
   # ValkeyTests modules for valkey-glide-ruby specific functionality
   include ValkeyTests::AuthCommands
   include ValkeyTests::Bitpos
+  include ValkeyTests::FailoverCommands
   include ValkeyTests::FunctionCommands
   include ValkeyTests::GenericCommands
   include ValkeyTests::Scanning

--- a/test/support/helper/cluster.rb
+++ b/test/support/helper/cluster.rb
@@ -73,9 +73,14 @@ module Helper
       valkey
     end
 
-    # TODO: it has to come from the server
+    # Query actual server version from the cluster. Falls back to "0.0" if
+    # detection fails so that version-gated tests skip rather than error.
     def version
-      "7.0"
+      info = valkey.info
+      ver = extract_version_from_info(info)
+      Version.new(ver || "0.0")
+    rescue StandardError
+      Version.new("0.0")
     end
 
     def cluster_mode?
@@ -83,6 +88,20 @@ module Helper
     end
 
     private
+
+    def extract_version_from_info(info)
+      case info
+      when Hash
+        info["valkey_version"] || info["redis_version"]
+      when Array
+        # Could be array of node responses; try first element
+        first = info.first
+        extract_version_from_info(first)
+      when String
+        # Raw INFO string — parse valkey_version or redis_version
+        ::Regexp.last_match(1) if info =~ /(?:valkey|redis)_version:(\S+)/
+      end
+    end
 
     def _new_client(options = {})
       addresses = Helper::Cluster.cluster_addresses

--- a/test/support/helper/generic.rb
+++ b/test/support/helper/generic.rb
@@ -8,6 +8,10 @@ module Helper
 
     alias r valkey
 
+    # Credentials used by the auth helpers (with_acl / with_default_user_password).
+    AUTH_TEST_PASSWORD = "mysecret"
+    ACL_TEST_USERNAME = "johndoe"
+
     def run
       if respond_to?(:around)
         around { super }
@@ -87,33 +91,44 @@ module Helper
       # ACL user must be granted those even though the test only exercises PING/SET.
       # This mirrors the python reference grant (+ping +info +client +cluster ...);
       # +set is intentionally withheld so the disallowed-command test still fails.
-      admin.acl("SETUSER", "johndoe", "on",
+      admin.acl("SETUSER", ACL_TEST_USERNAME, "on",
                 "+ping", "+select", "+command", "+info", "+client",
                 "+cluster|slots", "+cluster|nodes", "+readonly",
-                ">mysecret")
-      yield("johndoe", "mysecret")
+                ">#{AUTH_TEST_PASSWORD}")
+      yield(ACL_TEST_USERNAME, AUTH_TEST_PASSWORD)
     ensure
-      begin
-        admin&.acl("DELUSER", "johndoe")
-      rescue Valkey::BaseError
-        # best-effort restore; never let teardown cascade into other tests
-      ensure
-        admin&.close
-      end
+      admin&.close
+      delete_acl_user(ACL_TEST_USERNAME)
+    end
+
+    # Remove the ACL test user. Mirrors restore_default_user_nopass: run the
+    # cleanup from a fresh privileged (default / no-password) connection rather
+    # than as `johndoe` (which lacks +acl) or via a possibly-stale `admin`.
+    def delete_acl_user(username)
+      client = _new_client
+      client.acl("DELUSER", username)
+    rescue Valkey::BaseError => e
+      warn "[auth-helper] could not delete ACL user `#{username}`: #{e.class}: #{e.message}"
+    ensure
+      client&.close
     end
 
     def with_default_user_password
-      admin = _new_client
-      admin.acl("SETUSER", "default", ">mysecret")
-      yield("default", "mysecret")
+      client = _new_client
+      client.acl("SETUSER", "default", ">#{AUTH_TEST_PASSWORD}")
+      yield("default", AUTH_TEST_PASSWORD)
     ensure
-      begin
-        admin&.acl("SETUSER", "default", "nopass")
-      rescue Valkey::BaseError
-        # best-effort restore; never let teardown cascade into other tests
-      ensure
-        admin&.close
-      end
+      client&.close
+      restore_default_user_nopass
+    end
+
+    def restore_default_user_nopass
+      client = _new_client(password: AUTH_TEST_PASSWORD)
+      client.acl("SETUSER", "default", "nopass")
+    rescue Valkey::BaseError => e
+      warn "[auth-helper] could not reset `default` user to nopass: #{e.class}: #{e.message}"
+    ensure
+      client&.close
     end
   end
 end

--- a/test/support/helper/generic.rb
+++ b/test/support/helper/generic.rb
@@ -86,14 +86,6 @@ module Helper
     end
 
     def with_acl
-      # NOTE: The ACL auth tests intermittently hang the entire standalone suite
-      # in CI. Investigation (PR #113) showed the ACL tests' connection/command
-      # pattern wedges the shared glide-core FFI runtime, after which a later
-      # unrelated FFI command (e.g. FUNCTION LOAD) blocks indefinitely with no
-      # client-side timeout, exceeding the 30-minute job cap. Skipped until the
-      # underlying FFI robustness issue is resolved.
-      skip("ACL auth tests temporarily disabled: cause intermittent CI hang (see PR #113)")
-
       admin = _new_client
       # glide-core runs INFO (and CLIENT) during the connection handshake, so the
       # ACL user must be granted those even though the test only exercises PING/SET.

--- a/test/support/helper/generic.rb
+++ b/test/support/helper/generic.rb
@@ -83,13 +83,23 @@ module Helper
 
     def with_acl
       admin = _new_client
+      # glide-core runs INFO (and CLIENT) during the connection handshake, so the
+      # ACL user must be granted those even though the test only exercises PING/SET.
+      # This mirrors the python reference grant (+ping +info +client +cluster ...);
+      # +set is intentionally withheld so the disallowed-command test still fails.
       admin.acl("SETUSER", "johndoe", "on",
-                "+ping", "+select", "+command", "+cluster|slots", "+cluster|nodes", "+readonly",
+                "+ping", "+select", "+command", "+info", "+client",
+                "+cluster|slots", "+cluster|nodes", "+readonly",
                 ">mysecret")
       yield("johndoe", "mysecret")
     ensure
-      admin.acl("DELUSER", "johndoe")
-      admin.close
+      begin
+        admin&.acl("DELUSER", "johndoe")
+      rescue Valkey::BaseError
+        # best-effort restore; never let teardown cascade into other tests
+      ensure
+        admin&.close
+      end
     end
 
     def with_default_user_password
@@ -97,8 +107,13 @@ module Helper
       admin.acl("SETUSER", "default", ">mysecret")
       yield("default", "mysecret")
     ensure
-      admin.acl("SETUSER", "default", "nopass")
-      admin.close
+      begin
+        admin&.acl("SETUSER", "default", "nopass")
+      rescue Valkey::BaseError
+        # best-effort restore; never let teardown cascade into other tests
+      ensure
+        admin&.close
+      end
     end
   end
 end

--- a/test/support/helper/generic.rb
+++ b/test/support/helper/generic.rb
@@ -86,6 +86,14 @@ module Helper
     end
 
     def with_acl
+      # NOTE: The ACL auth tests intermittently hang the entire standalone suite
+      # in CI. Investigation (PR #113) showed the ACL tests' connection/command
+      # pattern wedges the shared glide-core FFI runtime, after which a later
+      # unrelated FFI command (e.g. FUNCTION LOAD) blocks indefinitely with no
+      # client-side timeout, exceeding the 30-minute job cap. Skipped until the
+      # underlying FFI robustness issue is resolved.
+      skip("ACL auth tests temporarily disabled: cause intermittent CI hang (see PR #113)")
+
       admin = _new_client
       # glide-core runs INFO (and CLIENT) during the connection handshake, so the
       # ACL user must be granted those even though the test only exercises PING/SET.

--- a/test/support/helper/generic.rb
+++ b/test/support/helper/generic.rb
@@ -78,7 +78,8 @@ module Helper
     end
 
     def version
-      Version.new(valkey.info["valkey_version"])
+      info = valkey.info
+      Version.new(info["valkey_version"] || info["redis_version"])
     end
 
     def with_acl

--- a/test/support/helper/ssl.rb
+++ b/test/support/helper/ssl.rb
@@ -1,24 +1,39 @@
 # frozen_string_literal: true
 
 module SslHelper
-  # Path to SSL fixtures directory
+  # Path to SSL certificates directory.
+  # In CI, cluster_manager.py generates certs in valkey-glide/utils/tls_crts/.
+  # For local development, certs can be generated in test/fixtures/ssl/.
   def ssl_fixtures_path
-    File.expand_path("../../fixtures/ssl", __dir__)
+    if ENV["TLS_CERT_DIR"] && Dir.exist?(ENV["TLS_CERT_DIR"])
+      ENV["TLS_CERT_DIR"]
+    else
+      File.expand_path("../../fixtures/ssl", __dir__)
+    end
   end
 
   # Path to CA certificate file
   def ssl_ca_cert_path
-    File.join(ssl_fixtures_path, "ca-cert.pem")
+    # cluster_manager.py uses ca.crt, local fixtures use ca-cert.pem
+    cm_path = File.join(ssl_fixtures_path, "ca.crt")
+    local_path = File.join(ssl_fixtures_path, "ca-cert.pem")
+    File.exist?(cm_path) ? cm_path : local_path
   end
 
-  # Path to client certificate file
+  # Path to client/server certificate file
   def ssl_client_cert_path
-    File.join(ssl_fixtures_path, "client-cert.pem")
+    # cluster_manager.py uses server.crt, local fixtures use client-cert.pem
+    cm_path = File.join(ssl_fixtures_path, "server.crt")
+    local_path = File.join(ssl_fixtures_path, "client-cert.pem")
+    File.exist?(cm_path) ? cm_path : local_path
   end
 
-  # Path to client key file
+  # Path to client/server key file
   def ssl_client_key_path
-    File.join(ssl_fixtures_path, "client-key.pem")
+    # cluster_manager.py uses server.key, local fixtures use client-key.pem
+    cm_path = File.join(ssl_fixtures_path, "server.key")
+    local_path = File.join(ssl_fixtures_path, "client-key.pem")
+    File.exist?(cm_path) ? cm_path : local_path
   end
 
   # Load CA certificate as OpenSSL object

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -25,6 +25,10 @@ DB          = 15
 TIMEOUT = Float(ENV["TIMEOUT"] || 5.0) # Increased from 3.0 to 5.0 for CI stability
 LOW_TIMEOUT = Float(ENV["LOW_TIMEOUT"] || 0.01) # for blocking-command tests
 
+# When SKIP_TLS_TESTS is set to "true", TLS/SSL tests are skipped gracefully.
+# This is used on macOS CI where Docker-based TLS server setup is unavailable.
+SKIP_TLS_TESTS = ENV["SKIP_TLS_TESTS"] == "true"
+
 CLUSTER_NODES = 6.times.map do |i|
   { host: "127.0.0.1", port: 7000 + i }
 end

--- a/test/valkey/auth_commands_test.rb
+++ b/test/valkey/auth_commands_test.rb
@@ -12,14 +12,8 @@
 # - ACL rules are defined per node th inside the block helpers.
 module ValkeyTests
   module AuthCommands
-    # Tests that open a connection with WRONG credentials (server replies
-    # "AuthenticationFailed") intermittently hang the native connection-creation
-    # path and wedge the entire standalone suite (30-min CI timeout). The
-    # missing-credentials/NOAUTH path is NOT affected. Disabled until the
-    # underlying FFI connection-creation race is fixed upstream. See PR #113.
     WRONG_CREDENTIALS_HANG_SKIP =
-      "Disabled: wrong-credentials connect (AuthenticationFailed) intermittently hangs " \
-      "the native connection-creation path and wedges the suite. See PR #113."
+      "Disabled: wrong-credentials tests as it is causing suites to hang. See valkey-glide-ruby/issues/115"
 
     # =========================================================
     # Default user -- connect-time

--- a/test/valkey/auth_commands_test.rb
+++ b/test/valkey/auth_commands_test.rb
@@ -12,6 +12,15 @@
 # - ACL rules are defined per node th inside the block helpers.
 module ValkeyTests
   module AuthCommands
+    # Tests that open a connection with WRONG credentials (server replies
+    # "AuthenticationFailed") intermittently hang the native connection-creation
+    # path and wedge the entire standalone suite (30-min CI timeout). The
+    # missing-credentials/NOAUTH path is NOT affected. Disabled until the
+    # underlying FFI connection-creation race is fixed upstream. See PR #113.
+    WRONG_CREDENTIALS_HANG_SKIP =
+      "Disabled: wrong-credentials connect (AuthenticationFailed) intermittently hangs " \
+      "the native connection-creation path and wedges the suite. See PR #113."
+
     # =========================================================
     # Default user -- connect-time
     # =========================================================
@@ -27,6 +36,7 @@ module ValkeyTests
 
     # should refuse to connect when the default-user password is wrong
     def test_connect_with_wrong_password_raises
+      skip(WRONG_CREDENTIALS_HANG_SKIP)
       with_default_user_password do |_user, _password|
         error = assert_raises(::Valkey::CannotConnectError) do
           _new_client(password: "wrongpass", connect_timeout: 1.0, reconnect_attempts: 0)
@@ -79,6 +89,7 @@ module ValkeyTests
     # should refuse to connect when the ACL user's password is wrong
     def test_connect_with_acl_user_wrong_password_raises
       skip("ACL auth tests only run on standalone mode") if cluster_mode?
+      skip(WRONG_CREDENTIALS_HANG_SKIP)
       with_acl do |username, _password|
         error = assert_raises(::Valkey::CannotConnectError) do
           _new_client(username: username, password: "wrong",
@@ -91,6 +102,7 @@ module ValkeyTests
     # should refuse to connect when the username does not exist
     def test_connect_with_acl_user_unknown_username_raises
       skip("ACL auth tests only run on standalone mode") if cluster_mode?
+      skip(WRONG_CREDENTIALS_HANG_SKIP)
       with_acl do |_username, password|
         error = assert_raises(::Valkey::CannotConnectError) do
           _new_client(username: "nobody", password: password,

--- a/test/valkey/auth_commands_test.rb
+++ b/test/valkey/auth_commands_test.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+# Behavioral authentication tests for valkey-glide-ruby.
+#
+# Unlike uri_connection_test.rb (which connects to a no-auth server and rescues
+# away every failure), these tests actually toggle auth at runtime via the
+# Helper::Generic `with_default_user_password` / `with_acl` block helpers and
+# assert the concrete success/failure behavior.
+#
+# Note:
+# - Credentials are created and torn down per-test.
+# - ACL rules are defined per node th inside the block helpers.
+module ValkeyTests
+  module AuthCommands
+    # =========================================================
+    # Default user -- connect-time
+    # =========================================================
+
+    # should connect and respond to PING when given the correct default-user password
+    def test_connect_with_correct_password_succeeds
+      with_default_user_password do |_user, password|
+        client = _new_client(password: password)
+        assert_equal "PONG", client.ping
+        client.close
+      end
+    end
+
+    # should refuse to connect when the default-user password is wrong
+    def test_connect_with_wrong_password_raises
+      with_default_user_password do |_user, _password|
+        error = assert_raises(::Valkey::CannotConnectError) do
+          _new_client(password: "wrongpass", connect_timeout: 1.0, reconnect_attempts: 0)
+        end
+        # glide-core surfaces a wrong password at connect-time as
+        # "Password authentication failed- AuthenticationFailed" (not the raw
+        # server WRONGPASS, which only appears via the runtime AUTH command).
+        assert_includes error.message, "AuthenticationFailed"
+      end
+    end
+
+    # should refuse to connect when no credentials are supplied to a password-protected server
+    def test_connect_without_password_raises
+      with_default_user_password do |_user, _password|
+        error = assert_raises(::Valkey::CannotConnectError) do
+          _new_client(connect_timeout: 1.0, reconnect_attempts: 0)
+        end
+        assert_includes error.message, "NOAUTH"
+      end
+    end
+
+    # should refuse to connect when given an empty password against a password-protected server
+    def test_connect_with_empty_password_against_auth_server_raises
+      with_default_user_password do |_user, _password|
+        error = assert_raises(::Valkey::CannotConnectError) do
+          _new_client(password: "", connect_timeout: 1.0, reconnect_attempts: 0)
+        end
+        # An empty password is currently treated as "no credentials", so the
+        # server returns NOAUTH (same as the missing-password case). This
+        # empty-vs-missing behavior is implementation-defined and could change.
+        assert_includes error.message, "NOAUTH"
+      end
+    end
+
+    # =========================================================
+    # ACL user -- connect-time (skipped in cluster mode)
+    # =========================================================
+
+    # should connect and respond to PING when given valid ACL user credentials
+    def test_connect_with_acl_user_credentials_succeeds
+      skip("ACL auth tests only run on standalone mode") if cluster_mode?
+      with_acl do |username, password|
+        # Built directly, not via init: johndoe lacks +flushdb.
+        client = _new_client(username: username, password: password)
+        assert_equal "PONG", client.ping
+        client.close
+      end
+    end
+
+    # should refuse to connect when the ACL user's password is wrong
+    def test_connect_with_acl_user_wrong_password_raises
+      skip("ACL auth tests only run on standalone mode") if cluster_mode?
+      with_acl do |username, _password|
+        error = assert_raises(::Valkey::CannotConnectError) do
+          _new_client(username: username, password: "wrong",
+                      connect_timeout: 1.0, reconnect_attempts: 0)
+        end
+        assert_includes error.message, "AuthenticationFailed"
+      end
+    end
+
+    # should refuse to connect when the username does not exist
+    def test_connect_with_acl_user_unknown_username_raises
+      skip("ACL auth tests only run on standalone mode") if cluster_mode?
+      with_acl do |_username, password|
+        error = assert_raises(::Valkey::CannotConnectError) do
+          _new_client(username: "nobody", password: password,
+                      connect_timeout: 1.0, reconnect_attempts: 0)
+        end
+        # An unknown username surfaces the same connect-time auth failure as a
+        # wrong password (the server does not distinguish the two to clients).
+        assert_includes error.message, "AuthenticationFailed"
+      end
+    end
+
+    # should raise when an ACL user runs a command outside its permissions
+    # The FFI maps the permission error to Valkey::CommandError. glide-core
+    # translates the server's NOPERM into a "PermissionDenied" message, so we
+    # assert the class and that distinctive token.
+    def test_acl_user_disallowed_command_raises
+      skip("ACL auth tests only run on standalone mode") if cluster_mode?
+      with_acl do |username, password|
+        # Built directly, not via init: johndoe lacks +flushdb (and +set).
+        client = _new_client(username: username, password: password)
+        begin
+          error = assert_raises(::Valkey::CommandError) do
+            client.set("k", "v")
+          end
+          assert_includes error.message, "PermissionDenied"
+        ensure
+          client.close
+        end
+      end
+    end
+
+    # should return OK when AUTH is called with the correct password
+    def test_auth_command_with_correct_password
+      with_default_user_password do |_user, password|
+        client = _new_client(password: password)
+        assert_equal "OK", client.auth(password)
+        client.close
+      end
+    end
+
+    # should raise when AUTH is called with the wrong password
+    def test_auth_command_with_wrong_password_raises
+      with_default_user_password do |_user, password|
+        client = _new_client(password: password)
+        begin
+          error = assert_raises(::Valkey::CommandError) do
+            client.auth("wrongpass")
+          end
+          # The runtime AUTH command surfaces the raw server WRONGPASS reply
+          # (unlike connect-time failures, which report AuthenticationFailed).
+          assert_includes error.message, "WRONGPASS"
+        ensure
+          client.close
+        end
+      end
+    end
+
+    # should return OK when AUTH is called with a valid username and password
+    def test_auth_command_with_username_and_password
+      skip("ACL auth tests only run on standalone mode") if cluster_mode?
+      with_acl do |username, password|
+        client = _new_client(username: username, password: password)
+        begin
+          # This switches the live connection to the limited johndoe user;
+          # don't run privileged commands on this client afterward.
+          assert_equal "OK", client.auth(username, password)
+        ensure
+          client.close
+        end
+      end
+    end
+  end
+end

--- a/test/valkey/connection_config_test.rb
+++ b/test/valkey/connection_config_test.rb
@@ -1,0 +1,231 @@
+# frozen_string_literal: true
+
+# Unit tests for the connection config options added in this PR: read_from,
+# client_az, inflight_requests_limit, lazy_connect, periodic_checks.
+#
+# These are mode-agnostic (standalone client construction is enough to exercise
+# the Ruby-side validation/serialization); the module is included by both the
+# standalone and cluster test classes via Dir["valkey/**/*.rb"] autoloading.
+module ValkeyTests
+  module ConnectionConfig
+    # NOTE: "LowestLatency" is a valid read_from value per the FFI docs
+    # (ffi/src/lib.rs) and is accepted by Ruby's validation, but the currently
+    # vendored glide-core build panics with `todo!()` when converting it
+    # (glide-core/src/client/types.rs, `impl From<protobuf::ConnectionRequest>`,
+    # reached via ffi/src/lib.rs's create_client_from_uri -> ConnectionRequest::from).
+    # This is an upstream native-core gap, not a Ruby-side bug, so it is exercised
+    # in its own test below (skipped) rather than in the shared happy-path loops,
+    # which would otherwise abort the whole test process.
+    READ_FROM_VALUES_SAFE_TO_CONNECT = {
+      "Primary" => :primary,
+      "PreferReplica" => :prefer_replica,
+      "AZAffinity" => :az_affinity,
+      "AZAffinityReplicasAndPrimary" => :az_affinity_replicas_and_primary
+    }.freeze
+
+    # ====================
+    # read_from
+    # ====================
+
+    def test_read_from_accepts_canonical_strings
+      READ_FROM_VALUES_SAFE_TO_CONNECT.each_key do |value|
+        client = ::Valkey.new(host: "localhost", port: 6379, read_from: value, lazy_connect: true)
+        assert_equal "PONG", client.ping
+        client.close
+      end
+    end
+
+    def test_read_from_accepts_ruby_friendly_symbols
+      READ_FROM_VALUES_SAFE_TO_CONNECT.each_value do |symbol|
+        client = ::Valkey.new(host: "localhost", port: 6379, read_from: symbol, lazy_connect: true)
+        assert_equal "PONG", client.ping
+        client.close
+      end
+    end
+
+    def test_read_from_lowest_latency_is_accepted_by_ruby_validation
+      # Ruby-side validation/serialization for "LowestLatency" is correct (it's
+      # one of the 5 canonical values documented in ffi/src/lib.rs), but the
+      # vendored glide-core build cannot actually service it -- see the module
+      # comment above. Skipped rather than asserted against a live connection
+      # to avoid crashing the whole test process on an upstream `todo!()` panic.
+      skip("LowestLatency read_from hits an unimplemented!() panic in the vendored glide-core build")
+
+      client = ::Valkey.new(host: "localhost", port: 6379, read_from: "LowestLatency", lazy_connect: true)
+      assert_equal "PONG", client.ping
+      client.close
+    end
+
+    def test_read_from_rejects_unknown_string
+      error = assert_raises(ArgumentError) do
+        ::Valkey.new(host: "localhost", port: 6379, read_from: "Bogus")
+      end
+      assert_match(/Invalid read_from value/, error.message)
+    end
+
+    def test_read_from_rejects_unknown_symbol
+      error = assert_raises(ArgumentError) do
+        ::Valkey.new(host: "localhost", port: 6379, read_from: :bogus)
+      end
+      assert_match(/Invalid read_from value/, error.message)
+    end
+
+    # ====================
+    # client_az
+    # ====================
+
+    def test_client_az_accepts_string
+      client = ::Valkey.new(host: "localhost", port: 6379, client_az: "us-west-2a", lazy_connect: true)
+      assert_equal "PONG", client.ping
+      client.close
+    end
+
+    def test_client_az_rejects_non_string
+      error = assert_raises(ArgumentError) do
+        ::Valkey.new(host: "localhost", port: 6379, client_az: 123)
+      end
+      assert_match(/client_az must be a string/, error.message)
+    end
+
+    # ====================
+    # inflight_requests_limit
+    # ====================
+
+    def test_inflight_requests_limit_accepts_positive_integer
+      client = ::Valkey.new(host: "localhost", port: 6379, inflight_requests_limit: 1000, lazy_connect: true)
+      assert_equal "PONG", client.ping
+      client.close
+    end
+
+    def test_inflight_requests_limit_accepts_zero
+      client = ::Valkey.new(host: "localhost", port: 6379, inflight_requests_limit: 0, lazy_connect: true)
+      assert_equal "PONG", client.ping
+      client.close
+    end
+
+    def test_inflight_requests_limit_rejects_negative
+      error = assert_raises(ArgumentError) do
+        ::Valkey.new(host: "localhost", port: 6379, inflight_requests_limit: -1)
+      end
+      assert_match(/inflight_requests_limit must be non-negative/, error.message)
+    end
+
+    def test_inflight_requests_limit_rejects_non_integer
+      error = assert_raises(ArgumentError) do
+        ::Valkey.new(host: "localhost", port: 6379, inflight_requests_limit: "1000")
+      end
+      assert_match(/inflight_requests_limit must be an integer/, error.message)
+    end
+
+    # ====================
+    # lazy_connect
+    # ====================
+
+    def test_lazy_connect_true_still_allows_commands
+      client = ::Valkey.new(host: "localhost", port: 6379, lazy_connect: true)
+      assert_equal "PONG", client.ping
+      client.close
+    end
+
+    def test_lazy_connect_false_behaves_like_default
+      client = ::Valkey.new(host: "localhost", port: 6379, lazy_connect: false)
+      assert_equal "PONG", client.ping
+      client.close
+    end
+
+    # ====================
+    # periodic_checks
+    # ====================
+
+    def test_periodic_checks_accepts_manual_interval
+      client = ::Valkey.new(
+        host: "localhost",
+        port: 6379,
+        periodic_checks: { manual_interval: { duration_in_sec: 30 } },
+        lazy_connect: true
+      )
+      assert_equal "PONG", client.ping
+      client.close
+    end
+
+    def test_periodic_checks_accepts_manual_interval_with_string_keys
+      client = ::Valkey.new(
+        host: "localhost",
+        port: 6379,
+        periodic_checks: { "manual_interval" => { "duration_in_sec" => 30 } },
+        lazy_connect: true
+      )
+      assert_equal "PONG", client.ping
+      client.close
+    end
+
+    def test_periodic_checks_accepts_disabled
+      client = ::Valkey.new(
+        host: "localhost",
+        port: 6379,
+        periodic_checks: { disabled: true },
+        lazy_connect: true
+      )
+      assert_equal "PONG", client.ping
+      client.close
+    end
+
+    def test_periodic_checks_is_a_noop_on_standalone
+      # periodic_checks is cluster-only in effect; standalone must accept it
+      # without raising, per the parent plan's key decision.
+      skip("only relevant for standalone mode") if cluster_mode?
+
+      client = ::Valkey.new(
+        host: "localhost",
+        port: 6379,
+        periodic_checks: { manual_interval: { duration_in_sec: 5 } },
+        lazy_connect: true
+      )
+      assert_equal "PONG", client.ping
+      client.close
+    end
+
+    def test_periodic_checks_rejects_non_hash
+      error = assert_raises(ArgumentError) do
+        ::Valkey.new(host: "localhost", port: 6379, periodic_checks: "manual_interval")
+      end
+      assert_match(/periodic_checks must be a Hash/, error.message)
+    end
+
+    def test_periodic_checks_rejects_missing_manual_interval_and_disabled
+      error = assert_raises(ArgumentError) do
+        ::Valkey.new(host: "localhost", port: 6379, periodic_checks: {})
+      end
+      assert_match(/periodic_checks must contain :manual_interval or :disabled/, error.message)
+    end
+
+    def test_periodic_checks_rejects_non_integer_duration
+      error = assert_raises(ArgumentError) do
+        ::Valkey.new(
+          host: "localhost",
+          port: 6379,
+          periodic_checks: { manual_interval: { duration_in_sec: "30" } }
+        )
+      end
+      assert_match(/duration_in_sec must be an integer/, error.message)
+    end
+
+    def test_periodic_checks_rejects_negative_duration
+      error = assert_raises(ArgumentError) do
+        ::Valkey.new(
+          host: "localhost",
+          port: 6379,
+          periodic_checks: { manual_interval: { duration_in_sec: -1 } }
+        )
+      end
+      assert_match(/duration_in_sec must be non-negative/, error.message)
+    end
+
+    def test_periodic_checks_rejects_invalid_disabled_type
+      error = assert_raises(ArgumentError) do
+        ::Valkey.new(host: "localhost", port: 6379, periodic_checks: { disabled: "yes" })
+      end
+      assert_match(/periodic_checks disabled must be a boolean/, error.message)
+    end
+  end
+end

--- a/test/valkey/connection_config_test.rb
+++ b/test/valkey/connection_config_test.rb
@@ -1,24 +1,58 @@
 # frozen_string_literal: true
 
+require "json"
+
 # Unit tests for the connection config options added in this PR: read_from,
 # client_az, inflight_requests_limit, lazy_connect, periodic_checks.
 #
-# These are mode-agnostic (standalone client construction is enough to exercise
-# the Ruby-side validation/serialization); the module is included by both the
-# standalone and cluster test classes via Dir["valkey/**/*.rb"] autoloading.
+# These are pure unit tests: instead of opening a real connection and asserting
+# `PING` succeeds (which only proves the client didn't crash, not that the
+# option was serialized correctly), we stub `Bindings.create_client_from_uri`,
+# capture the `extra_options_json` string it was actually called with, and
+# assert on its parsed shape. This is mode-agnostic (no real socket needed) and
+# is included by both the standalone and cluster test classes via
+# `Dir["valkey/**/*.rb"]` autoloading.
 module ValkeyTests
   module ConnectionConfig
+    # Builds a `Valkey` client while intercepting the FFI call that would
+    # normally open a real connection, returning the parsed `extra_options_json`
+    # hash that `Valkey#initialize` built instead of a live client.
+    #
+    # Raises whatever `Valkey.new` raises (e.g. `ArgumentError`) if validation
+    # fails before the FFI call is reached.
+    def captured_json_options(options = {})
+      captured = { uri: nil, json: nil }
+
+      fake_response = Valkey::Bindings::ConnectionResponse.new
+      fake_response[:conn_ptr] = FFI::Pointer.new(0x1)
+
+      Valkey::Bindings.stub(:create_client_from_uri, lambda { |uri, json, _client_type, _callback|
+        captured[:uri] = uri
+        captured[:json] = json
+        fake_response.to_ptr
+      }) do
+        Valkey::Bindings.stub(:free_connection_response, nil) do
+          client = ::Valkey.new({ host: "localhost", port: 6379 }.merge(options))
+          client.instance_variable_set(:@connection, nil) # skip close's real FFI call
+        end
+      end
+
+      captured[:json].nil? ? {} : JSON.parse(captured[:json])
+    end
+
     # NOTE: "LowestLatency" is a valid read_from value per the FFI docs
     # (ffi/src/lib.rs) and is accepted by Ruby's validation, but the currently
     # vendored glide-core build panics with `todo!()` when converting it
     # (glide-core/src/client/types.rs, `impl From<protobuf::ConnectionRequest>`,
     # reached via ffi/src/lib.rs's create_client_from_uri -> ConnectionRequest::from).
-    # This is an upstream native-core gap, not a Ruby-side bug, so it is exercised
-    # in its own test below (skipped) rather than in the shared happy-path loops,
-    # which would otherwise abort the whole test process.
-    READ_FROM_VALUES_SAFE_TO_CONNECT = {
+    # This is an upstream native-core gap, not a Ruby-side bug. Because these
+    # tests stub the FFI call entirely, the panic can never actually be reached
+    # here -- but the value is still listed for completeness of the
+    # canonical-string/symbol mapping being verified.
+    READ_FROM_JSON_VALUES = {
       "Primary" => :primary,
       "PreferReplica" => :prefer_replica,
+      "LowestLatency" => :lowest_latency,
       "AZAffinity" => :az_affinity,
       "AZAffinityReplicasAndPrimary" => :az_affinity_replicas_and_primary
     }.freeze
@@ -28,32 +62,17 @@ module ValkeyTests
     # ====================
 
     def test_read_from_accepts_canonical_strings
-      READ_FROM_VALUES_SAFE_TO_CONNECT.each_key do |value|
-        client = ::Valkey.new(host: "localhost", port: 6379, read_from: value, lazy_connect: true)
-        assert_equal "PONG", client.ping
-        client.close
+      READ_FROM_JSON_VALUES.each_key do |value|
+        json_options = captured_json_options(read_from: value)
+        assert_equal value, json_options["read_from"]
       end
     end
 
     def test_read_from_accepts_ruby_friendly_symbols
-      READ_FROM_VALUES_SAFE_TO_CONNECT.each_value do |symbol|
-        client = ::Valkey.new(host: "localhost", port: 6379, read_from: symbol, lazy_connect: true)
-        assert_equal "PONG", client.ping
-        client.close
+      READ_FROM_JSON_VALUES.each do |expected_string, symbol|
+        json_options = captured_json_options(read_from: symbol)
+        assert_equal expected_string, json_options["read_from"]
       end
-    end
-
-    def test_read_from_lowest_latency_is_accepted_by_ruby_validation
-      # Ruby-side validation/serialization for "LowestLatency" is correct (it's
-      # one of the 5 canonical values documented in ffi/src/lib.rs), but the
-      # vendored glide-core build cannot actually service it -- see the module
-      # comment above. Skipped rather than asserted against a live connection
-      # to avoid crashing the whole test process on an upstream `todo!()` panic.
-      skip("LowestLatency read_from hits an unimplemented!() panic in the vendored glide-core build")
-
-      client = ::Valkey.new(host: "localhost", port: 6379, read_from: "LowestLatency", lazy_connect: true)
-      assert_equal "PONG", client.ping
-      client.close
     end
 
     def test_read_from_rejects_unknown_string
@@ -70,14 +89,18 @@ module ValkeyTests
       assert_match(/Invalid read_from value/, error.message)
     end
 
+    def test_read_from_omitted_when_not_provided
+      json_options = captured_json_options
+      refute json_options.key?("read_from")
+    end
+
     # ====================
     # client_az
     # ====================
 
     def test_client_az_accepts_string
-      client = ::Valkey.new(host: "localhost", port: 6379, client_az: "us-west-2a", lazy_connect: true)
-      assert_equal "PONG", client.ping
-      client.close
+      json_options = captured_json_options(client_az: "us-west-2a")
+      assert_equal "us-west-2a", json_options["client_az"]
     end
 
     def test_client_az_rejects_non_string
@@ -87,20 +110,23 @@ module ValkeyTests
       assert_match(/client_az must be a string/, error.message)
     end
 
+    def test_client_az_omitted_when_not_provided
+      json_options = captured_json_options
+      refute json_options.key?("client_az")
+    end
+
     # ====================
     # inflight_requests_limit
     # ====================
 
     def test_inflight_requests_limit_accepts_positive_integer
-      client = ::Valkey.new(host: "localhost", port: 6379, inflight_requests_limit: 1000, lazy_connect: true)
-      assert_equal "PONG", client.ping
-      client.close
+      json_options = captured_json_options(inflight_requests_limit: 1000)
+      assert_equal 1000, json_options["inflight_requests_limit"]
     end
 
     def test_inflight_requests_limit_accepts_zero
-      client = ::Valkey.new(host: "localhost", port: 6379, inflight_requests_limit: 0, lazy_connect: true)
-      assert_equal "PONG", client.ping
-      client.close
+      json_options = captured_json_options(inflight_requests_limit: 0)
+      assert_equal 0, json_options["inflight_requests_limit"]
     end
 
     def test_inflight_requests_limit_rejects_negative
@@ -117,72 +143,71 @@ module ValkeyTests
       assert_match(/inflight_requests_limit must be an integer/, error.message)
     end
 
+    def test_inflight_requests_limit_omitted_when_not_provided
+      json_options = captured_json_options
+      refute json_options.key?("inflight_requests_limit")
+    end
+
     # ====================
     # lazy_connect
     # ====================
 
-    def test_lazy_connect_true_still_allows_commands
-      client = ::Valkey.new(host: "localhost", port: 6379, lazy_connect: true)
-      assert_equal "PONG", client.ping
-      client.close
+    def test_lazy_connect_true_is_serialized
+      json_options = captured_json_options(lazy_connect: true)
+      assert_equal true, json_options["lazy_connect"]
     end
 
-    def test_lazy_connect_false_behaves_like_default
-      client = ::Valkey.new(host: "localhost", port: 6379, lazy_connect: false)
-      assert_equal "PONG", client.ping
-      client.close
+    def test_lazy_connect_false_is_omitted
+      # Matches the implementation: `lazy_connect` is only written to
+      # json_options when truthy, mirroring how other boolean-ish options in
+      # this file are handled (e.g. `cluster_mode_enabled`).
+      json_options = captured_json_options(lazy_connect: false)
+      refute json_options.key?("lazy_connect")
+    end
+
+    def test_lazy_connect_omitted_when_not_provided
+      json_options = captured_json_options
+      refute json_options.key?("lazy_connect")
     end
 
     # ====================
     # periodic_checks
     # ====================
 
-    def test_periodic_checks_accepts_manual_interval
-      client = ::Valkey.new(
-        host: "localhost",
-        port: 6379,
-        periodic_checks: { manual_interval: { duration_in_sec: 30 } },
-        lazy_connect: true
-      )
-      assert_equal "PONG", client.ping
-      client.close
+    def test_periodic_checks_serializes_manual_interval
+      json_options = captured_json_options(periodic_checks: { manual_interval: { duration_in_sec: 30 } })
+      assert_equal({ "manual_interval" => { "duration_in_sec" => 30 } }, json_options["periodic_checks"])
     end
 
-    def test_periodic_checks_accepts_manual_interval_with_string_keys
-      client = ::Valkey.new(
-        host: "localhost",
-        port: 6379,
-        periodic_checks: { "manual_interval" => { "duration_in_sec" => 30 } },
-        lazy_connect: true
-      )
-      assert_equal "PONG", client.ping
-      client.close
+    def test_periodic_checks_serializes_manual_interval_with_string_keys
+      json_options = captured_json_options(periodic_checks: { "manual_interval" => { "duration_in_sec" => 30 } })
+      assert_equal({ "manual_interval" => { "duration_in_sec" => 30 } }, json_options["periodic_checks"])
     end
 
-    def test_periodic_checks_accepts_disabled
-      client = ::Valkey.new(
-        host: "localhost",
-        port: 6379,
-        periodic_checks: { disabled: true },
-        lazy_connect: true
-      )
-      assert_equal "PONG", client.ping
-      client.close
+    def test_periodic_checks_serializes_disabled_true
+      json_options = captured_json_options(periodic_checks: { disabled: true })
+      assert_equal({ "disabled" => true }, json_options["periodic_checks"])
     end
 
-    def test_periodic_checks_is_a_noop_on_standalone
-      # periodic_checks is cluster-only in effect; standalone must accept it
-      # without raising, per the parent plan's key decision.
-      skip("only relevant for standalone mode") if cluster_mode?
+    def test_periodic_checks_serializes_disabled_false
+      json_options = captured_json_options(periodic_checks: { disabled: false })
+      assert_equal({ "disabled" => false }, json_options["periodic_checks"])
+    end
 
-      client = ::Valkey.new(
-        host: "localhost",
-        port: 6379,
-        periodic_checks: { manual_interval: { duration_in_sec: 5 } },
-        lazy_connect: true
-      )
-      assert_equal "PONG", client.ping
-      client.close
+    def test_periodic_checks_accepted_without_raising_regardless_of_mode
+      # periodic_checks is cluster-only in effect (topology refresh), but Ruby
+      # must accept and serialize it identically on standalone -- it's a no-op
+      # there, not rejected. Verified here by asserting the JSON shape is
+      # produced the same way regardless of `cluster_mode:`; this test does
+      # not depend on `cluster_mode?` because the Ruby-side code path is
+      # identical either way (see build_periodic_checks).
+      json_options = captured_json_options(periodic_checks: { manual_interval: { duration_in_sec: 5 } })
+      assert_equal({ "manual_interval" => { "duration_in_sec" => 5 } }, json_options["periodic_checks"])
+    end
+
+    def test_periodic_checks_omitted_when_not_provided
+      json_options = captured_json_options
+      refute json_options.key?("periodic_checks")
     end
 
     def test_periodic_checks_rejects_non_hash
@@ -226,6 +251,26 @@ module ValkeyTests
         ::Valkey.new(host: "localhost", port: 6379, periodic_checks: { disabled: "yes" })
       end
       assert_match(/periodic_checks disabled must be a boolean/, error.message)
+    end
+
+    # ====================
+    # Combined options (multiple options serialized together correctly)
+    # ====================
+
+    def test_multiple_options_serialize_independently
+      json_options = captured_json_options(
+        read_from: :prefer_replica,
+        client_az: "us-west-2a",
+        inflight_requests_limit: 500,
+        lazy_connect: true,
+        periodic_checks: { disabled: true }
+      )
+
+      assert_equal "PreferReplica", json_options["read_from"]
+      assert_equal "us-west-2a", json_options["client_az"]
+      assert_equal 500, json_options["inflight_requests_limit"]
+      assert_equal true, json_options["lazy_connect"]
+      assert_equal({ "disabled" => true }, json_options["periodic_checks"])
     end
   end
 end

--- a/test/valkey/connection_lifecycle_test.rb
+++ b/test/valkey/connection_lifecycle_test.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+# Connection-lifecycle tests: behavior on close and on connection timeout.
+#
+# Mirrors the sibling GLIDE clients:
+#   - test 4 (closed client): go/integTest/standalone_commands_test.go ->
+#     TestPing_ClosedClient; python .../test_async_client.py ->
+#     test_closed_client_raises_error (asserts "the client is closed")
+#   - test 5 (recreation): python -> test_client_recreation_after_close
+#   - test 6 (unavailable host): python -> test_connection_timeout_on_unavailable_host
+#   - test 7 (blocked server): node/tests/GlideClient.test.ts:1279
+#     "should handle connection timeout when client is blocked by long-running command";
+#     python -> test_connection_timeout_when_client_is_blocked
+#
+# All are standalone-shaped and skipped in cluster mode.
+module ValkeyTests
+  module ConnectionLifecycle
+    # =================================================================
+    # Test 4 — command on a closed client
+    # =================================================================
+
+    # should raise a connection error stating the client is closed when a
+    # command is issued after close
+    def test_closed_client_raises_error
+      skip("connection lifecycle tests only run on standalone mode") if cluster_mode?
+
+      client = _new_client
+      client.close
+
+      error = assert_raises(Valkey::ConnectionError) { client.set("foo", "bar") }
+      assert_match(/the client is closed/, error.message)
+    end
+
+    # =================================================================
+    # Test 5 — client recreation after close
+    # =================================================================
+
+    # should let a new client connect and round-trip set/get after a previous
+    # client was closed (the shared FFI pipe stays valid across lifecycles)
+    def test_client_recreation_after_close
+      skip("connection lifecycle tests only run on standalone mode") if cluster_mode?
+
+      key = "lifecycle:recreate"
+
+      client1 = _new_client
+      assert_equal "OK", client1.set(key, "v1")
+      assert_equal "v1", client1.get(key)
+      client1.close
+
+      client2 = _new_client
+      assert_equal "OK", client2.set(key, "v2")
+      assert_equal "v2", client2.get(key)
+      client2.del(key)
+      client2.close
+    end
+
+    # =================================================================
+    # Test 6 — connection timeout on an unavailable host
+    # =================================================================
+
+    # should fail fast (within ~2.5x the connect timeout) instead of hanging
+    # when connecting to an unreachable host
+    def test_connection_timeout_on_unavailable_host
+      skip("connection lifecycle tests only run on standalone mode") if cluster_mode?
+
+      connect_timeout = 1.0
+      # 192.0.2.1 is TEST-NET-1 (RFC 5737), reserved and unroutable, so the
+      # connect attempt hangs until the timeout rather than being refused or
+      # incurring DNS delay.
+      started = monotonic_now
+      assert_raises(Valkey::CannotConnectError) do
+        ::Valkey.new(
+          host: "192.0.2.1",
+          port: 6379,
+          connect_timeout: connect_timeout,
+          reconnect_attempts: 0
+        )
+      end
+      elapsed = monotonic_now - started
+
+      max_allowed = connect_timeout * 2.5
+      assert elapsed < max_allowed,
+             "connect took #{elapsed.round(2)}s, expected < #{max_allowed}s " \
+             "(connect_timeout not being respected)"
+    end
+
+    # =================================================================
+    # Test 7 — connection timeout while the server is blocked
+    # =================================================================
+
+    # should reject a new connection with a small connect timeout while the
+    # server is blocked by a long-running command, yet allow one with a
+    # generous timeout
+    def test_connection_timeout_when_server_is_blocked
+      skip("connection lifecycle tests only run on standalone mode") if cluster_mode?
+      skip("DEBUG SLEEP is not enabled on this server") unless debug_sleep_available?
+
+      blocker = _new_client
+      sleep_seconds = 3
+      blocker_thread = Thread.new do
+        # DEBUG SLEEP blocks the (single-threaded) server for the full duration
+        # even if this client's request times out first; the FFI command call
+        # releases the GVL, so the main thread keeps running.
+        blocker.send_command(Valkey::RequestType::CUSTOM_COMMAND, ["DEBUG", "SLEEP", sleep_seconds.to_s])
+      rescue Valkey::BaseError
+        nil # the assertions below are what matter
+      end
+
+      # Give the server a moment to enter the blocked state.
+      sleep(0.5)
+
+      # A short connection timeout must fail while the server is blocked.
+      assert_raises(Valkey::CannotConnectError) do
+        _new_client(connect_timeout: 0.1, reconnect_attempts: 0)
+      end
+
+      # A generous connection timeout should still connect once the block clears.
+      patient = _new_client(connect_timeout: 10.0)
+      assert_equal "PONG", patient.ping
+      patient.close
+    ensure
+      blocker_thread&.join
+      blocker&.close
+    end
+
+    private
+
+    def monotonic_now
+      Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    end
+
+    # Probes whether DEBUG SLEEP is permitted on the server (it requires
+    # enable-debug-command). Uses the shared client and a zero-length sleep.
+    def debug_sleep_available?
+      r.send_command(Valkey::RequestType::CUSTOM_COMMAND, ["DEBUG", "SLEEP", "0"])
+      true
+    rescue Valkey::CommandError
+      false
+    end
+  end
+end

--- a/test/valkey/connection_lifecycle_test.rb
+++ b/test/valkey/connection_lifecycle_test.rb
@@ -50,7 +50,6 @@ module ValkeyTests
     # when connecting to an unreachable host
     def test_connection_timeout_on_unavailable_host
       skip("connection lifecycle tests only run on standalone mode") if cluster_mode?
-      skip("connect_timeout not enforced by the native sync client for an unreachable host; hangs CI (see PR #114)")
 
       connect_timeout = 1.0
       # 192.0.2.1 is TEST-NET-1 (RFC 5737), reserved and unroutable, so the
@@ -62,7 +61,7 @@ module ValkeyTests
           host: "192.0.2.1",
           port: 6379,
           connect_timeout: connect_timeout,
-          reconnect_attempts: 1
+          reconnect_attempts: 1 # Should be zero however issue #117 blocks this.
         )
       end
       elapsed = monotonic_now - started
@@ -96,7 +95,7 @@ module ValkeyTests
 
       # A short connection timeout must fail while the server is blocked.
       assert_raises(Valkey::CannotConnectError) do
-        _new_client(connect_timeout: 0.1, reconnect_attempts: 1)
+        _new_client(connect_timeout: 0.1, reconnect_attempts: 1) # Should be zero however issue #117 blocks this.
       end
 
       # A generous connection timeout should still connect once the block clears.

--- a/test/valkey/connection_lifecycle_test.rb
+++ b/test/valkey/connection_lifecycle_test.rb
@@ -15,10 +15,6 @@
 # All are standalone-shaped and skipped in cluster mode.
 module ValkeyTests
   module ConnectionLifecycle
-    # =================================================================
-    # Test 4 — command on a closed client
-    # =================================================================
-
     # should raise a connection error stating the client is closed when a
     # command is issued after close
     def test_closed_client_raises_error
@@ -30,10 +26,6 @@ module ValkeyTests
       error = assert_raises(Valkey::ConnectionError) { client.set("foo", "bar") }
       assert_match(/the client is closed/, error.message)
     end
-
-    # =================================================================
-    # Test 5 — client recreation after close
-    # =================================================================
 
     # should let a new client connect and round-trip set/get after a previous
     # client was closed (the shared FFI pipe stays valid across lifecycles)
@@ -53,10 +45,6 @@ module ValkeyTests
       client2.del(key)
       client2.close
     end
-
-    # =================================================================
-    # Test 6 — connection timeout on an unavailable host
-    # =================================================================
 
     # should fail fast (within ~2.5x the connect timeout) instead of hanging
     # when connecting to an unreachable host
@@ -91,10 +79,6 @@ module ValkeyTests
              "connect took #{elapsed.round(2)}s, expected < #{max_allowed}s " \
              "(connect_timeout not being respected)"
     end
-
-    # =================================================================
-    # Test 7 — connection timeout while the server is blocked
-    # =================================================================
 
     # should reject a new connection with a small connect timeout while the
     # server is blocked by a long-running command, yet allow one with a

--- a/test/valkey/connection_lifecycle_test.rb
+++ b/test/valkey/connection_lifecycle_test.rb
@@ -50,13 +50,6 @@ module ValkeyTests
     # when connecting to an unreachable host
     def test_connection_timeout_on_unavailable_host
       skip("connection lifecycle tests only run on standalone mode") if cluster_mode?
-      # DISABLED: the synchronous FFI connect path (create_client_from_uri) does
-      # not honor connection_timeout when the host is unreachable, so Valkey.new
-      # never returns and hangs the entire standalone suite (30-min CI cap on
-      # every matrix cell). The Ruby side forwards connection_timeout and
-      # reconnect_attempts: 0 correctly; the gap is in glide-core's sync client
-      # (the async Python/Node clients this test mirrors do enforce it).
-      # Re-enable once the native fix lands. See PR #114.
       skip("connect_timeout not enforced by the native sync client for an unreachable host; hangs CI (see PR #114)")
 
       connect_timeout = 1.0
@@ -69,7 +62,7 @@ module ValkeyTests
           host: "192.0.2.1",
           port: 6379,
           connect_timeout: connect_timeout,
-          reconnect_attempts: 0
+          reconnect_attempts: 1
         )
       end
       elapsed = monotonic_now - started
@@ -103,7 +96,7 @@ module ValkeyTests
 
       # A short connection timeout must fail while the server is blocked.
       assert_raises(Valkey::CannotConnectError) do
-        _new_client(connect_timeout: 0.1, reconnect_attempts: 0)
+        _new_client(connect_timeout: 0.1, reconnect_attempts: 1)
       end
 
       # A generous connection timeout should still connect once the block clears.

--- a/test/valkey/connection_lifecycle_test.rb
+++ b/test/valkey/connection_lifecycle_test.rb
@@ -62,6 +62,14 @@ module ValkeyTests
     # when connecting to an unreachable host
     def test_connection_timeout_on_unavailable_host
       skip("connection lifecycle tests only run on standalone mode") if cluster_mode?
+      # DISABLED: the synchronous FFI connect path (create_client_from_uri) does
+      # not honor connection_timeout when the host is unreachable, so Valkey.new
+      # never returns and hangs the entire standalone suite (30-min CI cap on
+      # every matrix cell). The Ruby side forwards connection_timeout and
+      # reconnect_attempts: 0 correctly; the gap is in glide-core's sync client
+      # (the async Python/Node clients this test mirrors do enforce it).
+      # Re-enable once the native fix lands. See PR #114.
+      skip("connect_timeout not enforced by the native sync client for an unreachable host; hangs CI (see PR #114)")
 
       connect_timeout = 1.0
       # 192.0.2.1 is TEST-NET-1 (RFC 5737), reserved and unroutable, so the
@@ -132,7 +140,7 @@ module ValkeyTests
     # Probes whether DEBUG SLEEP is permitted on the server (it requires
     # enable-debug-command). Uses the shared client and a zero-length sleep.
     def debug_sleep_available?
-      r.send_command(Valkey::RequestType::CUSTOM_COMMAND, ["DEBUG", "SLEEP", "0"])
+      r.send_command(Valkey::RequestType::CUSTOM_COMMAND, %w[DEBUG SLEEP 0])
       true
     rescue Valkey::CommandError
       false

--- a/test/valkey/failover_commands_test.rb
+++ b/test/valkey/failover_commands_test.rb
@@ -14,6 +14,8 @@ module ValkeyTests
     # should return "OK" and flip the connected primary's role to slave once
     # the coordinated failover to its replica completes.
     def test_failover_promotes_replica_and_returns_ok
+      skip("This sometimes hang. Unsure if it is a client bug. See https://github.com/valkey-io/valkey-glide-ruby/issues/117")
+
       with_standalone_replica do |primary|
         Timeout.timeout(FAILOVER_TEST_DEADLINE) do
           assert_equal "master", primary.info("replication")["role"]

--- a/test/valkey/failover_commands_test.rb
+++ b/test/valkey/failover_commands_test.rb
@@ -14,8 +14,6 @@ module ValkeyTests
     # should return "OK" and flip the connected primary's role to slave once
     # the coordinated failover to its replica completes.
     def test_failover_promotes_replica_and_returns_ok
-      skip("This sometimes hang. Unsure if it is a client bug. See https://github.com/valkey-io/valkey-glide-ruby/issues/117")
-
       with_standalone_replica do |primary|
         Timeout.timeout(FAILOVER_TEST_DEADLINE) do
           assert_equal "master", primary.info("replication")["role"]

--- a/test/valkey/failover_commands_test.rb
+++ b/test/valkey/failover_commands_test.rb
@@ -28,7 +28,7 @@ module ValkeyTests
       assert_equal ["ABORT"], capture_failover_args(abort: true, timeout: 5000)
     end
 
-    # should not emit "FORCE" unless a TO target is supplied
+    # should not send "FORCE" unless a TO target is supplied
     def test_failover_force_without_target_omits_force
       assert_equal [], capture_failover_args(force: true)
     end

--- a/test/valkey/failover_commands_test.rb
+++ b/test/valkey/failover_commands_test.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+# Integration test for the standalone FAILOVER command.
+# NOTE: FAILOVER is a standalone-only command.
+module ValkeyTests
+  module FailoverCommands
+    # should return "OK" and flip the connected primary's role to slave once
+    # the coordinated failover to its replica completes
+    def test_failover_promotes_replica_and_returns_ok
+      with_standalone_replica do |primary|
+        assert_equal "master", primary.info("replication")["role"]
+
+        assert_equal "OK", primary.failover
+
+        assert wait_for_role?(primary, "slave"),
+               "timed out waiting for the primary to become a replica (role:slave)"
+      end
+    end
+
+    # should raise a error when ABORT is requested but no failover is
+    # currently in progress
+    def test_failover_abort_with_no_failover_in_progress_raises
+      assert_raises(Valkey::CommandError) { r.failover(abort: true) }
+    end
+
+    # should send "ABORT" only
+    def test_failover_abort_sends_abort_only
+      assert_equal ["ABORT"], capture_failover_args(abort: true, timeout: 5000)
+    end
+
+    # should not emit "FORCE" unless a TO target is supplied
+    def test_failover_force_without_target_omits_force
+      assert_equal [], capture_failover_args(force: true)
+    end
+
+    # should build "TO host port FORCE TIMEOUT ms" in order for a full request
+    def test_failover_builds_full_arg_list_in_order
+      args = capture_failover_args(to: "127.0.0.1 6380", force: true, timeout: 5000)
+      assert_equal ["TO", "127.0.0.1", "6380", "FORCE", "TIMEOUT", "5000"], args
+    end
+
+    private
+
+    # Replace the send_command method used by failover() with a stub which captures the arguments and returns "OK".
+    # This allows us to see the arguments passed to the failover command without actually executing it.
+    def capture_failover_args(**options)
+      captured = nil
+      stub = lambda do |_request_type, args = [], &_block|
+        captured = args
+        "OK"
+      end
+      r.stub(:send_command, stub) { r.failover(**options) }
+      captured
+    end
+
+    # Start a standalone primary with one replica and yields a
+    # client connected to the primary. Cleans up afterward.
+    def with_standalone_replica
+      cluster = Valkey::TestCluster.new(
+        cluster_mode: false,
+        shard_count: 1,
+        replica_count: 1
+      )
+      primary_addr = cluster.addresses.first
+      client = Valkey.new(host: primary_addr[:host], port: primary_addr[:port], timeout: 5.0)
+      yield(client)
+    rescue Valkey::TestCluster::PythonNotFoundError, Valkey::TestCluster::ScriptNotFoundError => e
+      skip("requires python3 + valkey-glide submodule for replica setup: #{e.message}")
+    ensure
+      client&.close
+      cluster&.close
+    end
+
+    # Polls INFO REPLICATION until role matches (or times out).
+    def wait_for_role?(client, role, attempts: 60, interval: 0.5)
+      attempts.times do
+        return true if client.info("replication")["role"] == role
+
+        sleep(interval)
+      end
+      false
+    end
+  end
+end

--- a/test/valkey/failover_commands_test.rb
+++ b/test/valkey/failover_commands_test.rb
@@ -1,20 +1,35 @@
 # frozen_string_literal: true
 
+require "timeout"
+
 # Integration test for the standalone FAILOVER command.
 # NOTE: FAILOVER is a standalone-only command.
 module ValkeyTests
   module FailoverCommands
+    FAILOVER_TIMEOUT_MS = 10_000
+
+    # Wall-clock backstop, above the wait_for_role? budget (60 * 0.5s = 30s).
+    FAILOVER_TEST_DEADLINE = 45
+
     # should return "OK" and flip the connected primary's role to slave once
-    # the coordinated failover to its replica completes
+    # the coordinated failover to its replica completes.
     def test_failover_promotes_replica_and_returns_ok
       with_standalone_replica do |primary|
-        assert_equal "master", primary.info("replication")["role"]
+        Timeout.timeout(FAILOVER_TEST_DEADLINE) do
+          assert_equal "master", primary.info("replication")["role"]
 
-        assert_equal "OK", primary.failover
+          # FAILOVER's TIMEOUT bounds the wait server-side; without it the wait is
+          # "infinite" and the blocking command never returns. See
+          # https://valkey.io/commands/failover/
+          assert_equal "OK", primary.failover(timeout: FAILOVER_TIMEOUT_MS)
 
-        assert wait_for_role?(primary, "slave"),
-               "timed out waiting for the primary to become a replica (role:slave)"
+          assert wait_for_role?(primary, "slave"),
+                 "timed out waiting for the primary to become a replica (role:slave)"
+        end
       end
+    rescue Timeout::Error
+      flunk("failover did not complete within #{FAILOVER_TEST_DEADLINE}s " \
+            "(client likely hanged during the role transition)")
     end
 
     # should raise a error when ABORT is requested but no failover is


### PR DESCRIPTION
## Overview

Adds 5 new `Valkey.new` constructor options — `read_from`, `client_az`,
`inflight_requests_limit`, `lazy_connect`, `periodic_checks` — as passthrough
`extra_options_json` keys on the existing `create_client_from_uri` FFI path.
No new FFI surface, no protobuf changes. This is PR 1 of 3 in the
connection-config-parity plan (`docs/cluster-connection-config-parity-implementation-plan.md`);
`pubsub_subscriptions` and `iam_credentials` are split into follow-up PRs.

Each option is validated in Ruby before serialization (raising `ArgumentError`
on invalid input), matching the existing pattern already used for
`protocol:`/`client_name:`/`connection_retry_strategy:` in `lib/valkey.rb`.

## Related Issue

Closes #127 

