### PR TITLE
Fix module tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -298,7 +298,7 @@ jobs:
           bundler-cache: true
 
       - name: Run module tests
-        run: bundle exec ruby -Itest -Ilib test/standalone/commands_test.rb -n '/TestStandaloneModuleCommands/'
+        run: bundle exec ruby -Itest -Ilib test/standalone/commands_test.rb -n '/TestStandalone(Module|Json|VectorSearch)Commands/'
         env:
           STANDALONE_ENDPOINTS: ${{ env.MODULES_STANDALONE_ENDPOINT }}
 

--- a/test/lint/json_commands.rb
+++ b/test/lint/json_commands.rb
@@ -15,12 +15,12 @@ module Lint
         r.json_set("test:json:check", "$", '{"test":1}')
         r.json_del("test:json:check")
       rescue Valkey::CommandError => e
-        if e.message.include?("unknown command") || e.message.include?("ERR unknown")
-          # JSON module genuinely not available, try loading it
-          @json_not_available = !try_load_json_module
-        else
-          @json_not_available = true
-        end
+        @json_not_available = if e.message.include?("unknown command") || e.message.include?("ERR unknown")
+                                # JSON module genuinely not available, try loading it
+                                !try_load_json_module
+                              else
+                                true
+                              end
       rescue StandardError
         @json_not_available = true
       end

--- a/test/lint/json_commands.rb
+++ b/test/lint/json_commands.rb
@@ -21,8 +21,13 @@ module Lint
             r.module_load(JSON_MODULE_PATH)
             r.json_set("test:json:check", "$", '{"test":1}')
             r.json_del("test:json:check")
-          rescue Valkey::CommandError
-            @json_not_available = true
+          rescue Valkey::CommandError => e
+            if e.message.include?("unknown command") || e.message.include?("No such file") ||
+               e.message.include?("MODULE command not allowed") || e.message.include?("cannot open")
+              @json_not_available = true
+            else
+              raise # unexpected error — let it surface
+            end
           end
         else
           @json_not_available = true

--- a/test/lint/json_commands.rb
+++ b/test/lint/json_commands.rb
@@ -289,7 +289,8 @@ module Lint
       true
     rescue Valkey::CommandError => e
       raise unless e.message.include?("unknown command") || e.message.include?("No such file") ||
-                   e.message.include?("MODULE command not allowed") || e.message.include?("cannot open")
+                   e.message.include?("MODULE command not allowed") || e.message.include?("cannot open") ||
+                   e.message.include?("Error loading the extension")
 
       false
     end

--- a/test/lint/json_commands.rb
+++ b/test/lint/json_commands.rb
@@ -7,19 +7,26 @@ module Lint
     def setup
       super
       @json_not_available = false
-      # Try to load JSON module if not already loaded
+      # Verify JSON commands work by probing directly.
+      # We avoid MODULE LIST since the MODULE command may be disabled on the server
+      # (e.g., enable-module-command not set). The valkey-bundle Docker image has
+      # JSON pre-loaded, so we just test if the commands are available.
       begin
-        modules = r.module_list
-        json_loaded = modules.any? do |m|
-          m.is_a?(Array) && m.include?("name") && %w[ReJSON rejson].include?(m[m.index("name") + 1])
-        end
-        r.module_load(JSON_MODULE_PATH) unless json_loaded
-
-        # Verify JSON commands work
         r.json_set("test:json:check", "$", '{"test":1}')
         r.json_del("test:json:check")
-      rescue Valkey::CommandError
-        @json_not_available = true
+      rescue Valkey::CommandError => e
+        if e.message.include?("unknown command") || e.message.include?("ERR unknown")
+          # JSON module genuinely not available, try loading it
+          begin
+            r.module_load(JSON_MODULE_PATH)
+            r.json_set("test:json:check", "$", '{"test":1}')
+            r.json_del("test:json:check")
+          rescue Valkey::CommandError
+            @json_not_available = true
+          end
+        else
+          @json_not_available = true
+        end
       rescue StandardError
         @json_not_available = true
       end

