### PR TITLE
Implement generic command execution: call(), call_v()

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,45 @@ end
 
 > **Note:** Transactional commands (`MULTI` / `EXEC` / `DISCARD`) in a pipeline are executed sequentially as a workaround for FFI batch stability. Prefer `multi` / `exec` on the main client for transactions.
 
+### Generic Command Dispatch (`call` / `call_v`)
+
+Not every command has a dedicated method yet. `call`/`call_v` are the escape hatch — send any
+command as plain arguments and get the raw reply back, matching `redis-client`'s `#call`/`#call_v`:
+
+```ruby
+client.call("SET", "mykey", "value")
+# => "OK"
+
+client.call_v(["MGET"] + keys)
+```
+
+`call`/`call_v` apply the same argument coercion as `redis-client`:
+
+```ruby
+# Integers/Floats auto-stringify
+client.call("SET", "mykey", 42)
+# equivalent to call("SET", "mykey", "42")
+
+# Arrays flatten (including nested arrays)
+client.call("LPUSH", "list", [1, 2, 3])
+# equivalent to call("LPUSH", "list", "1", "2", "3")
+
+# Hashes flatten to alternating key/value
+client.call("HMSET", "hash", { "foo" => "1" })
+# equivalent to call("HMSET", "hash", "foo", "1")
+
+# Keyword args become trailing command flags (call only, not call_v):
+# a truthy value emits the upcased flag name; a non-boolean value also emits
+# the stringified value. Falsy/nil values are dropped entirely, not stringified.
+client.call("SET", "k", "v", nx: true, ex: 60)
+# equivalent to call("SET", "k", "v", "NX", "EX", "60")
+client.call("SET", "k", "v", nx: false, ex: nil)
+# equivalent to call("SET", "k", "v")
+```
+
+`call_v` takes the whole command as a single Array (no keyword flags) — useful when the command is
+built dynamically. Both return the raw reply with no type-casting based on the command name.
+
 ### Connection Options (redis-rb compatible)
 
 | Option | Description |

--- a/lib/valkey/commands/generic_commands.rb
+++ b/lib/valkey/commands/generic_commands.rb
@@ -571,17 +571,25 @@ class Valkey
 
       # Flattens Arrays and Hashes (to alternating key/value) and stringifies
       # Integers/Floats, matching `redis-client`'s documented `#call`/`#call_v` behavior.
-      def flatten_call_args(args)
-        args.flat_map do |arg|
+      #
+      # Appends into a single accumulator instead of flat_map + recursive return
+      # values, which would allocate a new intermediate array at every nesting
+      # level for large/deeply-nested inputs.
+      def flatten_call_args(args, acc = [])
+        args.each do |arg|
           case arg
           when Array
-            flatten_call_args(arg)
+            flatten_call_args(arg, acc)
           when Hash
-            flatten_call_args(arg.to_a.flatten(1))
+            arg.each do |key, value|
+              acc << key.to_s
+              flatten_call_args([value], acc)
+            end
           else
-            arg.to_s
+            acc << arg.to_s
           end
         end
+        acc
       end
 
       # Converts `call`'s **kwargs into trailing command flags: a truthy value emits

--- a/lib/valkey/commands/generic_commands.rb
+++ b/lib/valkey/commands/generic_commands.rb
@@ -541,7 +541,7 @@ class Valkey
       #   valkey.call("SET", "k", "v", nx: true, ex: 60)
       #     # equivalent to call("SET", "k", "v", "NX", "EX", "60")
       #
-      # @param [Array<String, Integer, Float, Array, Hash>] args command name and its arguments
+      # @param [Array<String, Integer, Float, Array, Hash>] argv command name and its arguments
       # @param [Hash] kwargs trailing command flags; truthy values emit the upcased flag name,
       #   non-boolean values also emit the stringified value; falsy/nil values are dropped
       # @return [Object] the raw reply, with no type-casting based on the command name

--- a/lib/valkey/commands/generic_commands.rb
+++ b/lib/valkey/commands/generic_commands.rb
@@ -559,12 +559,12 @@ class Valkey
       # @example
       #   valkey.call_v(["MGET"] + keys)
       #
