### PR TITLE
feat(ruby): persist cluster_mode state on client instance

### DIFF
--- a/lib/valkey.rb
+++ b/lib/valkey.rb
@@ -382,7 +382,8 @@ class Valkey
     json_options = {}
 
     # Cluster mode
-    json_options["cluster_mode_enabled"] = true if options[:cluster_mode]
+    @cluster_mode = options[:cluster_mode] ? true : false
+    json_options["cluster_mode_enabled"] = true if @cluster_mode
 
     # Protocol
     json_options["protocol"] = case options[:protocol]
@@ -557,6 +558,13 @@ class Valkey
     @queued_commands = []
     # Track if we're inside a multi block (multi { ... }) vs direct multi calls
     @in_multi_block = false
+  end
+
+  # Whether this client was configured for cluster mode.
+  #
+  # @return [Boolean] true if the client was created with `cluster_mode: true`
+  def cluster_mode?
+    @cluster_mode
   end
 
   def close

--- a/test/valkey/uri_connection_test.rb
+++ b/test/valkey/uri_connection_test.rb
@@ -853,6 +853,31 @@ module ValkeyTests
       # Expected if no cluster
     end
 
+    def test_cluster_mode_predicate_true_when_enabled
+      skip("URI connection tests only run on standalone mode") if cluster_mode?
+      # cluster_mode: true against a standalone server requires an actual reachable
+      # cluster node to construct successfully (the client validates topology on
+      # connect) - use the same single-node cluster target as
+      # test_cluster_mode_with_single_node above, and skip if no cluster is running
+      # on port 7000 rather than asserting against an unreachable target.
+      client = ::Valkey.new(
+        nodes: [{ host: "localhost", port: 7000 }],
+        cluster_mode: true,
+        connect_timeout: 1.0
+      )
+      assert client.cluster_mode?
+      client.close
+    rescue ::Valkey::CannotConnectError
+      skip("No cluster node reachable on port 7000 to verify cluster_mode? against a live connection")
+    end
+
+    def test_cluster_mode_predicate_false_by_default
+      skip("URI connection tests only run on standalone mode") if cluster_mode?
+      client = ::Valkey.new(host: "localhost", port: 6379)
+      refute client.cluster_mode?
+      client.close
+    end
+
     # ====================
     # COMBINED EDGE CASES
     # ====================


### PR DESCRIPTION
## Overview

Adds real `cluster_mode?` instance state to `Valkey` client instance. This is a small, self-contained addition with no consumer behavior attached to it.

## Related Issue

Closes #122 