--- a/test/lint/json_commands.rb
+++ b/test/lint/json_commands.rb
@@ -17,18 +17,7 @@ module Lint
       rescue Valkey::CommandError => e
         if e.message.include?("unknown command") || e.message.include?("ERR unknown")
           # JSON module genuinely not available, try loading it
-          begin
-            r.module_load(JSON_MODULE_PATH)
-            r.json_set("test:json:check", "$", '{"test":1}')
-            r.json_del("test:json:check")
-          rescue Valkey::CommandError => e
-            if e.message.include?("unknown command") || e.message.include?("No such file") ||
-               e.message.include?("MODULE command not allowed") || e.message.include?("cannot open")
-              @json_not_available = true
-            else
-              raise # unexpected error — let it surface
-            end
-          end
+          @json_not_available = !try_load_json_module
         else
           @json_not_available = true
         end
@@ -286,6 +275,23 @@ module Lint
       rescue StandardError
         nil
       end
+    end
+
+    private
+
+    # Attempt to load the JSON module and verify it works.
+    # Returns true if successful, false if module is unavailable.
+    # Raises on unexpected errors (OOM, permission, misconfiguration).
+    def try_load_json_module
+      r.module_load(JSON_MODULE_PATH)
+      r.json_set("test:json:check", "$", '{"test":1}')
+      r.json_del("test:json:check")
+      true
+    rescue Valkey::CommandError => e
+      raise unless e.message.include?("unknown command") || e.message.include?("No such file") ||
+                   e.message.include?("MODULE command not allowed") || e.message.include?("cannot open")
+
+      false
     end
   end
 end

--- a/test/lint/vector_search_commands.rb
+++ b/test/lint/vector_search_commands.rb
@@ -24,7 +24,7 @@ module Lint
       # Temporarily switch to DB 0 for cleanup
       r.select(0)
 
-      # Clean up test index unconditionally (don't use index_exists? which switches DBs)
+      # Clean up test index unconditionally
       begin
         r.ft_drop_index(TEST_INDEX)
       rescue Valkey::CommandError
@@ -167,7 +167,7 @@ module Lint
       skip_if_redisearch_unavailable(e)
     end
 
-    def test_ft_drop_index_with_dd
+    def test_ft_drop_index_preserves_documents
       ensure_redisearch_loaded
 
       with_db0 do
@@ -513,19 +513,6 @@ module Lint
           raise
         end
       end
-    end
-
-    def index_exists?(index_name)
-      with_db0 do
-        list = r.ft_list
-        if list.is_a?(Array)
-          list.include?(index_name)
-        else
-          false
-        end
-      end
-    rescue Valkey::CommandError
-      false
     end
 
     def skip_if_redisearch_unavailable(error)

--- a/test/lint/vector_search_commands.rb
+++ b/test/lint/vector_search_commands.rb
@@ -396,8 +396,10 @@ module Lint
 
         # FT.PROFILE is not available in Valkey's native search implementation.
         # It is a Redis Stack (RediSearch module) only command.
+        # Use "@price:[0 +inf]" instead of "*" to align with test_ft_aggregate
+        # (Valkey native search rejects wildcard in FT.AGGREGATE queries).
         begin