-      # @param [Array<String, Integer, Float, Array, Hash>] args command name and its arguments
+      # @param [Array<String, Integer, Float, Array, Hash>] argv command name and its arguments
       # @return [Object] the raw reply, with no type-casting based on the command name
       #
       # @see https://valkey.io/commands/
       def call_v(argv)
-        send_command(RequestType::CUSTOM_COMMAND, flatten_call_args(args))
+        send_command(RequestType::CUSTOM_COMMAND, flatten_call_args(argv))
       end
 
       private

--- a/lib/valkey/commands/generic_commands.rb
+++ b/lib/valkey/commands/generic_commands.rb
@@ -600,12 +600,16 @@ class Valkey
       # Converts `call`'s **kwargs into trailing command flags: a truthy value emits
       # the upcased flag name, and a non-boolean truthy value also emits the
       # stringified value. Falsy/nil values are dropped entirely, not stringified.
+      #
+      # @example
+      #   call_flags(nx: true, ex: 60, cond: false, ttl: nil)
+      #   # => ["NX", "EX", "60"]
       def call_flags(kwargs)
         kwargs.each_with_object([]) do |(name, value), flags|
           next unless value
 
           flags << name.to_s.upcase
-          flags << value.to_s unless [true, false].include?(value)
+          flags << value.to_s unless value == true
         end
       end
     end

--- a/lib/valkey/commands/generic_commands.rb
+++ b/lib/valkey/commands/generic_commands.rb
@@ -547,8 +547,8 @@ class Valkey
       # @return [Object] the raw reply, with no type-casting based on the command name
       #
       # @see https://valkey.io/commands/
-      def call(*args, **kwargs)
-        send_command(RequestType::CUSTOM_COMMAND, flatten_call_args(args) + call_flags(kwargs))
+      def call(*argv, **kwargs)
+        send_command(RequestType::CUSTOM_COMMAND, flatten_call_args(argv).concat(call_flags(kwargs)))
       end
 
       # Send any command as a single Array of arguments and get the raw reply back.
@@ -563,7 +563,7 @@ class Valkey
       # @return [Object] the raw reply, with no type-casting based on the command name
       #
       # @see https://valkey.io/commands/
-      def call_v(args)
+      def call_v(argv)
         send_command(RequestType::CUSTOM_COMMAND, flatten_call_args(args))
       end
 

--- a/lib/valkey/commands/generic_commands.rb
+++ b/lib/valkey/commands/generic_commands.rb
@@ -520,6 +520,81 @@ class Valkey
 
         send_command(command, args, &block)
       end
+
+      # Send any command as plain arguments and get the raw reply back, with no
+      # per-command method needed. Escape hatch for commands without a dedicated
+      # method yet, matching `redis-client`'s `#call`.
+      #
+      # @example Basic dispatch
+      #   valkey.call("SET", "mykey", "value")
+      #     # => "OK"
+      # @example Integers/Floats auto-stringify
+      #   valkey.call("SET", "mykey", 42)
+      #     # equivalent to call("SET", "mykey", "42")
+      # @example Arrays flatten
+      #   valkey.call("LPUSH", "list", [1, 2, 3])
+      #     # equivalent to call("LPUSH", "list", "1", "2", "3")
+      # @example Hashes flatten to alternating key/value
+      #   valkey.call("HMSET", "hash", { "foo" => "1" })
+      #     # equivalent to call("HMSET", "hash", "foo", "1")
+      # @example Keyword args become command flags; falsy/nil flags are dropped
+      #   valkey.call("SET", "k", "v", nx: true, ex: 60)
+      #     # equivalent to call("SET", "k", "v", "NX", "EX", "60")
+      #
+      # @param [Array<String, Integer, Float, Array, Hash>] args command name and its arguments
+      # @param [Hash] kwargs trailing command flags; truthy values emit the upcased flag name,
+      #   non-boolean values also emit the stringified value; falsy/nil values are dropped
+      # @return [Object] the raw reply, with no type-casting based on the command name
+      #
+      # @see https://valkey.io/commands/
+      def call(*args, **kwargs)
+        send_command(RequestType::CUSTOM_COMMAND, flatten_call_args(args) + call_flags(kwargs))
+      end
+
+      # Send any command as a single Array of arguments and get the raw reply back.
+      # Same as {#call} but takes the whole command as one Array instead of splatted
+      # args, useful when the command is built dynamically. Matches `redis-client`'s
+      # `#call_v` — no keyword flags.
+      #
+      # @example
+      #   valkey.call_v(["MGET"] + keys)
+      #
+      # @param [Array<String, Integer, Float, Array, Hash>] args command name and its arguments
+      # @return [Object] the raw reply, with no type-casting based on the command name
+      #
+      # @see https://valkey.io/commands/
+      def call_v(args)
+        send_command(RequestType::CUSTOM_COMMAND, flatten_call_args(args))
+      end
+
+      private
+
+      # Flattens Arrays and Hashes (to alternating key/value) and stringifies
+      # Integers/Floats, matching `redis-client`'s documented `#call`/`#call_v` behavior.
+      def flatten_call_args(args)
+        args.flat_map do |arg|
+          case arg
+          when Array
+            flatten_call_args(arg)
+          when Hash
+            flatten_call_args(arg.to_a.flatten(1))
+          else
+            arg.to_s
+          end
+        end
+      end
+
+      # Converts `call`'s **kwargs into trailing command flags: a truthy value emits
+      # the upcased flag name, and a non-boolean truthy value also emits the
+      # stringified value. Falsy/nil values are dropped entirely, not stringified.
+      def call_flags(kwargs)
+        kwargs.each_with_object([]) do |(name, value), flags|
+          next unless value
+
+          flags << name.to_s.upcase
+          flags << value.to_s unless [true, false].include?(value)
+        end
+      end
     end
   end
 end

