### PR TITLE
Enabling scan_each

### DIFF
--- a/lib/valkey/commands/generic_commands.rb
+++ b/lib/valkey/commands/generic_commands.rb
@@ -9,6 +9,11 @@ class Valkey
     module GenericCommands
       # Scan the keyspace
       #
+      # @note Standalone mode only. glide-core has no defined default route for
+      #   SCAN in cluster mode, so each call may land on a different node with
+      #   no cursor continuity between them — results are undefined (missed or
+      #   duplicated keys) rather than merely partial.
+      #
       # @example Retrieve the first batch of keys
       #   valkey.scan(0)
       #     # => ["4", ["key:21", "key:47", "key:42"]]
@@ -32,6 +37,9 @@ class Valkey
       end
 
       # Scan the keyspace
+      #
+      # @note Standalone mode only. Built on {#scan}, which has undefined
+      #   routing behavior in cluster mode (see its note).
       #
       # @example Retrieve all of the keys (with possible duplicates)
       #   valkey.scan_each.to_a

--- a/lib/valkey/commands/generic_commands.rb
+++ b/lib/valkey/commands/generic_commands.rb
@@ -52,16 +52,16 @@ class Valkey
       #
       # @return [Enumerator] an enumerator for all found keys
       #
-      # def scan_each(**options, &block)
-      #   return to_enum(:scan_each, **options) unless block_given?
-      #
-      #   cursor = 0
-      #   loop do
-      #     cursor, keys = scan(cursor, **options)
-      #     keys.each(&block)
-      #     break if cursor == "0"
-      #   end
-      # end
+      def scan_each(**options, &block)
+        return to_enum(:scan_each, **options) unless block_given?
+
+        cursor = 0
+        loop do
+          cursor, keys = scan(cursor, **options)
+          keys.each(&block)
+          break if cursor == "0"
+        end
+      end
 
       # Remove the expiration from a key.
       #

--- a/test/lint/generic_commands.rb
+++ b/test/lint/generic_commands.rb
@@ -366,6 +366,16 @@ module Lint
       assert_equal 2, all_keys.uniq.size
     end
 
+    def test_scan_each
+      skip("SCAN with match pattern may not see all keys in cluster mode") if cluster_mode?
+
+      set_some_keys
+
+      all_keys = valkey.scan_each(match: '{key}*').to_a
+
+      assert_equal 2, all_keys.uniq.size
+    end
+
     def test_type
       assert_equal "none", r.type("foo")
 


### PR DESCRIPTION
# Add `scan_each` to valkey-glide-ruby

## What
Enables `Valkey#scan_each`, a lazy iterator over the keyspace built on top of the
existing `scan`/`_scan` commands. The method was already scaffolded (ported verbatim
from redis-rb) but left commented out; this change uncomments it as-is, matching
redis-rb's implementation exactly:

```ruby
def scan_each(**options, &block)
  return to_enum(:scan_each, **options) unless block_given?

  cursor = 0
  loop do
    cursor, keys = scan(cursor, **options)
    keys.each(&block)
    break if cursor == "0"
  end
end
```

- Returns an `Enumerator` when no block is given (`valkey.scan_each.to_a`,
  `valkey.scan_each(match: "key:1?").to_a`).
- Yields each key to the block otherwise (`valkey.scan_each(type: "hash") { |k| ... }`).
- Supports the same `:match`, `:count`, and `:type` options as `scan`.

## Why it was commented out
`generic_commands.rb` was originally ported wholesale from redis-rb as a template,
with every method commented out. Commands were enabled incrementally in later
commits (e.g. `scan`, `persist`, etc. in "implement a few generic commands").
`scan_each` was simply missed in that pass — not a deliberate limitation.

## Files changed
- `lib/valkey/commands/generic_commands.rb` — uncommented `scan_each`.
- `test/lint/generic_commands.rb` — added `test_scan_each`, mirroring the existing
  `test_scan` test (same `{key}*` cluster-safe match pattern, same key count assertion).

## Verification
- Built the native FFI library locally (`rake native:build` + `rake native:package`).
- Ran `test_scan` and `test_scan_each` against a local `valkey-server` on port 6379 — both pass.
- Manually verified both call styles (enumerator and block form), with and without a
  `match:` filter.

## Commit
`ac1c975` — "Enabling scan_each"