-          result = r.ft_profile(TEST_INDEX, "AGGREGATE", "QUERY", "*",
+          result = r.ft_profile(TEST_INDEX, "AGGREGATE", "QUERY", "@price:[0 +inf]",
                                 "GROUPBY", "1", "@category")
           assert_kind_of Array, result
           assert result.length >= 1, "Should return at least aggregation results"

--- a/test/lint/vector_search_commands.rb
+++ b/test/lint/vector_search_commands.rb
@@ -26,7 +26,7 @@ module Lint
 
       # Clean up test index if it exists
       begin
-        r.ft_drop_index(TEST_INDEX, dd: true) if index_exists?(TEST_INDEX)
+        r.ft_drop_index(TEST_INDEX) if index_exists?(TEST_INDEX)
       rescue Valkey::CommandError => e
         # Ignore errors if index doesn't exist or command not available
         unless e.message.include?("Unknown Index") || e.message.include?("unknown command")
@@ -36,7 +36,7 @@ module Lint
 
       # Clean up any other test indexes
       begin
-        r.ft_drop_index("#{TEST_INDEX}_2", dd: true) if index_exists?("#{TEST_INDEX}_2")
+        r.ft_drop_index("#{TEST_INDEX}_2") if index_exists?("#{TEST_INDEX}_2")
       rescue Valkey::CommandError
         # Ignore - index doesn't exist
       end
@@ -49,8 +49,10 @@ module Lint
         begin
           r.module_unload(REDISEARCH_MODULE_NAME)
         rescue Valkey::CommandError => e
-          # RediSearch might not support unloading in some versions
-          unless e.message.include?("can't unload") || e.message.include?("data types")
+          # RediSearch might not support unloading in some versions, or MODULE command
+          # may not be allowed (e.g., enable-module-command not set on server)
+          unless e.message.include?("can't unload") || e.message.include?("data types") ||
+                 e.message.include?("MODULE command not allowed")
             warn "Warning: Unexpected error unloading RediSearch: #{e.message}"
           end
         end
@@ -172,13 +174,16 @@ module Lint
         # Add a document
         r.send_command(Valkey::RequestType::HSET, ["doc:1", "title", "test document"])
 
-        # Drop the index with DD flag (delete documents)
-        result = r.ft_drop_index(TEST_INDEX, dd: true)
+        # Note: Valkey's native FT.DROPINDEX does not support the DD flag.
+        # DD is a Redis Stack (RediSearch module) extension. On Valkey, dropping
+        # an index never deletes the underlying keys. We test that ft_drop_index
+        # works without DD and that documents are preserved.
+        result = r.ft_drop_index(TEST_INDEX)
         assert_equal "OK", result
 
-        # Verify document was deleted
+        # On Valkey, documents are preserved after dropping an index (no DD needed)
         exists = r.exists("doc:1")
-        assert_equal 0, exists, "Document should be deleted with DD flag"
+        assert_equal 1, exists, "Document should be preserved after FT.DROPINDEX on Valkey"
       end
     rescue Valkey::CommandError => e
       skip_if_redisearch_unavailable(e)
@@ -352,19 +357,21 @@ module Lint
 
         sleep 0.1
 
-        # Profile a search query
-        # Note: FT.PROFILE returns [search_results, profiling_metrics]
-        # We validate search_results work, but skip validating profiling_metrics due to complex nested structures
+        # FT.PROFILE is not available in Valkey's native search implementation.
+        # It is a Redis Stack (RediSearch module) only command.
+        # We test that the method exists and handles the expected error gracefully.
         begin
           result = r.ft_profile(TEST_INDEX, "SEARCH", "QUERY", "hello")
           assert_kind_of Array, result
           assert result.length >= 1, "Should return at least search results"
-          # result[0] would be search results, result[1] would be profiling metrics
         rescue Valkey::CommandError => e
-          # Profiling metrics have complex nested structures not fully supported in RESP2 conversion
-          raise unless e.message.include?("Array inside map must contain exactly two elements")
-
-          skip("FT.PROFILE profiling metrics conversion not yet fully supported in glide-core")
+          if e.message.include?("unknown command")
+            skip("FT.PROFILE not available in Valkey's native search")
+          elsif e.message.include?("Array inside map must contain exactly two elements")
+            skip("FT.PROFILE profiling metrics conversion not yet fully supported in glide-core")
+          else
+            raise
+          end
         end
       end
     rescue Valkey::CommandError => e
@@ -382,20 +389,21 @@ module Lint
 
         sleep 0.1
 
-        # Profile an aggregation query
-        # Note: FT.PROFILE returns [aggregation_results, profiling_metrics]
-        # We validate aggregation_results work, but skip validating profiling_metrics due to complex nested structures
+        # FT.PROFILE is not available in Valkey's native search implementation.
+        # It is a Redis Stack (RediSearch module) only command.
         begin
           result = r.ft_profile(TEST_INDEX, "AGGREGATE", "QUERY", "*",
                                 "GROUPBY", "1", "@category")
           assert_kind_of Array, result
           assert result.length >= 1, "Should return at least aggregation results"
-          # result[0] would be aggregation results, result[1] would be profiling metrics
         rescue Valkey::CommandError => e
-          # Profiling metrics have complex nested structures not fully supported in RESP2 conversion
-          raise unless e.message.include?("Array inside map must contain exactly two elements")
-
-          skip("FT.PROFILE profiling metrics conversion not yet fully supported in glide-core")
+          if e.message.include?("unknown command")
+            skip("FT.PROFILE not available in Valkey's native search")
+          elsif e.message.include?("Array inside map must contain exactly two elements")
+            skip("FT.PROFILE profiling metrics conversion not yet fully supported in glide-core")
+          else
+            raise
+          end
         end
       end
     rescue Valkey::CommandError => e

--- a/test/lint/vector_search_commands.rb
+++ b/test/lint/vector_search_commands.rb
@@ -174,7 +174,7 @@ module Lint
         # Add a document
         r.send_command(Valkey::RequestType::HSET, ["doc:1", "title", "test document"])
 
-        # Note: Valkey's native FT.DROPINDEX does not support the DD flag.
+        # NOTE: Valkey's native FT.DROPINDEX does not support the DD flag.
         # DD is a Redis Stack (RediSearch module) extension. On Valkey, dropping
         # an index never deletes the underlying keys. We test that ft_drop_index
         # works without DD and that documents are preserved.

--- a/test/lint/vector_search_commands.rb
+++ b/test/lint/vector_search_commands.rb
@@ -24,19 +24,16 @@ module Lint
       # Temporarily switch to DB 0 for cleanup
       r.select(0)
 
-      # Clean up test index if it exists
+      # Clean up test index unconditionally (don't use index_exists? which switches DBs)
       begin
-        r.ft_drop_index(TEST_INDEX) if index_exists?(TEST_INDEX)
-      rescue Valkey::CommandError => e
-        # Ignore errors if index doesn't exist or command not available
-        unless e.message.include?("Unknown Index") || e.message.include?("unknown command")
-          warn "Warning: Could not drop test index: #{e.message}"
-        end
+        r.ft_drop_index(TEST_INDEX)
+      rescue Valkey::CommandError
+        # Ignore - index doesn't exist or command not available
       end
 
       # Clean up any other test indexes
       begin
-        r.ft_drop_index("#{TEST_INDEX}_2") if index_exists?("#{TEST_INDEX}_2")
+        r.ft_drop_index("#{TEST_INDEX}_2")
       rescue Valkey::CommandError
         # Ignore - index doesn't exist
       end

--- a/test/lint/vector_search_commands.rb
+++ b/test/lint/vector_search_commands.rb
@@ -91,7 +91,8 @@ module Lint
         assert_equal "OK", result
 
         # Verify index exists
-        assert index_exists?(TEST_INDEX), "Index should exist after creation"
+        list = r.ft_list
+        assert list.include?(TEST_INDEX), "Index should exist after creation"
       end
     rescue Valkey::CommandError => e
       skip_if_redisearch_unavailable(e)
@@ -116,7 +117,8 @@ module Lint
         assert_equal "OK", result
 
         # Verify index exists
-        assert index_exists?(TEST_INDEX), "Index should exist after creation"
+        list = r.ft_list
+        assert list.include?(TEST_INDEX), "Index should exist after creation"
       end
     rescue Valkey::CommandError => e
       skip_if_redisearch_unavailable(e)
@@ -148,14 +150,18 @@ module Lint
       with_db0 do
         # Create an index
         r.ft_create(TEST_INDEX, "SCHEMA", "title", "TEXT")
-        assert index_exists?(TEST_INDEX)
+
+        # Verify index exists (use ft_list directly since we're already in db0)
+        list = r.ft_list
+        assert list.include?(TEST_INDEX), "Index should exist after creation"
 
         # Drop the index
         result = r.ft_drop_index(TEST_INDEX)
         assert_equal "OK", result
 
         # Verify index no longer exists
-        assert !index_exists?(TEST_INDEX), "Index should not exist after drop"
+        list = r.ft_list
+        assert !list.include?(TEST_INDEX), "Index should not exist after drop"
       end
     rescue Valkey::CommandError => e
       skip_if_redisearch_unavailable(e)
@@ -248,8 +254,10 @@ module Lint
 
         sleep 0.1
 
-        # Run aggregation
-        results = r.ft_aggregate(TEST_INDEX, "*", "GROUPBY", "1", "@category",
+        # Run aggregation with a numeric filter that matches all documents
+        # NOTE: Valkey's native search does not support "*" wildcard in FT.AGGREGATE queries.
+        # Use a filter expression that matches all indexed documents instead.
+        results = r.ft_aggregate(TEST_INDEX, "@price:[0 +inf]", "GROUPBY", "1", "@category",
                                  "REDUCE", "COUNT", "0", "AS", "count")
         assert_kind_of Array, results
       end


### PR DESCRIPTION
### Summary

Fix module tests CI coverage and resolve test failures for JSON and VectorSearch commands in the Ruby client. Previously, only TestStandaloneModuleCommands ran in CI — JSON (19 tests) and VectorSearch (17 tests) were silently excluded. After enabling them, multiple failures were identified and fixed related to Valkey 
compatibility and a DB-switching bug in test teardown.

### Issue link

This Pull Request is linked to issue: https://github.com/valkey-io/valkey-glide-ruby/issues/119

### Features / Behaviour Changes

- No user-facing API changes
- CI now exercises JSON and VectorSearch module tests that were previously skipped
- FT.DROPINDEX tests aligned with Valkey's native search behavior (no DD flag support)
- FT.PROFILE tests gracefully skip on Valkey (command only exists in Redis Stack)

### Implementation

1. CI regex fix (.github/workflows/CI.yml): Changed filter from /TestStandaloneModuleCommands/ to /TestStandalone(Module|Json|VectorSearch)Commands/

2. JSON setup (test/lint/json_commands.rb): Replaced MODULE LIST probe with direct json_set/json_del probe.
3. VectorSearch teardown (test/lint/vector_search_commands.rb): Fixed DB-switching bug — index_exists? calls with_db0.
4. Valkey compatibility (test/lint/vector_search_commands.rb):
   - Removed DD flag from FT.DROPINDEX (not supported in Valkey native search, aligned with Python/Java/Node clients)
   - FT.PROFILE tests rescue unknown command and skip (command not available in Valkey)
   - test_ft_drop_index_with_dd updated to verify Valkey behavior 

### Limitations

- FT.PROFILE will always skip on Valkey native search — it's a Redis Stack-only command
- MODULE LOAD/UNLOAD tests still skip because the Docker container doesn't set --enable-module-command yes
- Cluster module tests exist but have no dedicated CI step (out of scope for this PR)
- ft_drop_index Ruby implementation still accepts dd: parameter for potential Redis Stack compatibility, but it will error on Valkey servers

### Testing

- All 19 JSON tests: PASS (previously all SKIPped)
- VectorSearch tests: teardown cascade resolved; ft_list, ft_info, ft_create, ft_search, ft_aggregate, ft_drop_index, ft_alias_*, ft_explain expected to pass
- FT.PROFILE tests: graceful SKIP on Valkey
- MODULE management tests: unchanged (9 pass, 2 skip)
- RuboCop: passes clean

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run (make *-lint targets) and Prettier has been run (make prettier-fix).
- [x] Destination branch is correct - main or release
- [x] Create merge commit if merging release branch into main, squash otherwise.
- [ ] Make sure to update the documentation in the [valkey-glide-docs](https://github.com/valkey-io/valkey-glide-docs) repository if necessary