--- a/lib/valkey/commands/generic_commands.rb
+++ b/lib/valkey/commands/generic_commands.rb
@@ -572,23 +572,28 @@ class Valkey
       # Flattens Arrays and Hashes (to alternating key/value) and stringifies
       # Integers/Floats, matching `redis-client`'s documented `#call`/`#call_v` behavior.
       #
-      # Appends into a single accumulator instead of flat_map + recursive return
-      # values, which would allocate a new intermediate array at every nesting
-      # level for large/deeply-nested inputs.
-      def flatten_call_args(args, acc = [])
-        args.each do |arg|
+      # @example
+      #   flatten_call_args(["CMD", [1, [2, 3]], { "a" => 1, "b" => [2, 3] }])
+      #   # => ["CMD", "1", "2", "3", "a", "1", "b", "2", "3"]
+      def flatten_call_args(args)
+        acc = []
+        # Ruby doesn't have a built in queue, so we use a reversed stack instead
+        # Insertions into the stack needs to be reversed to maintain the Queue LIFO
+        # ordering
+        stack = args.reverse
+
+        until stack.empty?
+          arg = stack.pop
           case arg
           when Array
-            flatten_call_args(arg, acc)
+            stack.concat(arg.reverse)
           when Hash
-            arg.each do |key, value|
-              acc << key.to_s
-              flatten_call_args([value], acc)
-            end
+            arg.to_a.reverse_each { |pair| stack.concat(pair.reverse) }
           else
             acc << arg.to_s
           end
         end
+
         acc
       end
 

--- a/test/cluster/cluster_commands_test.rb
+++ b/test/cluster/cluster_commands_test.rb
@@ -30,6 +30,7 @@ class TestClusterCommands < Minitest::Test
 
   # ValkeyTests modules without conflicting setup methods
   include ValkeyTests::Bitpos
+  include ValkeyTests::Call
   include ValkeyTests::GenericCommands
   include ValkeyTests::Scanning
   include ValkeyTests::ScriptingCommands

--- a/test/lint/generic_commands.rb
+++ b/test/lint/generic_commands.rb
@@ -384,6 +384,38 @@ module Lint
       assert_equal r.wait(0, 0), 0
     end
 
+    # call/call_v generic-command primitive tests
+    #
+    # These mirror how sibling clients (Go/Python/Node) actually use their own
+    # generic-command primitive throughout their own test suites: as a utility for
+    # fetching diagnostic info (CLIENT INFO, CLUSTER NODES) other tests lean on,
+    # not just as an isolated unit-tested method.
+
+    def test_call_client_info
+      info = r.call("CLIENT", "INFO")
+
+      assert_kind_of String, info
+      assert_includes info, "id="
+    end
+
+    def test_call_cluster_nodes
+      skip("CLUSTER NODES only meaningful in cluster mode") unless cluster_mode?
+
+      nodes = r.call("CLUSTER", "NODES")
+
+      assert_kind_of String, nodes
+      refute_empty nodes
+    end
+
+    def test_call_v_dbsize
+      r.set("call_v:probe", "1")
+
+      size = r.call_v(["DBSIZE"])
+
+      assert_kind_of Integer, size
+      assert size >= 1
+    end
+
     # Keys command tests
 
     def test_keys

--- a/test/standalone/valkey_test.rb
+++ b/test/standalone/valkey_test.rb
@@ -10,7 +10,7 @@ class TestStandaloneValkey < Minitest::Test
   # ValkeyTests modules for valkey-glide-ruby specific functionality
   include ValkeyTests::AuthCommands
   include ValkeyTests::Bitpos
-
+  include ValkeyTests::Call
   include ValkeyTests::ConnectionLifecycle
   include ValkeyTests::FailoverCommands
   include ValkeyTests::FunctionCommands

--- a/test/valkey/call_test.rb
+++ b/test/valkey/call_test.rb
@@ -52,6 +52,19 @@ module ValkeyTests
       assert_equal "v", r.call("GET", "call:e2e:flagged")
     end
 
+    # should apply the same Array/Hash flattening end-to-end via call_v's
+    # single-Array argument (mirrors test_call_end_to_end_with_flattening_and_flags
+    # for call — no kwargs/flags case here, since call_v doesn't take any).
+    def test_call_v_end_to_end_with_flattening
+      r.del("call:v:e2e:list", "call:v:e2e:hash")
+
+      assert_equal 3, r.call_v(["LPUSH", "call:v:e2e:list", [1, 2, 3]])
+      assert_equal %w[3 2 1], r.call_v(["LRANGE", "call:v:e2e:list", 0, -1])
+
+      assert_equal "OK", r.call_v(["HMSET", "call:v:e2e:hash", { "foo" => "1" }])
+      assert_equal "1", r.call_v(["HGET", "call:v:e2e:hash", "foo"])
+    end
+
     # Everything below stubs `send_command` (same technique as `capture_failover_args`
     # in failover_commands_test.rb) to assert on the literal flattened/coerced
     # argument array before it ever reaches the network — independent of any

--- a/test/valkey/call_test.rb
+++ b/test/valkey/call_test.rb
@@ -90,9 +90,12 @@ module ValkeyTests
       assert_equal %w[CMD k foo 1 2], capture_call_args("CMD", "k", { "foo" => [1, 2] })
     end
 
-    # should apply the same flattening to call_v's single Array argument
+    # should apply the same flattening to call_v's single Array argument,
+    # including a Hash value that is itself an Array (mirrors
+    # test_call_arg_construction_flattens_hash_with_array_values for call)
     def test_call_v_arg_construction_flattens
       assert_equal %w[LPUSH list 1 2 3], capture_call_v_args(["LPUSH", "list", [1, 2, 3]])
+      assert_equal %w[CMD k foo 1 2], capture_call_v_args(["CMD", "k", { "foo" => [1, 2] }])
     end
 
     # should append upcased flag names for truthy boolean kwargs, in the order given

--- a/test/valkey/call_test.rb
+++ b/test/valkey/call_test.rb
@@ -81,5 +81,96 @@ module ValkeyTests
       assert_equal "OK", r.call("SET", "call:flags2", "v", nx: false, ex: nil)
       assert_equal(-1, r.ttl("call:flags2"))
     end
+
+    # The tests above exercise flattening/coercion indirectly, through server-visible
+    # side effects (e.g. LPUSH's returned length, LRANGE's returned order) — they
+    # confirm the server *received something equivalent*, not the exact argument
+    # array `call`/`call_v` constructed. These stub `send_command` (same technique as
+    # `capture_failover_args` in failover_commands_test.rb) to assert on the literal
+    # flattened/coerced array before it ever reaches the network, independent of any
+    # particular command's server-side semantics.
+
+    # should pass args through unchanged when they are already flat strings
+    def test_call_arg_construction_passthrough
+      assert_equal %w[SET k v], capture_call_args("SET", "k", "v")
+    end
+
+    # should stringify Integer/Float args without flattening them
+    def test_call_arg_construction_stringifies_integers_and_floats
+      assert_equal %w[SET k 42], capture_call_args("SET", "k", 42)
+      assert_equal %w[SET k 3.5], capture_call_args("SET", "k", 3.5)
+    end
+
+    # should flatten a single Array arg into its own separate elements, in order
+    def test_call_arg_construction_flattens_array
+      assert_equal %w[LPUSH list 1 2 3], capture_call_args("LPUSH", "list", [1, 2, 3])
+    end
+
+    # should recursively flatten nested Arrays, not just one level deep
+    def test_call_arg_construction_flattens_nested_array
+      assert_equal %w[LPUSH list 1 2 3 4], capture_call_args("LPUSH", "list", [1, [2, [3, 4]]])
+    end
+
+    # should flatten a Hash arg to alternating key/value strings, preserving pair order
+    def test_call_arg_construction_flattens_hash
+      assert_equal %w[HMSET hash foo 1 bar 2], capture_call_args("HMSET", "hash", { "foo" => 1, "bar" => 2 })
+    end
+
+    # should flatten a Hash whose values are Arrays (key preserved, value flattened)
+    def test_call_arg_construction_flattens_hash_with_array_values
+      assert_equal %w[CMD k foo 1 2], capture_call_args("CMD", "k", { "foo" => [1, 2] })
+    end
+
+    # should apply the same flattening to call_v's single Array argument
+    def test_call_v_arg_construction_flattens
+      assert_equal %w[LPUSH list 1 2 3], capture_call_v_args(["LPUSH", "list", [1, 2, 3]])
+    end
+
+    # should append upcased flag names for truthy boolean kwargs, in the order given
+    def test_call_arg_construction_boolean_flags
+      assert_equal %w[SET k v NX], capture_call_args("SET", "k", "v", nx: true)
+    end
+
+    # should append both the upcased flag name and its stringified value for
+    # non-boolean truthy kwargs
+    def test_call_arg_construction_value_flags
+      assert_equal %w[SET k v EX 60], capture_call_args("SET", "k", "v", ex: 60)
+    end
+
+    # should drop false-valued and nil-valued kwargs entirely, not stringify them
+    def test_call_arg_construction_drops_falsy_and_nil_flags
+      assert_equal %w[SET k v], capture_call_args("SET", "k", "v", nx: false, ex: nil)
+    end
+
+    # should combine positional flattening and trailing flags in a single call,
+    # flags always appended after all positional (including flattened) args
+    def test_call_arg_construction_combines_flattening_and_flags
+      assert_equal %w[SET k v NX EX 60], capture_call_args("SET", "k", "v", nx: true, ex: 60)
+    end
+
+    private
+
+    # Replaces send_command with a stub that captures the args call() built, without
+    # dispatching to the server. Mirrors capture_failover_args in
+    # failover_commands_test.rb.
+    def capture_call_args(*args, **kwargs)
+      captured = nil
+      stub = lambda do |_request_type, sent_args = [], &_block|
+        captured = sent_args
+        "OK"
+      end
+      r.stub(:send_command, stub) { r.call(*args, **kwargs) }
+      captured
+    end
+
+    def capture_call_v_args(args)
+      captured = nil
+      stub = lambda do |_request_type, sent_args = [], &_block|
+        captured = sent_args
+        "OK"
+      end
+      r.stub(:send_command, stub) { r.call_v(args) }
+      captured
+    end
   end
 end

--- a/test/valkey/call_test.rb
+++ b/test/valkey/call_test.rb
@@ -2,6 +2,11 @@
 
 module ValkeyTests
   module Call
+    # E2E: confirms call/call_v actually reach the server and the raw reply comes
+    # back untyped. Argument-construction correctness (flattening order, flag
+    # emission, coercion) is covered by the stub-based unit tests below — these
+    # only need to prove the whole pipeline (construct -> dispatch -> reply) works.
+
     def test_call_round_trip
       assert_equal "OK", r.call("SET", "call:key", "value")
       assert_equal "value", r.call("GET", "call:key")
@@ -26,69 +31,33 @@ module ValkeyTests
       end
     end
 
-    def test_call_stringifies_integers_and_floats
-      assert_equal "OK", r.call("SET", "call:num", 42)
-      assert_equal "42", r.call("GET", "call:num")
+    # should apply flattened Array/Hash args and kwargs-derived flags correctly
+    # end-to-end (server-visible effects: 3-element list, hash field set, TTL from
+    # a flag) in a single pass through the real dispatch path — the granular
+    # flattening/flag-construction cases themselves are unit-tested below.
+    def test_call_end_to_end_with_flattening_and_flags
+      r.del("call:e2e:list", "call:e2e:hash")
 
-      assert_equal "OK", r.call("SET", "call:float", 3.5)
-      assert_equal "3.5", r.call("GET", "call:float")
-    end
+      assert_equal 3, r.call("LPUSH", "call:e2e:list", [1, 2, 3])
+      assert_equal %w[3 2 1], r.call("LRANGE", "call:e2e:list", 0, -1)
 
-    def test_call_flattens_array_arguments
-      r.del("call:list")
+      assert_equal "OK", r.call("HMSET", "call:e2e:hash", { "foo" => "1" })
+      assert_equal "1", r.call("HGET", "call:e2e:hash", "foo")
 
-      assert_equal 3, r.call("LPUSH", "call:list", [1, 2, 3])
-      assert_equal %w[3 2 1], r.call("LRANGE", "call:list", 0, -1)
-    end
-
-    def test_call_flattens_nested_array_arguments
-      r.del("call:list2")
-
-      assert_equal 3, r.call("LPUSH", "call:list2", [1, [2, 3]])
-      assert_equal %w[3 2 1], r.call("LRANGE", "call:list2", 0, -1)
-    end
-
-    def test_call_flattens_hash_arguments
-      r.del("call:hash")
-
-      assert_equal "OK", r.call("HMSET", "call:hash", { "foo" => "1" })
-      assert_equal "1", r.call("HGET", "call:hash", "foo")
-    end
-
-    def test_call_v_flattens_array_and_hash_arguments
-      r.del("call:v:list")
-      r.del("call:v:hash")
-
-      assert_equal 3, r.call_v(["LPUSH", "call:v:list", [1, 2, 3]])
-      assert_equal "OK", r.call_v(["HMSET", "call:v:hash", { "foo" => "1" }])
-    end
-
-    def test_call_kwargs_become_trailing_flags
-      r.del("call:flags")
-
-      assert_equal "OK", r.call("SET", "call:flags", "v", nx: true, ex: 60)
-      assert_in_range 1..60, r.ttl("call:flags")
+      assert_equal "OK", r.call("SET", "call:e2e:flagged", "v", nx: true, ex: 60)
+      assert_in_range 1..60, r.ttl("call:e2e:flagged")
 
       # NX means "only set if not exists" — key already exists, so this is a no-op (nil reply)
-      assert_nil r.call("SET", "call:flags", "v2", nx: true)
-      assert_equal "v", r.call("GET", "call:flags")
+      assert_nil r.call("SET", "call:e2e:flagged", "v2", nx: true)
+      assert_equal "v", r.call("GET", "call:e2e:flagged")
     end
 
-    def test_call_drops_falsy_and_nil_kwargs
-      r.del("call:flags2")
-
-      # nx: false and ex: nil should be dropped entirely, not stringified
-      assert_equal "OK", r.call("SET", "call:flags2", "v", nx: false, ex: nil)
-      assert_equal(-1, r.ttl("call:flags2"))
-    end
-
-    # The tests above exercise flattening/coercion indirectly, through server-visible
-    # side effects (e.g. LPUSH's returned length, LRANGE's returned order) — they
-    # confirm the server *received something equivalent*, not the exact argument
-    # array `call`/`call_v` constructed. These stub `send_command` (same technique as
-    # `capture_failover_args` in failover_commands_test.rb) to assert on the literal
-    # flattened/coerced array before it ever reaches the network, independent of any
-    # particular command's server-side semantics.
+    # Everything below stubs `send_command` (same technique as `capture_failover_args`
+    # in failover_commands_test.rb) to assert on the literal flattened/coerced
+    # argument array before it ever reaches the network — independent of any
+    # particular command's server-side semantics. This is where flattening/flag
+    # correctness is actually verified; the E2E tests above just prove the pipeline
+    # composes.
 
     # should pass args through unchanged when they are already flat strings
     def test_call_arg_construction_passthrough

--- a/test/valkey/call_test.rb
+++ b/test/valkey/call_test.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+module ValkeyTests
+  module Call
+    def test_call_round_trip
+      assert_equal "OK", r.call("SET", "call:key", "value")
+      assert_equal "value", r.call("GET", "call:key")
+    end
+
+    def test_call_v_round_trip
+      r.call("SET", "call:v:key1", "v1")
+      r.call("SET", "call:v:key2", "v2")
+
+      assert_equal %w[v1 v2], r.call_v(["MGET", "call:v:key1", "call:v:key2"])
+    end
+
+    def test_call_raises_command_error_for_unknown_command
+      assert_raises(Valkey::CommandError) do
+        r.call("NOTACOMMAND", "foo")
+      end
+    end
+
+    def test_call_v_raises_command_error_for_unknown_command
+      assert_raises(Valkey::CommandError) do
+        r.call_v(%w[NOTACOMMAND foo])
+      end
+    end
+
+    def test_call_stringifies_integers_and_floats
+      assert_equal "OK", r.call("SET", "call:num", 42)
+      assert_equal "42", r.call("GET", "call:num")
+
+      assert_equal "OK", r.call("SET", "call:float", 3.5)
+      assert_equal "3.5", r.call("GET", "call:float")
+    end
+
+    def test_call_flattens_array_arguments
+      r.del("call:list")
+
+      assert_equal 3, r.call("LPUSH", "call:list", [1, 2, 3])
+      assert_equal %w[3 2 1], r.call("LRANGE", "call:list", 0, -1)
+    end
+
+    def test_call_flattens_nested_array_arguments
+      r.del("call:list2")
+
+      assert_equal 3, r.call("LPUSH", "call:list2", [1, [2, 3]])
+      assert_equal %w[3 2 1], r.call("LRANGE", "call:list2", 0, -1)
+    end
+
+    def test_call_flattens_hash_arguments
+      r.del("call:hash")
+
+      assert_equal "OK", r.call("HMSET", "call:hash", { "foo" => "1" })
+      assert_equal "1", r.call("HGET", "call:hash", "foo")
+    end
+
+    def test_call_v_flattens_array_and_hash_arguments
+      r.del("call:v:list")
+      r.del("call:v:hash")
+
+      assert_equal 3, r.call_v(["LPUSH", "call:v:list", [1, 2, 3]])
+      assert_equal "OK", r.call_v(["HMSET", "call:v:hash", { "foo" => "1" }])
+    end
+
+    def test_call_kwargs_become_trailing_flags
+      r.del("call:flags")
+
+      assert_equal "OK", r.call("SET", "call:flags", "v", nx: true, ex: 60)
+      assert_in_range 1..60, r.ttl("call:flags")
+
+      # NX means "only set if not exists" — key already exists, so this is a no-op (nil reply)
+      assert_nil r.call("SET", "call:flags", "v2", nx: true)
+      assert_equal "v", r.call("GET", "call:flags")
+    end
+
+    def test_call_drops_falsy_and_nil_kwargs
+      r.del("call:flags2")
+
+      # nx: false and ex: nil should be dropped entirely, not stringified
+      assert_equal "OK", r.call("SET", "call:flags2", "v", nx: false, ex: nil)
+      assert_equal(-1, r.ttl("call:flags2"))
+    end
+  end
+end


### PR DESCRIPTION
## Overview

Adds `call(*args, **kwargs)` and `call_v(args)` as the generic command dispatch, matching `redis-client`'s `#call`/`#call_v`. 

Sends any command directly through the previously-unused `RequestType::CUSTOM_COMMAND`, with redis-client-compatible argument coercion (Integer/Float stringify, Array flatten, Hash flatten to alternating key/value, kwargs→trailing flags) and a raw, untyped reply.

## Related Issue
Closes #126 

## Changes

* `lib/valkey/commands/generic_commands.rb`: Add public `call`/`call_v` dispatching via `RequestType::CUSTOM_COMMAND`, plus private `flatten_call_args` (recursive Array/Hash flattening, Integer/Float stringify) and `call_flags` (kwargs → upcased trailing flags, dropping falsy/nil) helpers.
* `README.md`: Document `call`/`call_v` as the escape hatch for commands without a dedicated method, including the coercion/flag examples.

## Testing

Integration and unit tests added
