### PR TITLE
feat(ruby): add structured Valkey Search 1.2 API

### DIFF
--- a/.github/json_matrices/build-matrix.json
+++ b/.github/json_matrices/build-matrix.json
@@ -16,5 +16,13 @@
         "TARGET": "aarch64-unknown-linux-gnu",
         "run": "always",
         "languages": ["ruby"]
+    },
+    {
+        "OS": "macos",
+        "NAMED_OS": "darwin",
+        "RUNNER": "macos-latest",
+        "ARCH": "arm64",
+        "TARGET": "aarch64-apple-darwin",
+        "languages": ["ruby"]
     }
 ]

--- a/.github/json_matrices/build-matrix.json
+++ b/.github/json_matrices/build-matrix.json
@@ -2,10 +2,11 @@
     {
         "OS": "ubuntu",
         "NAMED_OS": "linux",
-        "RUNNER": "ubuntu-latest",
+        "RUNNER": "ubuntu-24.04",
         "ARCH": "x64",
         "TARGET": "x86_64-unknown-linux-gnu",
-        "run": "always"
+        "run": "always",
+        "languages": ["ruby"]
     },
     {
         "OS": "ubuntu",
@@ -13,6 +14,7 @@
         "RUNNER": "ubuntu-24.04-arm",
         "ARCH": "arm64",
         "TARGET": "aarch64-unknown-linux-gnu",
-        "run": "always"
+        "run": "always",
+        "languages": ["ruby"]
     }
 ]

--- a/.github/json_matrices/engine-matrix.json
+++ b/.github/json_matrices/engine-matrix.json
@@ -1,0 +1,28 @@
+[
+    {
+        "type": "valkey",
+        "version": "9.0",
+        "run": "always"
+    },
+    {
+        "type": "valkey",
+        "version": "8.1"
+    },
+    {
+        "type": "valkey",
+        "version": "8.0"
+    },
+    {
+        "type": "valkey",
+        "version": "7.2"
+    },
+    {
+        "type": "redis",
+        "version": "7.0"
+    },
+    {
+        "type": "redis",
+        "version": "6.2",
+        "run": "always"
+    }
+]

--- a/.github/json_matrices/supported-languages-versions.json
+++ b/.github/json_matrices/supported-languages-versions.json
@@ -1,0 +1,7 @@
+[
+    {
+        "language": "ruby",
+        "versions": ["3.0", "3.1", "3.2", "3.3", "3.4"],
+        "always-run-versions": ["3.2", "3.4"]
+    }
+]

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,13 +1,57 @@
 name: CI
 
+run-name: ${{ inputs.name || format('{0} @ {1} {2}', github.ref_name, github.sha, toJson(inputs)) }}
+
 on:
+  pull_request:
+    paths:
+      - lib/**
+      - test/**
+      - valkey-glide/ffi/**
+      - .github/workflows/**
+      - .github/json_matrices/**
+      - Gemfile
+      - Gemfile.lock
+      - Rakefile
+      - valkey.gemspec
+
   push:
     branches:
       - main
+      - release-*
 
-  pull_request:
+  schedule:
+    - cron: "0 6 * * *"
 
   workflow_dispatch:
+    inputs:
+      full-matrix:
+        description: "Run the full matrix"
+        type: boolean
+        default: false
+      run-with-macos:
+        description: "Include macOS runners"
+        type: choice
+        options:
+          - "false"
+          - "use-self-hosted"
+          - "use-github"
+        default: "false"
+      name:
+        description: "Custom run name"
+        type: string
+        required: false
+
+  workflow_call:
+    inputs:
+      run-with-macos:
+        description: "Include macOS runners"
+        type: string
+        default: "false"
+
+concurrency:
+  group: ruby-${{ github.head_ref || github.ref }}-${{ toJson(inputs) }}
+  cancel-in-progress: true
 
 jobs:
   lint:
@@ -25,10 +69,48 @@ jobs:
       - name: Lint
         run: bundle exec rubocop
 
-  build-native-library:
-    name: Build Native Library
+  get-matrices:
+    name: Get Matrices
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    outputs:
+      engine-matrix-output: ${{ steps.create-matrices.outputs.engine-matrix-output }}
+      host-matrix-output: ${{ steps.create-matrices.outputs.host-matrix-output }}
+      version-matrix-output: ${{ steps.create-matrices.outputs.version-matrix-output }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Determine full matrix mode
+        id: full-matrix
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          FULL_MATRIX_INPUT: ${{ inputs.full-matrix }}
+        run: |
+          if [[ "$EVENT_NAME" == "schedule" ]] || \
+             [[ "$EVENT_NAME" == "workflow_call" ]] || \
+             [[ "$EVENT_NAME" == "workflow_dispatch" && "$FULL_MATRIX_INPUT" == "true" ]]; then
+            echo "run-full-matrix=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run-full-matrix=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create test matrices
+        id: create-matrices
+        uses: ./.github/workflows/create-test-matrices
+        with:
+          language-name: ruby
+          run-full-matrix: ${{ steps.full-matrix.outputs.run-full-matrix }}
+          run-with-macos: ${{ inputs.run-with-macos || 'false' }}
+
+  build-native-library:
+    name: Build Native Library / ${{ matrix.host.NAMED_OS }}-${{ matrix.host.ARCH }}
+    needs: [get-matrices]
+    runs-on: ${{ matrix.host.RUNNER }}
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        host: ${{ fromJson(needs.get-matrices.outputs.host-matrix-output) }}
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -40,7 +122,7 @@ jobs:
       - name: Install Rust
         uses: ./valkey-glide/.github/actions/install-rust
         with:
-          target: x86_64-unknown-linux-gnu
+          target: ${{ matrix.host.TARGET }}
 
       - name: Install protoc
         uses: ./valkey-glide/.github/actions/install-protoc
@@ -56,9 +138,9 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             valkey-glide/ffi/target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('valkey-glide/ffi/Cargo.lock') }}
+          key: ${{ matrix.host.TARGET }}-cargo-${{ hashFiles('valkey-glide/ffi/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-
+            ${{ matrix.host.TARGET }}-cargo-
 
       - name: Build native library
         working-directory: valkey-glide/ffi
@@ -70,202 +152,102 @@ jobs:
       - name: Upload native library
         uses: actions/upload-artifact@v4
         with:
-          name: native-lib-linux-x64
+          name: native-lib-${{ matrix.host.NAMED_OS }}-${{ matrix.host.ARCH }}
           path: valkey-glide/ffi/target/release/libglide_ffi.so
           if-no-files-found: error
 
-  standalone:
-    needs: [build-native-library]
-    runs-on: ubuntu-latest
-    name: Standalone / Ruby ${{ matrix.ruby }} Valkey ${{ matrix.valkey }}
-    timeout-minutes: 15
+  test-ruby:
+    name: Test / Ruby ${{ matrix.version }} / ${{ matrix.engine.type }} ${{ matrix.engine.version }} / ${{ matrix.host.ARCH }}
+    needs: [build-native-library, get-matrices]
+    runs-on: ${{ matrix.host.RUNNER }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        ruby:
-          - 3.4
-          - 3.3
-          - 3.2
-          - 3.1
-          - 3.0
-        valkey:
-          - 7.2.10
-          - 8
-          - 8.1
-
+        engine: ${{ fromJson(needs.get-matrices.outputs.engine-matrix-output) }}
+        version: ${{ fromJson(needs.get-matrices.outputs.version-matrix-output) }}
+        host: ${{ fromJson(needs.get-matrices.outputs.host-matrix-output) }}
     steps:
-      - uses: actions/checkout@v4
+      - name: Check out code
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
       - name: Download native library
         uses: actions/download-artifact@v4
         with:
-          name: native-lib-linux-x64
+          name: native-lib-${{ matrix.host.NAMED_OS }}-${{ matrix.host.ARCH }}
           path: valkey-glide/ffi/target/release/
-
-      - name: Copy modules for testing
-        run: |
-          echo "Copying modules for testing..."
-          mkdir -p test/fixtures
-
-          echo "Copying RedisJSON module for JSON commands testing..."
-          cp .github/files/librejson-v2.8.15.so test/fixtures/redisjson.so
-          chmod +x test/fixtures/redisjson.so
-          ls -lh test/fixtures/redisjson.so
-
-          echo "Copying RedisBloom module..."
-          cp .github/files/redisbloom-amd64-v2.6.12.so test/fixtures/redisbloom.so
-          chmod +x test/fixtures/redisbloom.so
-          ls -lh test/fixtures/redisbloom.so
-
-          echo "Copying RediSearch module for Vector Search commands testing..."
-          cp .github/files/redisearch-amd64-v2.10.24.so test/fixtures/redisearch.so
-          chmod +x test/fixtures/redisearch.so
-          ls -lh test/fixtures/redisearch.so
-
-      - name: Generate SSL certificates for testing
-        run: |
-          echo "Generating SSL certificates for SSL/TLS testing..."
-          ruby test/fixtures/ssl/generate_certs.rb
-          echo "SSL certificates generated:"
-          ls -lh test/fixtures/ssl/*.pem
-
-      - name: Start Valkey with MODULE commands enabled
-        run: |
-          echo "Starting Valkey ${{ matrix.valkey }} with MODULE commands enabled..."
-          docker run -d \
-            --name valkey-test \
-            -p 6379:6379 \
-            -v $(pwd)/test/fixtures:/tmp/modules:ro \
-            valkey/valkey:${{ matrix.valkey }} \
-            valkey-server --enable-module-command yes
-
-          echo "Waiting for Valkey to be ready..."
-          for i in {1..30}; do
-            if docker exec valkey-test valkey-cli ping > /dev/null 2>&1; then
-              echo "Valkey is ready!"
-              break
-            fi
-            echo "Waiting... ($i/30)"
-            sleep 1
-          done
-
-          echo "Verifying MODULE commands are enabled..."
-          docker exec valkey-test valkey-cli CONFIG GET enable-module-command
-
-          echo "Verifying module files are accessible..."
-          docker exec valkey-test ls -lh /tmp/modules/
-
-      - name: Start SSL-enabled Valkey on port 6380
-        run: |
-          echo "Creating Valkey SSL configuration..."
-          cat > /tmp/valkey-ssl.conf << 'EOF'
-          # Disable regular port, use TLS port only
-          port 0
-          tls-port 6380
-
-          # SSL/TLS certificate files
-          tls-cert-file /ssl/server-cert.pem
-          tls-key-file /ssl/server-key.pem
-          tls-ca-cert-file /ssl/ca-cert.pem
-
-          # Don't require client certificates (optional)
-          tls-auth-clients no
-
-          # Allow TLS v1.2 and v1.3
-          tls-protocols "TLSv1.2 TLSv1.3"
-          EOF
-
-          echo "SSL configuration created:"
-          cat /tmp/valkey-ssl.conf
-
-          echo "Verifying SSL certificate files exist..."
-          ls -lh $(pwd)/test/fixtures/ssl/*.pem
-
-          echo "Starting SSL-enabled Valkey on port 6380..."
-          docker run -d \
-            --name valkey-ssl \
-            -p 6380:6380 \
-            -v $(pwd)/test/fixtures/ssl:/ssl:ro \
-            -v /tmp/valkey-ssl.conf:/etc/valkey-ssl.conf:ro \
-            valkey/valkey:${{ matrix.valkey }} \
-            valkey-server /etc/valkey-ssl.conf
-
-          echo "Waiting for container to start..."
-          sleep 2
-
-          echo "Checking if container is running..."
-          docker ps -a | grep valkey-ssl || echo "Container not found!"
-
-          echo "Checking container logs..."
-          docker logs valkey-ssl || echo "Could not get logs"
-
-          echo "Verifying SSL cert files are accessible inside container..."
-          docker exec valkey-ssl ls -lh /ssl/ || echo "Cannot access /ssl/ directory"
-          docker exec valkey-ssl cat /etc/valkey-ssl.conf || echo "Cannot read config file"
-
-          echo "Waiting for SSL Valkey to be ready..."
-          for i in {1..30}; do
-            if docker exec valkey-ssl valkey-cli --tls --insecure -p 6380 ping > /dev/null 2>&1; then
-              echo "SSL Valkey is ready!"
-              break
-            fi
-            echo "Waiting... ($i/30)"
-            sleep 1
-          done
-
-          echo "Verifying SSL connection from host..."
-          docker exec valkey-ssl valkey-cli --tls --insecure -p 6380 ping || echo "SSL verification failed"
-
-          echo "Testing connection from host machine..."
-          docker run --rm --network host valkey/valkey:${{ matrix.valkey }} valkey-cli --tls --insecure -p 6380 ping || echo "Host connection test failed"
-
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ matrix.ruby }}
-          bundler-cache: true
-
-      - name: Run standalone tests
-        run: bundle exec rake test:standalone
-
-      - name: Stop Valkey containers
-        if: always()
-        run: |
-          docker stop valkey-test && docker rm valkey-test || true
-          docker stop valkey-ssl && docker rm valkey-ssl || true
-
-  cluster:
-    needs: [build-native-library]
-    runs-on: ubuntu-latest
-    name: Cluster / Ruby ${{ matrix.ruby }}
-    timeout-minutes: 20
-    strategy:
-      fail-fast: false
-      matrix:
-        ruby:
-          - 3.4
-          - 3.3
-          - 3.2
-          - 3.1
-          - 3.0
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 
-      - name: Install Valkey
+      - name: Install Valkey engine
         uses: ./valkey-glide/.github/actions/install-engine
         with:
-          engine-version: "8.0"
-          target: x86_64-unknown-linux-gnu
+          engine-version: ${{ matrix.engine.version }}
+          target: ${{ matrix.host.TARGET }}
+
+      - name: Start standalone server via cluster_manager.py
+        run: |
+          python3 valkey-glide/utils/cluster_manager.py start -r 0 -p 6379 --prefix standalone
+          echo "Standalone server started on port 6379"
+
+      - name: Start TLS server via cluster_manager.py
+        run: |
+          python3 valkey-glide/utils/cluster_manager.py --tls start -r 0 -p 6380 --prefix tls-standalone
+          echo "TLS server started on port 6380"
+          echo "TLS_CERT_DIR=$(pwd)/valkey-glide/utils/tls_crts" >> $GITHUB_ENV
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.version }}
+          bundler-cache: true
+
+      - name: Run tests
+        run: bundle exec rake test
+
+      - name: Upload test artifacts
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-report-ruby-${{ matrix.version }}-${{ matrix.engine.type }}-${{ matrix.engine.version }}-${{ matrix.host.NAMED_OS }}-${{ matrix.host.ARCH }}
+          path: |
+            test/reports/
+            tmp/test-results/
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: Upload cluster logs on failure
+        if: failure()
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: cluster-logs-ruby-${{ matrix.version }}-${{ matrix.engine.type }}-${{ matrix.engine.version }}-${{ matrix.host.NAMED_OS }}-${{ matrix.host.ARCH }}
+          path: valkey-glide/utils/clusters/
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: Stop servers
+        if: always()
+        run: |
+          python3 valkey-glide/utils/cluster_manager.py stop --prefix standalone || true
+          python3 valkey-glide/utils/cluster_manager.py --tls stop --prefix tls-standalone || true
+
+  module-tests:
+    name: Module Tests
+    needs: [build-native-library]
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Download native library
         uses: actions/download-artifact@v4
@@ -273,20 +255,37 @@ jobs:
           name: native-lib-linux-x64
           path: valkey-glide/ffi/target/release/
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Valkey engine
+        uses: ./valkey-glide/.github/actions/install-engine
+        with:
+          engine-version: "9.0"
+          target: x86_64-unknown-linux-gnu
+
+      - name: Start module servers via Docker
+        uses: ./valkey-glide/.github/actions/start-valkey-docker
+        with:
+          engine-version: "9.0"
+
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ${{ matrix.ruby }}
+          ruby-version: "3.4"
           bundler-cache: true
 
-      - name: Run cluster tests
-        run: bundle exec rake test:cluster
-        timeout-minutes: 25
+      - name: Run module tests
+        run: bundle exec ruby -Itest -Ilib test/standalone/commands_test.rb -n '/TestStandaloneModuleCommands/'
+        env:
+          STANDALONE_ENDPOINTS: ${{ env.MODULES_STANDALONE_ENDPOINT }}
 
-      - name: Upload cluster logs on failure
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: cluster-logs-${{ matrix.ruby }}
-          path: valkey-glide/utils/clusters/
-          retention-days: 7
+      - name: Stop containers
+        if: always()
+        run: |
+          docker stop valkey-modules-standalone && docker rm valkey-modules-standalone || true
+          for port in $(seq 8001 8006); do
+            docker stop "valkey-modules-cluster-${port}" && docker rm "valkey-modules-cluster-${port}" || true
+          done

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -94,13 +94,27 @@ jobs:
             echo "run-full-matrix=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Determine macOS runner mode
+        id: macos-mode
+        env:
+          RUN_WITH_MACOS: ${{ inputs.run-with-macos || 'false' }}
+          RUN_FULL_MATRIX: ${{ steps.full-matrix.outputs.run-full-matrix }}
+        run: |
+          if [[ "$RUN_WITH_MACOS" != "false" ]]; then
+            echo "run-with-macos=$RUN_WITH_MACOS" >> "$GITHUB_OUTPUT"
+          elif [[ "$RUN_FULL_MATRIX" == "true" ]]; then
+            echo "run-with-macos=use-github" >> "$GITHUB_OUTPUT"
+          else
+            echo "run-with-macos=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Create test matrices
         id: create-matrices
         uses: ./.github/workflows/create-test-matrices
         with:
           language-name: ruby
           run-full-matrix: ${{ steps.full-matrix.outputs.run-full-matrix }}
-          run-with-macos: ${{ inputs.run-with-macos || 'false' }}
+          run-with-macos: ${{ steps.macos-mode.outputs.run-with-macos }}
 
   build-native-library:
     name: Build Native Library / ${{ matrix.host.NAMED_OS }}-${{ matrix.host.ARCH }}
@@ -153,11 +167,11 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: native-lib-${{ matrix.host.NAMED_OS }}-${{ matrix.host.ARCH }}
-          path: valkey-glide/ffi/target/release/libglide_ffi.so
+          path: valkey-glide/ffi/target/release/libglide_ffi.${{ matrix.host.OS == 'macos' && 'dylib' || 'so' }}
           if-no-files-found: error
 
   test-ruby:
-    name: Test / Ruby ${{ matrix.version }} / ${{ matrix.engine.type }} ${{ matrix.engine.version }} / ${{ matrix.host.ARCH }}
+    name: Test / Ruby ${{ matrix.version }} / ${{ matrix.engine.type }} ${{ matrix.engine.version }} / ${{ matrix.host.NAMED_OS }}-${{ matrix.host.ARCH }}
     needs: [build-native-library, get-matrices]
     runs-on: ${{ matrix.host.RUNNER }}
     timeout-minutes: 30
@@ -196,6 +210,7 @@ jobs:
           echo "Standalone server started on port 6379"
 
       - name: Start TLS server via cluster_manager.py
+        if: matrix.host.OS != 'macos'
         run: |
           python3 valkey-glide/utils/cluster_manager.py --tls start -r 0 -p 6380 --prefix tls-standalone
           echo "TLS server started on port 6380"
@@ -209,6 +224,8 @@ jobs:
 
       - name: Run tests
         run: bundle exec rake test
+        env:
+          SKIP_TLS_TESTS: ${{ matrix.host.OS == 'macos' && 'true' || '' }}
 
       - name: Upload test artifacts
         if: always()
@@ -236,7 +253,10 @@ jobs:
         if: always()
         run: |
           python3 valkey-glide/utils/cluster_manager.py stop --prefix standalone || true
-          python3 valkey-glide/utils/cluster_manager.py --tls stop --prefix tls-standalone || true
+          # Stop TLS server (skip on macOS where TLS setup is unavailable)
+          if [[ "${{ matrix.host.OS }}" != "macos" ]]; then
+            python3 valkey-glide/utils/cluster_manager.py --tls stop --prefix tls-standalone || true
+          fi
 
   module-tests:
     name: Module Tests

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -93,6 +93,10 @@ jobs:
           version: "29.1"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Install openssl (macOS)
+        if: matrix.host.OS == 'macos'
+        run: brew install openssl
+
       - name: Build native library
         working-directory: valkey-glide/ffi
         env:
@@ -105,7 +109,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: native-lib-${{ matrix.host.TARGET }}
-          path: valkey-glide/ffi/target/release/libglide_ffi.so
+          path: valkey-glide/ffi/target/release/libglide_ffi.${{ matrix.host.OS == 'macos' && 'dylib' || 'so' }}
           if-no-files-found: error
 
   build-and-publish-gem:
@@ -139,8 +143,16 @@ jobs:
           for target in $(echo '${{ env.PLATFORM_MATRIX }}' | jq -r '.[].TARGET'); do
             echo "Creating directory for $target"
             mkdir -p "lib/valkey/native/$target"
-            echo "Copying native library for $target"
-            cp "native-libs/native-lib-$target/libglide_ffi.so" "lib/valkey/native/$target/"
+
+            # Determine correct file extension based on target
+            if [[ "$target" == *"apple-darwin"* ]]; then
+              LIB_EXT="dylib"
+            else
+              LIB_EXT="so"
+            fi
+
+            echo "Copying native library for $target (extension: $LIB_EXT)"
+            cp "native-libs/native-lib-$target/libglide_ffi.$LIB_EXT" "lib/valkey/native/$target/"
           done
 
           echo "Native libraries organized:"
@@ -166,10 +178,31 @@ jobs:
       - name: Verify gem contents
         run: |
           gem unpack ${{ steps.build-gem.outputs.GEM_FILE }} --target=gem-contents
-          echo "Gem contents:"
-          find gem-contents -type f | head -50
-          echo ""
-          echo "Native libraries in gem:"
+
+          # Find the unpacked gem directory (gem unpack creates a subdirectory)
+          GEM_DIR=$(find gem-contents -maxdepth 1 -type d | tail -1)
+          echo "Unpacked gem directory: $GEM_DIR"
+
+          # Verify all platform libraries are present
+          MISSING=""
+          for target in $(echo '${{ env.PLATFORM_MATRIX }}' | jq -r '.[].TARGET'); do
+            if [[ "$target" == *"apple-darwin"* ]]; then
+              LIB_EXT="dylib"
+            else
+              LIB_EXT="so"
+            fi
+            LIB_PATH="$GEM_DIR/lib/valkey/native/$target/libglide_ffi.$LIB_EXT"
+            if [[ ! -f "$LIB_PATH" ]]; then
+              MISSING="$MISSING\n  - $target (expected: $LIB_PATH)"
+            fi
+          done
+
+          if [[ -n "$MISSING" ]]; then
+            echo "ERROR: Missing native libraries for platforms:$MISSING"
+            exit 1
+          fi
+
+          echo "All platform libraries verified present"
           find gem-contents -name "libglide_ffi.*" -exec ls -lh {} \;
 
       - name: Upload gem artifact
@@ -178,6 +211,7 @@ jobs:
           name: ruby-gem
           path: "*.gem"
           if-no-files-found: error
+          retention-days: 7
 
       - name: Publish to RubyGems
         id: publish
@@ -225,11 +259,21 @@ jobs:
           gem install ruby-progressbar
           gem install rake
 
-      - name: Start Valkey
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Valkey engine
+        uses: ./valkey-glide/.github/actions/install-engine
+        with:
+          engine-version: "9.0"
+          target: ${{ matrix.host.TARGET }}
+
+      - name: Start standalone server via cluster_manager.py
         run: |
-          docker run -d --name valkey-test -p 6379:6379 valkey/valkey:8
-          sleep 5
-          docker exec valkey-test valkey-cli ping
+          python3 valkey-glide/utils/cluster_manager.py start -r 0 -p 6379 --prefix standalone
+          echo "Standalone server started on port 6379"
 
       - name: Download gem artifact (unpublished)
         if: ${{ needs.build-and-publish-gem.outputs.published != 'true' }}
@@ -284,4 +328,5 @@ jobs:
 
       - name: Stop Valkey
         if: always()
-        run: docker stop valkey-test && docker rm valkey-test || true
+        run: |
+          python3 valkey-glide/utils/cluster_manager.py stop --prefix standalone || true

--- a/.github/workflows/create-test-matrices/action.yml
+++ b/.github/workflows/create-test-matrices/action.yml
@@ -1,0 +1,130 @@
+name: Create Test Matrices
+description: "Filters JSON matrix files to produce engine, host, and language version matrices based on full/reduced mode"
+
+inputs:
+  language-name:
+    description: "The language to filter for (e.g., 'ruby')"
+    required: true
+  run-full-matrix:
+    description: "Whether to run the full matrix (true) or reduced matrix (false)"
+    required: true
+  run-with-macos:
+    description: "Include macOS runners: 'false', 'use-self-hosted', or 'use-github'"
+    required: false
+    default: "false"
+
+outputs:
+  engine-matrix-output:
+    description: "Filtered engine versions as a JSON array"
+    value: ${{ steps.generate-matrices.outputs.engine-matrix-output }}
+  host-matrix-output:
+    description: "Filtered host/runner entries as a JSON array"
+    value: ${{ steps.generate-matrices.outputs.host-matrix-output }}
+  version-matrix-output:
+    description: "Filtered language versions as a JSON array"
+    value: ${{ steps.generate-matrices.outputs.version-matrix-output }}
+
+runs:
+  using: composite
+  steps:
+    - name: Generate matrices
+      id: generate-matrices
+      shell: bash
+      env:
+        RUN_FULL_MATRIX: ${{ inputs.run-full-matrix }}
+        LANGUAGE_NAME: ${{ inputs.language-name }}
+        RUN_WITH_MACOS: ${{ inputs.run-with-macos }}
+      run: |
+        # Resolve path to JSON matrix files
+        MATRICES_DIR="${GITHUB_WORKSPACE}/.github/json_matrices"
+
+        # --- Engine Matrix ---
+        ENGINE_FILE="${MATRICES_DIR}/engine-matrix.json"
+        if [[ ! -f "$ENGINE_FILE" ]]; then
+          echo "ERROR: Engine matrix file not found: $ENGINE_FILE"
+          exit 1
+        fi
+
+        if [[ "$RUN_FULL_MATRIX" == "true" ]]; then
+          ENGINE_MATRIX=$(jq -c '.' "$ENGINE_FILE")
+        else
+          ENGINE_MATRIX=$(jq -c '[.[] | select(.run == "always")]' "$ENGINE_FILE")
+        fi
+
+        # --- Host Matrix ---
+        HOST_FILE="${MATRICES_DIR}/build-matrix.json"
+        if [[ ! -f "$HOST_FILE" ]]; then
+          echo "ERROR: Build matrix file not found: $HOST_FILE"
+          exit 1
+        fi
+
+        # Filter by language
+        HOST_MATRIX=$(jq -c --arg lang "$LANGUAGE_NAME" \
+          '[.[] | select(.languages | index($lang))]' "$HOST_FILE")
+
+        # Handle macOS option
+        if [[ "$RUN_WITH_MACOS" == "use-github" ]]; then
+          MACOS_ENTRY="{\"OS\":\"macos\",\"NAMED_OS\":\"darwin\",\"RUNNER\":\"macos-latest\",\"ARCH\":\"arm64\",\"TARGET\":\"aarch64-apple-darwin\",\"languages\":[\"$LANGUAGE_NAME\"],\"run\":\"always\"}"
+          HOST_MATRIX=$(echo "$HOST_MATRIX" | jq -c --argjson macos "$MACOS_ENTRY" '. + [$macos]')
+        fi
+
+        # --- Version Matrix ---
+        VERSIONS_FILE="${MATRICES_DIR}/supported-languages-versions.json"
+        if [[ ! -f "$VERSIONS_FILE" ]]; then
+          echo "ERROR: Supported languages versions file not found: $VERSIONS_FILE"
+          exit 1
+        fi
+
+        LANG_ENTRY=$(jq -c --arg lang "$LANGUAGE_NAME" \
+          '.[] | select(.language == $lang)' "$VERSIONS_FILE")
+
+        if [[ -z "$LANG_ENTRY" ]]; then
+          echo "ERROR: Language '$LANGUAGE_NAME' not found in $VERSIONS_FILE"
+          exit 1
+        fi
+
+        if [[ "$RUN_FULL_MATRIX" == "true" ]]; then
+          VERSION_MATRIX=$(echo "$LANG_ENTRY" | jq -c '.versions')
+        else
+          VERSION_MATRIX=$(echo "$LANG_ENTRY" | jq -c '."always-run-versions"')
+        fi
+
+        # --- Set outputs ---
+        echo "engine-matrix-output=$ENGINE_MATRIX" >> "$GITHUB_OUTPUT"
+        echo "host-matrix-output=$HOST_MATRIX" >> "$GITHUB_OUTPUT"
+        echo "version-matrix-output=$VERSION_MATRIX" >> "$GITHUB_OUTPUT"
+
+        echo "Engine matrix: $ENGINE_MATRIX"
+        echo "Host matrix: $HOST_MATRIX"
+        echo "Version matrix: $VERSION_MATRIX"
+
+    - name: Validate matrices are non-empty
+      shell: bash
+      run: |
+        ENGINE_MATRIX='${{ steps.generate-matrices.outputs.engine-matrix-output }}'
+        HOST_MATRIX='${{ steps.generate-matrices.outputs.host-matrix-output }}'
+        VERSION_MATRIX='${{ steps.generate-matrices.outputs.version-matrix-output }}'
+
+        FAILED=0
+
+        if [[ $(echo "$ENGINE_MATRIX" | jq 'length') -eq 0 ]]; then
+          echo "ERROR: Engine matrix is empty"
+          FAILED=1
+        fi
+
+        if [[ $(echo "$HOST_MATRIX" | jq 'length') -eq 0 ]]; then
+          echo "ERROR: Host matrix is empty"
+          FAILED=1
+        fi
+
+        if [[ $(echo "$VERSION_MATRIX" | jq 'length') -eq 0 ]]; then
+          echo "ERROR: Version matrix is empty"
+          FAILED=1
+        fi
+
+        if [[ $FAILED -eq 1 ]]; then
+          echo "Matrix validation failed: one or more matrices are empty"
+          exit 1
+        fi
+
+        echo "All matrices validated successfully"

--- a/.github/workflows/create-test-matrices/action.yml
+++ b/.github/workflows/create-test-matrices/action.yml
@@ -58,14 +58,23 @@ runs:
           exit 1
         fi
 
-        # Filter by language
+        # Filter by language and exclude macOS entries (macOS is handled separately below)
         HOST_MATRIX=$(jq -c --arg lang "$LANGUAGE_NAME" \
-          '[.[] | select(.languages | index($lang))]' "$HOST_FILE")
+          '[.[] | select((.languages | index($lang)) and .OS != "macos")]' "$HOST_FILE")
 
         # Handle macOS option
         if [[ "$RUN_WITH_MACOS" == "use-github" ]]; then
-          MACOS_ENTRY="{\"OS\":\"macos\",\"NAMED_OS\":\"darwin\",\"RUNNER\":\"macos-latest\",\"ARCH\":\"arm64\",\"TARGET\":\"aarch64-apple-darwin\",\"languages\":[\"$LANGUAGE_NAME\"],\"run\":\"always\"}"
+          # Include macOS entries from build-matrix.json with matching runner
+          MAC_ENTRIES=$(jq --arg lang "$LANGUAGE_NAME" -c \
+            '[.[] | select(.OS == "macos" and (.languages | index($lang)))]' "$HOST_FILE")
+          HOST_MATRIX=$(echo "$HOST_MATRIX" | jq -c --argjson mac "$MAC_ENTRIES" '. + $mac')
+        elif [[ "$RUN_WITH_MACOS" == "use-self-hosted" ]]; then
+          # Override RUNNER with self-hosted label array
+          MACOS_ENTRY='{"OS":"macos","NAMED_OS":"darwin","RUNNER":["self-hosted","macOS","ARM64","ephemeral"],"ARCH":"arm64","TARGET":"aarch64-apple-darwin","languages":["'"$LANGUAGE_NAME"'"]}'
           HOST_MATRIX=$(echo "$HOST_MATRIX" | jq -c --argjson macos "$MACOS_ENTRY" '. + [$macos]')
+        elif [[ "$RUN_WITH_MACOS" != "false" ]]; then
+          echo "ERROR: Invalid run-with-macos value: '$RUN_WITH_MACOS'. Expected 'false', 'use-github', or 'use-self-hosted'."
+          exit 1
         fi
 
         # --- Version Matrix ---

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ Gemfile.lock
 
 # Used by RuboCop. Remote config files pulled in from inherit_from directive.
 .rubocop-https?--*
+
+# SDD (Spec-Driven Development) documents — local project documentation
+sdd/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,224 +1,47 @@
-# AGENTS: Ruby Client Context for Agentic Tools
+# AGENTS.md
 
-This file provides AI agents and developers with the minimum but sufficient context to work productively with the Valkey GLIDE Ruby client (`valkey-rb`). It covers build commands, testing, contribution requirements, and essential guardrails specific to the Ruby implementation.
+Valkey GLIDE for Ruby (`valkey-rb`): official Ruby client for Valkey, wrapping the Rust glide-core via FFI with a synchronous redis-rb-compatible API.
 
-## Repository Overview
+## SDD skill
 
-This is the **Ruby client** for Valkey GLIDE, published as the `valkey-rb` gem. It provides a synchronous, redis-rb-compatible API on top of the Rust GLIDE core via FFI.
+This project uses Spec-Driven Development (SDD). If you have access to the SDD skill, load it before taking any action on this project — it governs how to read, write, and maintain all project documentation. If the skill is unavailable, read the files in `sdd/` directly.
 
-**Primary Languages:** Ruby, Rust (FFI native library, built separately from [valkey-glide](https://github.com/valkey-io/valkey-glide))
+## Documentation
 
-**Build System:** Bundler, Rake, RubyGems
+Project documentation lives in the `sdd/` directory.
 
-**Architecture:** Ruby wrapper around `glide-ffi` (`libglide_ffi.so` / `.dylib`) — same FFI path as Go and Python sync clients
+### If you are exploring this project
 
-**Key Components:**
+Read these files first:
+- `sdd/PRODUCT.md` — What this project is and why it exists
+- `sdd/TDD.md` — Behavioral contract (test rubrics in Given/When/Then format)
 
-- `lib/valkey.rb` — Main client, pipelining, response conversion
-- `lib/valkey/bindings.rb` — FFI bindings
-- `lib/valkey/commands/` — Command modules
-- `lib/valkey/opentelemetry.rb` — Native OTel configuration
-- `test/valkey/` — Standalone integration tests
-- `test/cluster/` — Cluster integration tests
-- `test/lint/` — redis-rb compatibility lint suites
+### If you are contributing to this project
 
-## Architecture Quick Facts
+Read all of the above, plus:
+- `sdd/POLICY.md` — Development rules, build process, and constraints you must follow
+- `sdd/TECH.md` — Technical architecture, dependencies, and module responsibilities
 
-**Core Implementation:** Ruby wrapper around glide-core via `glide-ffi` cdylib
+### Detailed reference (read when relevant)
 
-**Client Types:** `Valkey` — standalone or cluster (`cluster_mode: true`)
+- `DEVELOPER.md` — Full developer setup guide (building from source, running tests, CI details)
+- `CONTRIBUTING.md` — PR process, DCO signoff, commit conventions
+- `CLAUDE.md` — Claude-specific workflow constraints
+- `README.md` — User-facing getting started and examples
 
-**API Style:** Synchronous, blocking calls (redis-rb style)
-
-**Communication:** Direct FFI (`Bindings.command`, `Bindings.batch`)
-
-**Supported Platforms:**
-
-- Linux: Ubuntu 20+, Amazon Linux 2/2023 (x86_64, aarch64)
-- macOS: 13.7+ (x86_64), 14.7+ (aarch64)
-- **Note:** Alpine Linux / MUSL is **not** supported
-
-**Ruby Versions:** 2.6, 2.7, 3.0, 3.1, 3.2, 3.3, 3.4, JRuby (CI matrix)
-
-**Gem name:** `valkey-rb` on RubyGems
-
-## Build and Test Rules (Agents)
-
-### Preferred (Bundler / Rake)
+## Quick build/test reference
 
 ```bash
-# Setup
-bin/setup                              # bundle install
-
-# Linting
-bundle exec rubocop
-
-# Testing
-bundle exec rake test                  # standalone + cluster
-bundle exec rake test:standalone       # standalone only
-bundle exec rake test:cluster          # cluster only (needs nodes 7000-7005)
-
-# Verbose / CI mode
-CI=1 bundle exec rake test:standalone
-
-# Console
-bundle exec bin/console
+bin/setup                           # bundle install
+bundle exec rubocop                 # lint
+bundle exec rake test:standalone    # needs Valkey on :6379
+bundle exec rake test:cluster       # needs cluster on :7000-7005
 ```
 
-### Raw Equivalents
+## Key constraints (see sdd/POLICY.md for full list)
 
-```bash
-# Run a single test file
-bundle exec ruby test/valkey/string_commands_test.rb
-
-# Run with custom port
-VALKEY_PORT=6379 TIMEOUT=10 bundle exec rake test:standalone
-
-# Load gem from lib/ without install
-RUBYOPT="-I$(pwd)/lib" ruby -r valkey -e 'p Valkey.new.ping'
-```
-
-### Test Prerequisites
-
-| Suite | Server requirement |
-|-------|-------------------|
-| `test:standalone` | Standalone Valkey/Redis on `localhost:6379` (DB 15) |
-| `test:cluster` | 6-node cluster on `127.0.0.1:7000`–`7005` |
-| SSL tests | TLS Valkey on port `6380` + certs in `test/fixtures/ssl/` |
-| Module tests | JSON, Bloom, Search modules loaded (see CI workflow) |
-
-### Rebuild Native FFI (when changing glide-core)
-
-```bash
-cd /path/to/valkey-glide/ffi
-cargo build --release
-cp target/release/libglide_ffi.so /path/to/valkey-glide-ruby/lib/valkey/   # Linux
-# cp target/release/libglide_ffi.dylib ...                                   # macOS
-```
-
-## Contribution Requirements
-
-### Developer Certificate of Origin (DCO) Signoff REQUIRED
-
-All commits must include a `Signed-off-by` line (per [valkey-glide CONTRIBUTING](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)):
-
-```bash
-git commit -s -m "feat(ruby): add new command implementation"
-git config --global format.signOff true
-```
-
-### Conventional Commits
-
-```
-<type>(<scope>): <description>
-```
-
-**Example:** `feat(ruby): implement CLUSTER SCAN with routing options`
-
-**Scopes:** `ruby`, or command family name when appropriate.
-
-### Code Quality Requirements
-
-**RuboCop (required before commit):**
-
-```bash
-bundle exec rubocop
-bundle exec rubocop -A   # auto-correct safe offenses
-```
-
-**Rust FFI (when updating native library):**
-
-```bash
-cd valkey-glide/ffi
-cargo clippy --all-features --all-targets -- -D warnings
-cargo fmt --manifest-path ./Cargo.toml --all
-```
-
-## Guardrails & Policies
-
-### Generated Outputs (Never Commit)
-
-- `*.gem` — built gem packages
-- `coverage/` — coverage reports
-- `tmp/`, `test/tmp/` — temporary test artifacts
-- Regenerated SSL certs unless intentionally updated (`test/fixtures/ssl/*.pem` may be committed for CI)
-- Wrong-platform `libglide_ffi` binaries (build per OS/arch)
-
-### Ruby-Specific Rules
-
-- **Ruby 2.6+ Required:** Minimum per `valkey.gemspec`
-- **FFI dependency:** `ffi ~> 1.17.0` — do not break ABI without rebuilding native lib
-- **Synchronous only:** No async client in this repo; do not add EventMachine/async patterns without design review
-- **redis-rb compatibility:** Prefer matching redis-rb method signatures and return types when implementing commands
-- **Command args:** All FFI args are strings; convert types in Ruby before `send_command`
-- **Pipeline transactions:** `MULTI`/`EXEC`/`DISCARD` in `pipelined` use sequential fallback — do not remove without fixing FFI batch stability
-- **OpenTelemetry:** Init once per process via `Valkey::OpenTelemetry.init`; spans created in FFI layer
-
-### Command Implementation Guidelines
-
-1. Check `RequestType` in `lib/valkey/request_type.rb` against glide-core `request_type.rs`
-2. Add method to appropriate `lib/valkey/commands/*.rb` module
-3. Use `send_command(RequestType::..., args)` 
-4. Add tests: `test/valkey/` + `test/lint/` when applicable
-5. Document with YARD comments + Valkey command link
-
-### Never Commit
-
-- Secrets, `.env` credentials, production URLs
-- Debug `puts` in production code paths (PubSub callback is intentional for now)
-
-## Project Structure (Essential)
-
-```text
-valkey-glide-ruby/
-├── lib/valkey.rb
-├── lib/valkey/
-│   ├── bindings.rb
-│   ├── libglide_ffi.{so,dylib}
-│   ├── commands/*.rb
-│   ├── opentelemetry.rb
-│   ├── pipeline.rb
-│   ├── request_type.rb
-│   └── response_type.rb
-├── test/valkey/          # standalone tests
-├── test/cluster/         # cluster tests
-├── test/lint/            # shared lint
-├── valkey.gemspec
-├── Rakefile
-└── .github/workflows/CI.yml
-```
-
-## Quality Gates (Agent Checklist)
-
-- [ ] `bundle exec rubocop` passes
-- [ ] `bundle exec rake test:standalone` passes (with Valkey running)
-- [ ] `bundle exec rake test:cluster` passes (if cluster commands touched)
-- [ ] New commands have tests in `test/valkey/` and lint coverage where applicable
-- [ ] `RequestType` matches glide-core enum
-- [ ] No secrets or generated junk committed
-- [ ] DCO signoff: `git log --format="%B" -n 1 | grep "Signed-off-by"`
-- [ ] Conventional commit format used
-- [ ] README / DEVELOPER.md updated if public API or setup changed
-- [ ] Native lib rebuilt and copied if FFI/protobuf changed upstream
-
-## Quick Facts for Reasoners
-
-**Package:** `valkey-rb` on RubyGems  
-**API Style:** Synchronous, redis-rb-compatible  
-**Client:** `Valkey.new` — standalone or `cluster_mode: true`  
-**Key Features:** Pipelining, OpenTelemetry (native), statistics, TLS, URL parsing, cluster routing  
-**Testing:** Minitest + rake tasks; lint suites for redis-rb parity  
-**Core repo:** [valkey-glide](https://github.com/valkey-io/valkey-glide) (`ffi/`, `glide-core/`)  
-**This repo:** [valkey-glide-ruby](https://github.com/valkey-io/valkey-glide-ruby)
-
-## If You Need More
-
-- **Getting Started:** [README.md](./README.md)
-- **Contributing:** [CONTRIBUTING.md](./CONTRIBUTING.md)
-- **Examples:** [examples/](./examples/)
-- **Development Setup:** [DEVELOPER.md](./DEVELOPER.md)
-- **Claude-specific rules:** [CLAUDE.md](./CLAUDE.md)
-- **Command coverage:** [Wiki — implementation status](https://github.com/valkey-io/valkey-glide-ruby/wiki/The-implementation-status-of-the-Valkey-commands)
-- **GLIDE docs:** [glide.valkey.io](https://glide.valkey.io/)
-- **Upstream FFI:** [valkey-glide/ffi](https://github.com/valkey-io/valkey-glide/tree/main/ffi)
-- **Other language AGENTS.md:** [valkey-glide/python/AGENTS.md](https://github.com/valkey-io/valkey-glide/blob/main/python/AGENTS.md), [java/AGENTS.md](https://github.com/valkey-io/valkey-glide/blob/main/java/AGENTS.md)
+- Synchronous only — no async patterns
+- All FFI args are strings — type conversion happens in Ruby
+- redis-rb API compatibility is a design goal
+- RequestType constants must match glide-core enum
+- DCO signoff required on all commits

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -58,7 +58,7 @@ valkey-glide-ruby/
 - **Bundler**
 - **git**
 - **Valkey** or Redis OSS (for integration tests)
-- **Docker** (optional; matches CI setup)
+- **Docker** (optional; only needed for module tests with `valkey-bundle` image)
 
 To **build** the native FFI library from source:
 
@@ -188,21 +188,25 @@ Default test configuration (see `test/test_helper.rb`):
 |----------|---------|---------|
 | `VALKEY_PORT` | `6379` | Plain TCP |
 | `VALKEY_SSL_PORT` | `6380` | TLS (optional) |
+| `TLS_CERT_DIR` | `valkey-glide/utils/tls_crts` | Path to TLS certs (set by CI) |
 | `TIMEOUT` | `5.0` | Client timeout |
 | DB | `15` | Test database |
 
 ```bash
-# Example: Docker standalone (matches CI)
-docker run -d --name valkey-test -p 6379:6379 valkey/valkey:8 \
-  valkey-server --enable-module-command yes
+# Preferred: use cluster_manager.py (same as CI and all other GLIDE clients)
+python3 valkey-glide/utils/cluster_manager.py start -r 0 -p 6379 --prefix standalone
+
+# Alternative: Docker standalone
+docker run -d --name valkey-test -p 6379:6379 valkey/valkey:8 valkey-server
 ```
 
 ### Start Valkey Cluster
 
-Cluster tests expect six nodes on `127.0.0.1:7000`–`7005`. CI uses `grokzen/redis-cluster:7.0.15`.
+Cluster tests auto-start via `cluster_manager.py` (the `TestCluster` class handles lifecycle).
+You can also start manually:
 
 ```bash
-docker run -d --name redis-cluster -p 7000-7005:7000-7005 grokzen/redis-cluster:7.0.15
+python3 valkey-glide/utils/cluster_manager.py start --cluster-mode --prefix cluster
 ```
 
 ### Run Tests
@@ -222,21 +226,33 @@ CI=1 bundle exec rake test:standalone
 
 ### SSL Tests
 
-Generate test certificates:
+The preferred approach (matching CI and all other GLIDE clients) uses `cluster_manager.py`:
+
+```bash
+# Start a TLS-only server on port 6380 (generates certs in valkey-glide/utils/tls_crts/)
+python3 valkey-glide/utils/cluster_manager.py --tls start -r 0 -p 6380 --prefix tls-standalone
+
+# Point tests at the generated certs
+export TLS_CERT_DIR=$(pwd)/valkey-glide/utils/tls_crts
+
+# Run tests
+bundle exec rake test:standalone
+
+# Stop the TLS server
+python3 valkey-glide/utils/cluster_manager.py --tls stop --prefix tls-standalone
+```
+
+Alternatively, for local development without Python, generate certs and start manually:
 
 ```bash
 ruby test/fixtures/ssl/generate_certs.rb
+# Then start a TLS Valkey server on port 6380 using those certs
 ```
-
-Start TLS Valkey on port 6380 (see `.github/workflows/CI.yml` for a full Docker example).
 
 ### Module Tests (JSON, Bloom, Search)
 
-CI copies prebuilt modules into `test/fixtures/`:
-
-- `redisjson.so` — JSON commands
-- `redisbloom.so` — Bloom filters
-- `redisearch.so` — Vector / FT commands
+CI uses the shared `start-valkey-docker` action with `valkey/valkey-bundle:9.1` (modules pre-loaded).
+Tests connect via `STANDALONE_ENDPOINTS` env var.
 
 Load modules when starting Valkey if you run module-specific tests locally.
 
@@ -427,7 +443,7 @@ ruby -e "require 'valkey'; c = Valkey.new; puts c.ping; c.close"
 | `LoadError` / FFI library not found | Confirm `lib/valkey/libglide_ffi.{so,dylib}` exists and matches your OS/arch. |
 | Wrong architecture after FFI rebuild | Rebuild `glide-ffi` on the target platform; do not copy Linux `.so` to macOS. |
 | Cluster tests flaky | Wait for `cluster_state:ok`; increase `TIMEOUT` env var. |
-| SSL test failures | Regenerate certs: `ruby test/fixtures/ssl/generate_certs.rb`. |
+| SSL test failures | Use `cluster_manager.py --tls` (see SSL Tests above), or regenerate local certs: `ruby test/fixtures/ssl/generate_certs.rb`. |
 | Pipeline / MULTI crashes | Transaction commands in `pipelined` use sequential fallback by design. |
 
 ## Recommended Editor Extensions

--- a/README.md
+++ b/README.md
@@ -257,6 +257,17 @@ For AI-assisted development, see [AGENTS.md](./AGENTS.md) and [CLAUDE.md](./CLAU
 
 Contributing: [CONTRIBUTING.md](./CONTRIBUTING.md).
 
+## Project Documentation (SDD)
+
+Detailed project documentation lives in the `sdd/` directory:
+
+- `sdd/PRODUCT.md` — Product definition and rationale
+- `sdd/TECH.md` — Technical architecture and system diagram
+- `sdd/TDD.md` — Test specifications (Given/When/Then rubrics)
+- `sdd/POLICY.md` — Development rules and constraints
+
+For AI-assisted development, see [AGENTS.md](./AGENTS.md) and [CLAUDE.md](./CLAUDE.md).
+
 ## Community and Feedback
 
 We encourage you to join our community to support, share feedback, and ask questions on Valkey Slack: [Join Valkey Slack](https://join.slack.com/t/valkey-oss-developer/shared_invite/zt-2nxs51chx-EB9hu9Qdch3GMfRcztTSkQ).

--- a/lib/valkey.rb
+++ b/lib/valkey.rb
@@ -243,13 +243,12 @@ class Valkey
   end
 
   def send_command(command_type, command_args = [], &block)
-    # Validate connection
-    if @connection.nil?
-      raise "Connection is nil"
-    elsif @connection.null?
-      raise "Connection pointer is null"
-    elsif @connection.address.zero?
-      raise "Connection address is 0"
+    # Validate connection. A nil/null pointer means the client was closed (or
+    # never established a usable connection); surface it as a typed error with
+    # the same "the client is closed" wording the sibling GLIDE clients use
+    # (Go ClosingError, Node/Java ClosingException).
+    if @connection.nil? || @connection.null? || @connection.address.zero?
+      raise ConnectionError, "the client is closed"
     end
 
     channel = 0

--- a/lib/valkey.rb
+++ b/lib/valkey.rb
@@ -15,6 +15,8 @@ require "valkey/errors"
 require "valkey/pubsub_callback"
 require "valkey/pipeline"
 require "valkey/opentelemetry"
+require "valkey/search/field"
+require "valkey/search/ft_create_options"
 
 class Valkey
   include Utils

--- a/lib/valkey.rb
+++ b/lib/valkey.rb
@@ -17,6 +17,10 @@ require "valkey/pipeline"
 require "valkey/opentelemetry"
 require "valkey/search/field"
 require "valkey/search/ft_create_options"
+require "valkey/search/ft_search_options"
+require "valkey/search/ft_search_result"
+require "valkey/search/ft_aggregate_options"
+require "valkey/search/ft_info_options"
 
 class Valkey
   include Utils

--- a/lib/valkey.rb
+++ b/lib/valkey.rb
@@ -247,9 +247,7 @@ class Valkey
     # never established a usable connection); surface it as a typed error with
     # the same "the client is closed" wording the sibling GLIDE clients use
     # (Go ClosingError, Node/Java ClosingException).
-    if @connection.nil? || @connection.null? || @connection.address.zero?
-      raise ConnectionError, "the client is closed"
-    end
+    raise ConnectionError, "the client is closed" if @connection.nil? || @connection.null? || @connection.address.zero?
 
     channel = 0
     route = ""

--- a/lib/valkey/commands/cluster_commands.rb
+++ b/lib/valkey/commands/cluster_commands.rb
@@ -71,13 +71,30 @@ class Valkey
         send_command(RequestType::CLUSTER_DEL_SLOTS_RANGE, [start_slot, end_slot])
       end
 
+      # Valid modes for CLUSTER FAILOVER: FORCE, TAKEOVER.
+      CLUSTER_FAILOVER_MODES = %i[force takeover].freeze
+
       # Force a failover of the cluster.
       #
-      # @param [String] force force the failover
+      # Must be sent to a replica node. Without a mode, performs a coordinated
+      # failover (the primary is asked to pause clients and hand over). +:force+
+      # promotes the replica without coordinating with the primary (useful when
+      # the primary is unreachable); +:takeover+ promotes it without any cluster
+      # consensus (most aggressive — risks data loss / split brain).
+      #
+      # @param [Symbol, nil] mode optional failover mode: +:force+ or +:takeover+
       # @return [String] `"OK"`
-      def cluster_failover(force = nil)
+      # @raise [ArgumentError] if +mode+ is not nil, +:force+, or +:takeover+
+      # @see https://valkey.io/commands/cluster-failover/
+      def cluster_failover(mode = nil)
         args = []
-        args << "FORCE" if force
+        unless mode.nil?
+          unless CLUSTER_FAILOVER_MODES.include?(mode)
+            raise ArgumentError, "invalid CLUSTER FAILOVER mode #{mode.inspect}: expected :force or :takeover"
+          end
+
+          args << mode.to_s.upcase
+        end
         send_command(RequestType::CLUSTER_FAILOVER, args)
       end
 

--- a/lib/valkey/commands/connection_commands.rb
+++ b/lib/valkey/commands/connection_commands.rb
@@ -299,8 +299,9 @@ class Valkey
           when :redirect
             args << "REDIRECT" << value.to_s
           when :prefix
-            args << "PREFIX"
-            Array(value).each { |prefix| args << prefix }
+            # Valkey requires the PREFIX keyword before each prefix value,
+            # e.g. PREFIX foo PREFIX bar.
+            Array(value).each { |prefix| args << "PREFIX" << prefix }
           when :bcast
             args << "BCAST" if value
           when :optin

--- a/lib/valkey/commands/connection_commands.rb
+++ b/lib/valkey/commands/connection_commands.rb
@@ -136,8 +136,10 @@ class Valkey
 
         send_command(RequestType::CLIENT_LIST, args) do |reply|
           reply.lines.map do |line|
-            entries = line.chomp.split(/[ =]/)
-            entries.each_slice(2).to_a.to_h
+            line.chomp.split.each_with_object({}) do |pair, hash|
+              key, value = pair.split("=", 2)
+              hash[key] = value || ""
+            end
           end
         end
       end

--- a/lib/valkey/commands/connection_commands.rb
+++ b/lib/valkey/commands/connection_commands.rb
@@ -94,7 +94,7 @@ class Valkey
       #   client(:set_name, "my_app")  # => "OK"
       #   client(:list)                # => [{"id" => "1", ...}, ...]
       def client(subcommand, *args)
-        send("client_#{subcommand.to_s.downcase}", *args)
+        public_send("client_#{subcommand.to_s.downcase}", *args)
       end
 
       # Get the current client's ID.
@@ -289,6 +289,12 @@ class Valkey
       def client_no_touch(mode)
         send_command(RequestType::CLIENT_NO_TOUCH, [mode.to_s.upcase])
       end
+
+      # Client-side caching commands are intentionally private.
+      #
+      # GLIDE's managed client-side caching is not yet implemented in the Ruby client
+      # These commands are not meant to be called directly and will be kept private.
+      private :client_tracking, :client_caching, :client_tracking_info, :client_getredir
 
       private
 

--- a/lib/valkey/commands/server_commands.rb
+++ b/lib/valkey/commands/server_commands.rb
@@ -499,13 +499,19 @@ class Valkey
       # @see https://valkey.io/commands/failover/
       def failover(to: nil, force: false, abort: false, timeout: nil)
         args = []
-        if to
-          host, port = to.split
-          args << "TO" << host << port
+        if abort
+          # ABORT is mutually exclusive: cancels an ongoing failover and
+          # ignores any other arguments (matches the core GLIDE clients).
+          args << "ABORT"
+        else
+          if to
+            host, port = to.split
+            args << "TO" << host << port
+            # FORCE is only valid in combination with TO.
+            args << "FORCE" if force
+          end
+          args << "TIMEOUT" << timeout.to_s if timeout
         end
-        args << "FORCE" if force
-        args << "ABORT" if abort
-        args << "TIMEOUT" << timeout.to_s if timeout
         send_command(RequestType::FAIL_OVER, args)
       end
 

--- a/lib/valkey/commands/vector_search_commands.rb
+++ b/lib/valkey/commands/vector_search_commands.rb
@@ -99,24 +99,57 @@ class Valkey
 
       # Create a search index with the given schema.
       #
-      # @example Create a basic index
+      # Supports two calling conventions:
+      #
+      # 1. **Raw args** (original interface, backward-compatible):
+      #    Pass all FT.CREATE arguments as positional strings.
+      #
+      # 2. **Structured options** (new, recommended):
+      #    Pass +fields:+ (array of {Valkey::Search::Field} subclasses) and
+      #    optionally +options:+ ({Valkey::Search::FtCreateOptions}).
+      #
+      # @example Raw args (backward-compatible)
       #   valkey.ft_create("myIndex", "SCHEMA", "title", "TEXT", "price", "NUMERIC")
       #     # => "OK"
       #
-      # @example Create an index with vector field
+      # @example Raw args with vector field
       #   valkey.ft_create("vecIndex", "ON", "HASH", "PREFIX", "1", "doc:",
       #                    "SCHEMA", "embedding", "VECTOR", "HNSW", "6",
       #                    "TYPE", "FLOAT32", "DIM", "128", "DISTANCE_METRIC", "COSINE")
       #     # => "OK"
       #
-      # @param [String] index the index name
-      # @param [Array<String>] args schema definition and options
+      # @example Structured options
+      #   valkey.ft_create("myIndex",
+      #     fields: [
+      #       Valkey::Search::TextField.new("title", sortable: true),
+      #       Valkey::Search::NumericField.new("price", sortable: true),
+      #       Valkey::Search::VectorFieldHnsw.new("embedding",
+      #         dim: 128, distance_metric: :cosine)
+      #     ],
+      #     options: Valkey::Search::FtCreateOptions.new(
+      #       data_type: :hash, prefixes: ["doc:"]
+      #     )
+      #   )
+      #     # => "OK"
+      #
+      # @param index [String] the index name
+      # @param args [Array<String>] raw schema definition and options (legacy interface)
+      # @param fields [Array<Valkey::Search::Field>, nil] structured field definitions
+      # @param options [Valkey::Search::FtCreateOptions, nil] index-level options
       # @return [String] "OK" on success
       #
-      # @see https://redis.io/commands/ft.create/
-      def ft_create(index, *args)
-        command_args = [index] + args
-        send_command(RequestType::FT_CREATE, command_args)
+      # @see https://valkey.io/commands/ft.create/
+      def ft_create(index, *args, fields: nil, options: nil)
+        if fields
+          command_args = [index]
+          command_args.concat(options.to_args) if options
+          command_args << "SCHEMA"
+          fields.each { |field| command_args.concat(field.to_args) }
+          send_command(RequestType::FT_CREATE, command_args)
+        else
+          command_args = [index] + args
+          send_command(RequestType::FT_CREATE, command_args)
+        end
       end
 
       # Drop an index and optionally delete all documents.

--- a/lib/valkey/commands/vector_search_commands.rb
+++ b/lib/valkey/commands/vector_search_commands.rb
@@ -25,19 +25,44 @@ class Valkey
 
       # Run a search query with aggregations.
       #
-      # @example Perform an aggregation query
-      #   valkey.ft_aggregate("myIndex", "*", "GROUPBY", "1", "@category", "REDUCE", "COUNT", "0", "AS", "count")
-      #     # => [[1, ["category", "electronics", "count", "5"]]]
+      # Supports two calling conventions:
       #
-      # @param [String] index the index name to search
-      # @param [String] query the search query
-      # @param [Array<String>] args additional query arguments (GROUPBY, REDUCE, etc.)
+      # 1. **Raw args** (original interface, backward-compatible):
+      #    Pass all FT.AGGREGATE arguments as positional strings.
+      #
+      # 2. **Structured options** (new, recommended):
+      #    Pass +options:+ ({Valkey::Search::FtAggregateOptions}) with pipeline
+      #    clauses and query-level settings.
+      #
+      # @example Raw args (backward-compatible)
+      #   valkey.ft_aggregate("myIndex", "*", "GROUPBY", "1", "@category",
+      #                       "REDUCE", "COUNT", "0", "AS", "count")
+      #
+      # @example Structured options
+      #   valkey.ft_aggregate("myIndex", "@price:[0 inf]",
+      #     options: Valkey::Search::FtAggregateOptions.new(
+      #       load_fields: ["@price"],
+      #       clauses: [
+      #         Valkey::Search::GroupBy.new(["@category"],
+      #           reducers: [Valkey::Search::Reducer.new("SUM", ["@price"], name: "total")])
+      #       ]
+      #     ))
+      #
+      # @param index [String] the index name to search
+      # @param query [String] the search query
+      # @param args [Array<String>] additional query arguments (legacy interface)
+      # @param options [Valkey::Search::FtAggregateOptions, nil] structured options
       # @return [Array] aggregation results
       #
-      # @see https://redis.io/commands/ft.aggregate/
-      def ft_aggregate(index, query, *args)
-        command_args = [index, query] + args
-        send_command(RequestType::FT_AGGREGATE, command_args)
+      # @see https://valkey.io/commands/ft.aggregate/
+      def ft_aggregate(index, query, *args, options: nil)
+        if options
+          command_args = [index, query] + options.to_args
+          send_command(RequestType::FT_AGGREGATE, command_args)
+        else
+          command_args = [index, query] + args
+          send_command(RequestType::FT_AGGREGATE, command_args)
+        end
       end
 
       # Add an alias to an index.
@@ -213,12 +238,19 @@ class Valkey
       #   valkey.ft_info("myIndex")
       #     # => ["index_name", "myIndex", "fields", [...], ...]
       #
-      # @param [String] index the index name
+      # @example Get cluster-wide info
+      #   valkey.ft_info("myIndex",
+      #     options: Valkey::Search::FtInfoOptions.new(scope: :cluster))
+      #
+      # @param index [String] the index name
+      # @param options [Valkey::Search::FtInfoOptions, nil] cluster scope options
       # @return [Array] index information as array of key-value pairs
       #
-      # @see https://redis.io/commands/ft.info/
-      def ft_info(index)
-        send_command(RequestType::FT_INFO, [index])
+      # @see https://valkey.io/commands/ft.info/
+      def ft_info(index, options: nil)
+        args = [index]
+        args.concat(options.to_args) if options
+        send_command(RequestType::FT_INFO, args)
       end
 
       # Profile a search or aggregation query.
@@ -244,30 +276,54 @@ class Valkey
 
       # Search an index with a query.
       #
-      # @example Basic search
-      #   valkey.ft_search("myIndex", "hello world")
-      #     # => [1, "doc1", ["title", "hello world"]]
+      # Supports two calling conventions:
       #
-      # @example Search with options
-      #   valkey.ft_search("myIndex", "@title:hello", "LIMIT", "0", "10", "RETURN", "2", "title", "price")
-      #     # => [total_results, doc_id, [field1, value1, field2, value2], ...]
+      # 1. **Raw args** (original interface, backward-compatible):
+      #    Pass all FT.SEARCH options as positional strings. Returns the raw
+      #    response array.
+      #
+      # 2. **Structured options** (new, recommended):
+      #    Pass +options:+ ({Valkey::Search::FtSearchOptions}). Returns a
+      #    {Valkey::Search::FtSearchResult} with typed documents.
+      #
+      # @example Raw args (backward-compatible)
+      #   valkey.ft_search("myIndex", "hello world")
+      #     # => [1, {"doc1" => {"title" => "hello world"}}]
+      #
+      # @example Structured options with pagination
+      #   result = valkey.ft_search("myIndex", "@title:hello",
+      #     options: Valkey::Search::FtSearchOptions.new(
+      #       limit: Valkey::Search::FtSearchLimit.new(offset: 0, count: 10),
+      #       return_fields: [Valkey::Search::ReturnField.new("title")]
+      #     ))
+      #   result.total_results  # => 2
+      #   result.documents.first["title"]  # => "hello world"
       #
       # @example Vector similarity search
-      #   valkey.ft_search("vecIndex", "*=>[KNN 5 @embedding $vec]",
-      #                    "PARAMS", "2", "vec", vector_blob,
-      #                    "RETURN", "1", "__embedding_score",
-      #                    "DIALECT", "2")
-      #     # => [results_count, doc_id, ["__embedding_score", "0.95"], ...]
+      #   result = valkey.ft_search("vecIndex", "*=>[KNN 5 @embedding $vec]",
+      #     options: Valkey::Search::FtSearchOptions.new(
+      #       params: { "vec" => vector_blob },
+      #       dialect: 2
+      #     ))
+      #   result.total_results  # => 5
       #
-      # @param [String] index the index name
-      # @param [String] query the search query
-      # @param [Array<String>] args additional query arguments (LIMIT, RETURN, SORTBY, etc.)
-      # @return [Array] search results with total count and matching documents
+      # @param index [String] the index name
+      # @param query [String] the search query
+      # @param args [Array<String>] additional query arguments (legacy interface)
+      # @param options [Valkey::Search::FtSearchOptions, nil] structured options
+      # @return [Array, Valkey::Search::FtSearchResult] raw array (legacy) or
+      #   structured result (when options: is provided)
       #
-      # @see https://redis.io/commands/ft.search/
-      def ft_search(index, query, *args)
-        command_args = [index, query] + args
-        send_command(RequestType::FT_SEARCH, command_args)
+      # @see https://valkey.io/commands/ft.search/
+      def ft_search(index, query, *args, options: nil)
+        if options
+          command_args = [index, query] + options.to_args
+          raw = send_command(RequestType::FT_SEARCH, command_args)
+          Search::FtSearchResult.from_raw(raw, withsortkeys: options.withsortkeys)
+        else
+          command_args = [index, query] + args
+          send_command(RequestType::FT_SEARCH, command_args)
+        end
       end
 
       # Convenience method for FT.* commands.

--- a/lib/valkey/search/field.rb
+++ b/lib/valkey/search/field.rb
@@ -1,0 +1,296 @@
+# frozen_string_literal: true
+
+class Valkey
+  module Search
+    # Base class for FT.CREATE field definitions.
+    # Subclasses implement {#to_args} to serialize into the argument array
+    # expected by the FT.CREATE SCHEMA clause.
+    #
+    # @abstract Subclass and override {#to_args}
+    class Field
+      # @return [String] the field name as it appears in the indexed document
+      attr_reader :name
+
+      # @return [String, nil] optional alias used to reference this field in queries
+      attr_reader :field_alias
+
+      # @return [Boolean] whether the field is sortable
+      attr_reader :sortable
+
+      # @param name [String] field name in the document
+      # @param field_alias [String, nil] alias for queries (AS <alias>)
+      # @param sortable [Boolean] enable SORTBY on this field
+      def initialize(name, field_alias: nil, sortable: false)
+        @name = name.to_s
+        @field_alias = field_alias&.to_s
+        @sortable = sortable
+      end
+
+      # Serialize the field definition into an array of strings suitable for
+      # appending after the SCHEMA keyword in FT.CREATE.
+      #
+      # @return [Array<String>]
+      # @abstract
+      def to_args
+        raise NotImplementedError, "#{self.class}#to_args must be implemented"
+      end
+
+      private
+
+      # Common trailing args shared by text/numeric/tag fields.
+      def base_trailing_args
+        args = []
+        args.push("AS", @field_alias) if @field_alias
+        args
+      end
+
+      def sortable_args
+        @sortable ? ["SORTABLE"] : []
+      end
+    end
+
+    # A full-text searchable field.
+    #
+    # @example
+    #   Valkey::Search::TextField.new("title", sortable: true, weight: 2.0)
+    #
+    # @see https://valkey.io/commands/ft.create/
+    class TextField < Field
+      # @return [Boolean] disable stemming for this field
+      attr_reader :nostem
+
+      # @return [Float, nil] scoring weight (default 1.0)
+      attr_reader :weight
+
+      # @return [Boolean] enable suffix trie optimization
+      attr_reader :withsuffixtrie
+
+      # @return [Boolean] disable suffix trie optimization
+      attr_reader :nosuffixtrie
+
+      # @param name [String] field name
+      # @param field_alias [String, nil] query alias
+      # @param sortable [Boolean] enable SORTBY
+      # @param nostem [Boolean] disable stemming
+      # @param weight [Float, nil] scoring weight
+      # @param withsuffixtrie [Boolean] enable suffix trie
+      # @param nosuffixtrie [Boolean] disable suffix trie
+      def initialize(name, field_alias: nil, sortable: false, nostem: false,
+                     weight: nil, withsuffixtrie: false, nosuffixtrie: false)
+        super(name, field_alias: field_alias, sortable: sortable)
+        @nostem = nostem
+        @weight = weight
+        @withsuffixtrie = withsuffixtrie
+        @nosuffixtrie = nosuffixtrie
+      end
+
+      # @return [Array<String>]
+      def to_args
+        args = [@name]
+        args.concat(base_trailing_args)
+        args << "TEXT"
+        args << "NOSTEM" if @nostem
+        args.push("WEIGHT", @weight.to_s) if @weight
+        args << "WITHSUFFIXTRIE" if @withsuffixtrie
+        args << "NOSUFFIXTRIE" if @nosuffixtrie
+        args.concat(sortable_args)
+        args
+      end
+    end
+
+    # A numeric field for range queries.
+    #
+    # @example
+    #   Valkey::Search::NumericField.new("price", sortable: true)
+    #
+    # @see https://valkey.io/commands/ft.create/
+    class NumericField < Field
+      # @param name [String] field name
+      # @param field_alias [String, nil] query alias
+      # @param sortable [Boolean] enable SORTBY
+      def initialize(name, field_alias: nil, sortable: false)
+        super(name, field_alias: field_alias, sortable: sortable)
+      end
+
+      # @return [Array<String>]
+      def to_args
+        args = [@name]
+        args.concat(base_trailing_args)
+        args << "NUMERIC"
+        args.concat(sortable_args)
+        args
+      end
+    end
+
+    # A tag field for exact-match filtering using comma-separated values.
+    #
+    # @example
+    #   Valkey::Search::TagField.new("category", separator: ";", case_sensitive: true)
+    #
+    # @see https://valkey.io/commands/ft.create/
+    class TagField < Field
+      # @return [String, nil] separator character (default comma)
+      attr_reader :separator
+
+      # @return [Boolean] whether tag matching is case-sensitive
+      attr_reader :case_sensitive
+
+      # @param name [String] field name
+      # @param field_alias [String, nil] query alias
+      # @param sortable [Boolean] enable SORTBY
+      # @param separator [String, nil] tag separator character
+      # @param case_sensitive [Boolean] enable case-sensitive matching
+      def initialize(name, field_alias: nil, sortable: false, separator: nil, case_sensitive: false)
+        super(name, field_alias: field_alias, sortable: sortable)
+        @separator = separator&.to_s
+        @case_sensitive = case_sensitive
+      end
+
+      # @return [Array<String>]
+      def to_args
+        args = [@name]
+        args.concat(base_trailing_args)
+        args << "TAG"
+        args.push("SEPARATOR", @separator) if @separator
+        args << "CASESENSITIVE" if @case_sensitive
+        args.concat(sortable_args)
+        args
+      end
+    end
+
+    # A vector field using the FLAT (brute-force) indexing algorithm.
+    #
+    # @example
+    #   Valkey::Search::VectorFieldFlat.new("embedding",
+    #     dim: 768, distance_metric: :cosine, type: :float32,
+    #     initial_cap: 1000)
+    #
+    # @see https://valkey.io/commands/ft.create/
+    class VectorFieldFlat < Field
+      # @return [Integer] vector dimensions
+      attr_reader :dim
+
+      # @return [Symbol] distance metric (:cosine, :l2, :ip)
+      attr_reader :distance_metric
+
+      # @return [Symbol] vector element type (:float32, :float64, :bfloat16, :float16)
+      attr_reader :type
+
+      # @return [Integer, nil] initial index capacity
+      attr_reader :initial_cap
+
+      # @param name [String] field name
+      # @param dim [Integer] number of dimensions
+      # @param distance_metric [Symbol, String] :cosine, :l2, or :ip
+      # @param type [Symbol, String] :float32, :float64, :bfloat16, or :float16
+      # @param field_alias [String, nil] query alias
+      # @param initial_cap [Integer, nil] initial vector capacity hint
+      def initialize(name, dim:, distance_metric:, type: :float32,
+                     field_alias: nil, initial_cap: nil)
+        super(name, field_alias: field_alias, sortable: false)
+        @dim = dim
+        @distance_metric = distance_metric.to_s.upcase.to_sym
+        @type = type.to_s.upcase.to_sym
+        @initial_cap = initial_cap
+      end
+
+      # @return [Array<String>]
+      def to_args
+        attrs = vector_attributes
+        args = [@name]
+        args.concat(base_trailing_args)
+        args.push("VECTOR", "FLAT", attrs.size.to_s)
+        args.concat(attrs)
+        args
+      end
+
+      private
+
+      def vector_attributes
+        attrs = []
+        attrs.push("TYPE", @type.to_s)
+        attrs.push("DIM", @dim.to_s)
+        attrs.push("DISTANCE_METRIC", @distance_metric.to_s)
+        attrs.push("INITIAL_CAP", @initial_cap.to_s) if @initial_cap
+        attrs
+      end
+    end
+
+    # A vector field using the HNSW (hierarchical navigable small world) algorithm.
+    #
+    # @example
+    #   Valkey::Search::VectorFieldHnsw.new("embedding",
+    #     dim: 768, distance_metric: :cosine, type: :float32,
+    #     m: 16, ef_construction: 200, ef_runtime: 10)
+    #
+    # @see https://valkey.io/commands/ft.create/
+    class VectorFieldHnsw < Field
+      # @return [Integer] vector dimensions
+      attr_reader :dim
+
+      # @return [Symbol] distance metric (:cosine, :l2, :ip)
+      attr_reader :distance_metric
+
+      # @return [Symbol] vector element type (:float32, :float64, :bfloat16, :float16)
+      attr_reader :type
+
+      # @return [Integer, nil] initial index capacity
+      attr_reader :initial_cap
+
+      # @return [Integer, nil] number of edges per node (default 16)
+      attr_reader :m
+
+      # @return [Integer, nil] vectors examined during construction (default 200)
+      attr_reader :ef_construction
+
+      # @return [Integer, nil] vectors examined during search (default 10)
+      attr_reader :ef_runtime
+
+      # @param name [String] field name
+      # @param dim [Integer] number of dimensions
+      # @param distance_metric [Symbol, String] :cosine, :l2, or :ip
+      # @param type [Symbol, String] :float32, :float64, :bfloat16, or :float16
+      # @param field_alias [String, nil] query alias
+      # @param initial_cap [Integer, nil] initial vector capacity hint
+      # @param m [Integer, nil] max edges per node in HNSW graph
+      # @param ef_construction [Integer, nil] vectors examined during index build
+      # @param ef_runtime [Integer, nil] vectors examined during search
+      def initialize(name, dim:, distance_metric:, type: :float32,
+                     field_alias: nil, initial_cap: nil,
+                     m: nil, ef_construction: nil, ef_runtime: nil)
+        super(name, field_alias: field_alias, sortable: false)
+        @dim = dim
+        @distance_metric = distance_metric.to_s.upcase.to_sym
+        @type = type.to_s.upcase.to_sym
+        @initial_cap = initial_cap
+        @m = m
+        @ef_construction = ef_construction
+        @ef_runtime = ef_runtime
+      end
+
+      # @return [Array<String>]
+      def to_args
+        attrs = vector_attributes
+        args = [@name]
+        args.concat(base_trailing_args)
+        args.push("VECTOR", "HNSW", attrs.size.to_s)
+        args.concat(attrs)
+        args
+      end
+
+      private
+
+      def vector_attributes
+        attrs = []
+        attrs.push("TYPE", @type.to_s)
+        attrs.push("DIM", @dim.to_s)
+        attrs.push("DISTANCE_METRIC", @distance_metric.to_s)
+        attrs.push("INITIAL_CAP", @initial_cap.to_s) if @initial_cap
+        attrs.push("M", @m.to_s) if @m
+        attrs.push("EF_CONSTRUCTION", @ef_construction.to_s) if @ef_construction
+        attrs.push("EF_RUNTIME", @ef_runtime.to_s) if @ef_runtime
+        attrs
+      end
+    end
+  end
+end

--- a/lib/valkey/search/ft_aggregate_options.rb
+++ b/lib/valkey/search/ft_aggregate_options.rb
@@ -1,0 +1,306 @@
+# frozen_string_literal: true
+
+class Valkey
+  module Search
+    # A reducer function used within a {GroupBy} clause.
+    #
+    # @example
+    #   Valkey::Search::Reducer.new("SUM", ["@price"], name: "total")
+    #   Valkey::Search::Reducer.new("COUNT", [], name: "count")
+    #
+    # @see https://valkey.io/commands/ft.aggregate/
+    class Reducer
+      # @return [String] the reduction function (COUNT, SUM, AVG, MIN, MAX, etc.)
+      attr_reader :function
+
+      # @return [Array<String>] arguments for the reducer
+      attr_reader :args
+
+      # @return [String, nil] alias for the reduced value
+      attr_reader :name
+
+      # @param function [String] reduction function name
+      # @param args [Array<String>] reducer arguments (field references, etc.)
+      # @param name [String, nil] output property name (AS alias)
+      def initialize(function, args = [], name: nil)
+        @function = function.to_s.upcase
+        @args = args.map(&:to_s)
+        @name = name&.to_s
+      end
+
+      # @return [Array<String>]
+      def to_args
+        result = ["REDUCE", @function, @args.size.to_s]
+        result.concat(@args)
+        result.push("AS", @name) if @name
+        result
+      end
+    end
+
+    # GROUPBY pipeline clause for FT.AGGREGATE.
+    #
+    # @example
+    #   Valkey::Search::GroupBy.new(["@category"],
+    #     reducers: [Valkey::Search::Reducer.new("COUNT", [], name: "count")])
+    #
+    # @see https://valkey.io/commands/ft.aggregate/
+    class GroupBy
+      # @return [Array<String>] properties to group by
+      attr_reader :properties
+
+      # @return [Array<Reducer>] reducers applied to each group
+      attr_reader :reducers
+
+      # @param properties [Array<String>] field names to group by
+      # @param reducers [Array<Reducer>] reducer functions
+      def initialize(properties, reducers: [])
+        @properties = properties.map(&:to_s)
+        @reducers = reducers
+      end
+
+      # @return [Array<String>]
+      def to_args
+        args = ["GROUPBY", @properties.size.to_s]
+        args.concat(@properties)
+        @reducers.each { |r| args.concat(r.to_args) }
+        args
+      end
+    end
+
+    # A single sort property within a {SortBy} clause.
+    #
+    # @example
+    #   Valkey::Search::SortProperty.new("@price", :asc)
+    #
+    class SortProperty
+      # @return [String] property name
+      attr_reader :property
+
+      # @return [Symbol] sort direction (:asc or :desc)
+      attr_reader :order
+
+      # @param property [String] field name to sort by
+      # @param order [Symbol, String] :asc or :desc
+      def initialize(property, order)
+        @property = property.to_s
+        @order = order.to_s.upcase.to_sym
+      end
+
+      # @return [Array<String>]
+      def to_args
+        [@property, @order.to_s]
+      end
+    end
+
+    # SORTBY pipeline clause for FT.AGGREGATE.
+    #
+    # @example
+    #   Valkey::Search::SortBy.new(
+    #     [Valkey::Search::SortProperty.new("@price", :asc)],
+    #     max: 10
+    #   )
+    #
+    # @see https://valkey.io/commands/ft.aggregate/
+    class SortBy
+      # @return [Array<SortProperty>] sort properties
+      attr_reader :properties
+
+      # @return [Integer, nil] MAX optimization hint
+      attr_reader :max
+
+      # @param properties [Array<SortProperty>] sort criteria
+      # @param max [Integer, nil] optimization: only sort top N elements
+      def initialize(properties, max: nil)
+        @properties = properties
+        @max = max
+      end
+
+      # @return [Array<String>]
+      def to_args
+        args = ["SORTBY", (@properties.size * 2).to_s]
+        @properties.each { |p| args.concat(p.to_args) }
+        args.push("MAX", @max.to_s) if @max
+        args
+      end
+    end
+
+    # APPLY pipeline clause for FT.AGGREGATE.
+    #
+    # @example
+    #   Valkey::Search::Apply.new("@price * 1.1", name: "price_with_tax")
+    #
+    # @see https://valkey.io/commands/ft.aggregate/
+    class Apply
+      # @return [String] the transformation expression
+      attr_reader :expression
+
+      # @return [String] output property name
+      attr_reader :name
+
+      # @param expression [String] transformation expression
+      # @param name [String] output property alias
+      def initialize(expression, name:)
+        @expression = expression.to_s
+        @name = name.to_s
+      end
+
+      # @return [Array<String>]
+      def to_args
+        ["APPLY", @expression, "AS", @name]
+      end
+    end
+
+    # FILTER pipeline clause for FT.AGGREGATE.
+    #
+    # @example
+    #   Valkey::Search::Filter.new("@count > 5")
+    #
+    # @see https://valkey.io/commands/ft.aggregate/
+    class Filter
+      # @return [String] filter expression
+      attr_reader :expression
+
+      # @param expression [String] predicate expression
+      def initialize(expression)
+        @expression = expression.to_s
+      end
+
+      # @return [Array<String>]
+      def to_args
+        ["FILTER", @expression]
+      end
+    end
+
+    # LIMIT pipeline clause for FT.AGGREGATE.
+    #
+    # @example
+    #   Valkey::Search::AggregateLimit.new(offset: 0, count: 10)
+    #
+    # @see https://valkey.io/commands/ft.aggregate/
+    class AggregateLimit
+      # @return [Integer] number of records to skip
+      attr_reader :offset
+
+      # @return [Integer] max records to retain
+      attr_reader :count
+
+      # @param offset [Integer] starting point
+      # @param count [Integer] number of records
+      def initialize(offset:, count:)
+        @offset = offset
+        @count = count
+      end
+
+      # @return [Array<String>]
+      def to_args
+        ["LIMIT", @offset.to_s, @count.to_s]
+      end
+    end
+
+    # Options for the FT.AGGREGATE command.
+    #
+    # Encapsulates query-level options (VERBATIM, INORDER, SLOP, LOAD, TIMEOUT,
+    # PARAMS, DIALECT) and pipeline clauses (GROUPBY, SORTBY, APPLY, FILTER, LIMIT)
+    # which can be repeated and intermixed in any order.
+    #
+    # @example Basic aggregation
+    #   Valkey::Search::FtAggregateOptions.new(
+    #     load_fields: ["@price"],
+    #     clauses: [
+    #       Valkey::Search::GroupBy.new(["@category"],
+    #         reducers: [Valkey::Search::Reducer.new("SUM", ["@price"], name: "total")])
+    #     ]
+    #   )
+    #
+    # @example With sorting and limit
+    #   Valkey::Search::FtAggregateOptions.new(
+    #     clauses: [
+    #       Valkey::Search::GroupBy.new(["@category"],
+    #         reducers: [Valkey::Search::Reducer.new("COUNT", [], name: "count")]),
+    #       Valkey::Search::SortBy.new(
+    #         [Valkey::Search::SortProperty.new("@count", :desc)], max: 5),
+    #       Valkey::Search::AggregateLimit.new(offset: 0, count: 5)
+    #     ]
+    #   )
+    #
+    # @see https://valkey.io/commands/ft.aggregate/
+    class FtAggregateOptions
+      # @return [Boolean] load all indexed fields
+      attr_reader :load_all
+
+      # @return [Array<String>] specific fields to load
+      attr_reader :load_fields
+
+      # @return [Integer, nil] timeout in milliseconds
+      attr_reader :timeout
+
+      # @return [Hash, nil] query parameter key/value pairs
+      attr_reader :params
+
+      # @return [Array] pipeline clauses (GroupBy, SortBy, Apply, Filter, AggregateLimit)
+      attr_reader :clauses
+
+      # @return [Boolean] disable stemming
+      attr_reader :verbatim
+
+      # @return [Boolean] require proximity terms in order
+      attr_reader :inorder
+
+      # @return [Integer, nil] proximity slop value
+      attr_reader :slop
+
+      # @return [Integer, nil] query dialect version
+      attr_reader :dialect
+
+      # @param load_all [Boolean] load all indexed fields for reducers
+      # @param load_fields [Array<String>] specific fields to load for reducers
+      # @param timeout [Integer, nil] query timeout in milliseconds
+      # @param params [Hash, nil] query parameters
+      # @param clauses [Array] pipeline clauses in execution order
+      # @param verbatim [Boolean] disable stemming
+      # @param inorder [Boolean] require term proximity in order
+      # @param slop [Integer, nil] proximity slop
+      # @param dialect [Integer, nil] query dialect (2)
+      def initialize(load_all: false, load_fields: [], timeout: nil, params: nil,
+                     clauses: [], verbatim: false, inorder: false, slop: nil,
+                     dialect: nil)
+        @load_all = load_all
+        @load_fields = load_fields.map(&:to_s)
+        @timeout = timeout
+        @params = params
+        @clauses = clauses
+        @verbatim = verbatim
+        @inorder = inorder
+        @slop = slop
+        @dialect = dialect
+      end
+
+      # Serialize into the argument array appended after index and query
+      # in FT.AGGREGATE.
+      #
+      # @return [Array<String>]
+      def to_args
+        args = []
+        args << "VERBATIM" if @verbatim
+        args << "INORDER" if @inorder
+        args.push("SLOP", @slop.to_s) if @slop
+        if @load_all
+          args.push("LOAD", "*")
+        elsif @load_fields.any?
+          args.push("LOAD", @load_fields.size.to_s)
+          args.concat(@load_fields)
+        end
+        args.push("TIMEOUT", @timeout.to_s) if @timeout
+        if @params && !@params.empty?
+          args.push("PARAMS", (@params.size * 2).to_s)
+          @params.each do |name, value|
+            args.push(name.to_s, value.to_s)
+          end
+        end
+        @clauses.each { |clause| args.concat(clause.to_args) }
+        args.push("DIALECT", @dialect.to_s) if @dialect
+        args
+      end
+    end
+  end
+end

--- a/lib/valkey/search/ft_create_options.rb
+++ b/lib/valkey/search/ft_create_options.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+class Valkey
+  module Search
+    # Index-level options for FT.CREATE.
+    #
+    # Encapsulates the options that appear *before* the SCHEMA keyword in an
+    # FT.CREATE command: data type (HASH/JSON), key prefixes, filters, default
+    # language, score, and other index-wide settings.
+    #
+    # @example Basic usage
+    #   opts = Valkey::Search::FtCreateOptions.new(
+    #     data_type: :hash,
+    #     prefixes: ["product:"]
+    #   )
+    #   opts.to_args
+    #   # => ["ON", "HASH", "PREFIX", "1", "product:"]
+    #
+    # @example Full options
+    #   opts = Valkey::Search::FtCreateOptions.new(
+    #     data_type: :json,
+    #     prefixes: ["item:", "doc:"],
+    #     filter: "@status!='archived'",
+    #     default_language: "english",
+    #     language_field: "lang",
+    #     default_score: 0.5,
+    #     score_field: "priority",
+    #     max_text_fields: true,
+    #     no_offsets: true,
+    #     temporary: 3600,
+    #     no_highlight: true,
+    #     no_fields: true,
+    #     no_freqs: true,
+    #     stopwords: ["the", "a", "is"],
+    #     skip_initial_scan: true
+    #   )
+    #
+    # @see https://valkey.io/commands/ft.create/
+    class FtCreateOptions
+      # @return [Symbol, nil] :hash or :json (ON HASH / ON JSON)
+      attr_reader :data_type
+
+      # @return [Array<String>] key prefixes to index
+      attr_reader :prefixes
+
+      # @return [String, nil] filter expression for conditional indexing
+      attr_reader :filter
+
+      # @return [String, nil] default language for stemming
+      attr_reader :default_language
+
+      # @return [String, nil] document field that holds the language
+      attr_reader :language_field
+
+      # @return [Float, nil] default document score (0.0–1.0)
+      attr_reader :default_score
+
+      # @return [String, nil] document field that holds the score
+      attr_reader :score_field
+
+      # @return [Boolean] allow unlimited TEXT fields
+      attr_reader :max_text_fields
+
+      # @return [Boolean] disable offset storage (saves memory, disables exact phrase search)
+      attr_reader :no_offsets
+
+      # @return [Integer, nil] TTL in seconds for a temporary index
+      attr_reader :temporary
+
+      # @return [Boolean] disable highlight/snippet support
+      attr_reader :no_highlight
+
+      # @return [Boolean] disable field storage (saves memory, disables RETURN)
+      attr_reader :no_fields
+
+      # @return [Boolean] disable term frequency tracking
+      attr_reader :no_freqs
+
+      # @return [Array<String>, nil] custom stopwords (empty array = no stopwords)
+      attr_reader :stopwords
+
+      # @return [Boolean] skip the initial full-key-space scan on creation
+      attr_reader :skip_initial_scan
+
+      # @param data_type [Symbol, String, nil] :hash or :json
+      # @param prefixes [Array<String>] key prefixes to index
+      # @param filter [String, nil] conditional indexing filter
+      # @param default_language [String, nil] stemming language
+      # @param language_field [String, nil] per-document language field name
+      # @param default_score [Float, nil] default document score
+      # @param score_field [String, nil] per-document score field name
+      # @param max_text_fields [Boolean] allow unlimited TEXT fields
+      # @param no_offsets [Boolean] disable offset storage
+      # @param temporary [Integer, nil] index TTL in seconds
+      # @param no_highlight [Boolean] disable highlighting
+      # @param no_fields [Boolean] disable field storage
+      # @param no_freqs [Boolean] disable frequency tracking
+      # @param stopwords [Array<String>, nil] custom stopwords list
+      # @param skip_initial_scan [Boolean] skip initial key scan
+      def initialize(data_type: nil, prefixes: [], filter: nil,
+                     default_language: nil, language_field: nil,
+                     default_score: nil, score_field: nil,
+                     max_text_fields: false, no_offsets: false,
+                     temporary: nil, no_highlight: false,
+                     no_fields: false, no_freqs: false,
+                     stopwords: nil, skip_initial_scan: false)
+        @data_type = data_type&.to_s&.upcase&.to_sym
+        @prefixes = prefixes.map(&:to_s)
+        @filter = filter&.to_s
+        @default_language = default_language&.to_s
+        @language_field = language_field&.to_s
+        @default_score = default_score
+        @score_field = score_field&.to_s
+        @max_text_fields = max_text_fields
+        @no_offsets = no_offsets
+        @temporary = temporary
+        @no_highlight = no_highlight
+        @no_fields = no_fields
+        @no_freqs = no_freqs
+        @stopwords = stopwords&.map(&:to_s)
+        @skip_initial_scan = skip_initial_scan
+      end
+
+      # Serialize options into the argument array that appears between the index
+      # name and the SCHEMA keyword in FT.CREATE.
+      #
+      # @return [Array<String>]
+      def to_args
+        args = []
+        args.push("ON", @data_type.to_s) if @data_type
+        if @prefixes.any?
+          args.push("PREFIX", @prefixes.size.to_s)
+          args.concat(@prefixes)
+        end
+        args.push("FILTER", @filter) if @filter
+        args.push("LANGUAGE", @default_language) if @default_language
+        args.push("LANGUAGE_FIELD", @language_field) if @language_field
+        args.push("SCORE", @default_score.to_s) if @default_score
+        args.push("SCORE_FIELD", @score_field) if @score_field
+        args << "MAXTEXTFIELDS" if @max_text_fields
+        args << "NOOFFSETS" if @no_offsets
+        args.push("TEMPORARY", @temporary.to_s) if @temporary
+        args << "NOHL" if @no_highlight
+        args << "NOFIELDS" if @no_fields
+        args << "NOFREQS" if @no_freqs
+        if @stopwords
+          args.push("STOPWORDS", @stopwords.size.to_s)
+          args.concat(@stopwords)
+        end
+        args << "SKIPINITIALSCAN" if @skip_initial_scan
+        args
+      end
+    end
+  end
+end

--- a/lib/valkey/search/ft_info_options.rb
+++ b/lib/valkey/search/ft_info_options.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+class Valkey
+  module Search
+    # Options for the FT.INFO command.
+    #
+    # Controls which nodes provide index information in cluster mode.
+    #
+    # @example Local scope (default)
+    #   Valkey::Search::FtInfoOptions.new(scope: :local)
+    #
+    # @example Cluster-wide info
+    #   Valkey::Search::FtInfoOptions.new(scope: :cluster)
+    #
+    # @see https://valkey.io/commands/ft.info/
+    class FtInfoOptions
+      # @return [Symbol, nil] info scope (:local, :primary, or :cluster)
+      attr_reader :scope
+
+      # @return [Symbol, nil] shard scope (:allshards or :someshards)
+      attr_reader :shard_scope
+
+      # @return [Symbol, nil] consistency mode (:consistent or :inconsistent)
+      attr_reader :consistency
+
+      # @param scope [Symbol, nil] which nodes provide info:
+      #   - +:local+ — only the executing node (default)
+      #   - +:primary+ — primary nodes of every shard (cluster only)
+      #   - +:cluster+ — all nodes including replicas (cluster only)
+      # @param shard_scope [Symbol, nil] :allshards or :someshards
+      # @param consistency [Symbol, nil] :consistent or :inconsistent
+      def initialize(scope: nil, shard_scope: nil, consistency: nil)
+        @scope = scope
+        @shard_scope = shard_scope
+        @consistency = consistency
+      end
+
+      # Serialize into the argument array appended after the index name
+      # in FT.INFO.
+      #
+      # @return [Array<String>]
+      def to_args
+        args = []
+        args << @scope.to_s.upcase if @scope
+        args << @shard_scope.to_s.upcase if @shard_scope
+        args << @consistency.to_s.upcase if @consistency
+        args
+      end
+    end
+  end
+end

--- a/lib/valkey/search/ft_search_options.rb
+++ b/lib/valkey/search/ft_search_options.rb
@@ -1,0 +1,206 @@
+# frozen_string_literal: true
+
+class Valkey
+  module Search
+    # Pagination parameters for FT.SEARCH.
+    #
+    # @example
+    #   Valkey::Search::FtSearchLimit.new(offset: 0, count: 10)
+    #
+    # @see https://valkey.io/commands/ft.search/
+    class FtSearchLimit
+      # @return [Integer] number of results to skip
+      attr_reader :offset
+
+      # @return [Integer] maximum number of results to return
+      attr_reader :count
+
+      # @param offset [Integer] number of results to skip
+      # @param count [Integer] maximum number of results to return
+      def initialize(offset:, count:)
+        @offset = offset
+        @count = count
+      end
+
+      # @return [Array<String>]
+      def to_args
+        ["LIMIT", @offset.to_s, @count.to_s]
+      end
+    end
+
+    # A field to include in RETURN clause of FT.SEARCH.
+    #
+    # @example
+    #   Valkey::Search::ReturnField.new("title")
+    #   Valkey::Search::ReturnField.new("$.price", field_alias: "price")
+    #
+    # @see https://valkey.io/commands/ft.search/
+    class ReturnField
+      # @return [String] field identifier
+      attr_reader :field_identifier
+
+      # @return [String, nil] optional alias for the field in results
+      attr_reader :field_alias
+
+      # @param field_identifier [String] field name to return
+      # @param field_alias [String, nil] alias to rename this field in results
+      def initialize(field_identifier, field_alias: nil)
+        @field_identifier = field_identifier.to_s
+        @field_alias = field_alias&.to_s
+      end
+
+      # @return [Array<String>]
+      def to_args
+        args = [@field_identifier]
+        args.push("AS", @field_alias) if @field_alias
+        args
+      end
+    end
+
+    # Options for the FT.SEARCH command.
+    #
+    # All parameters are optional. Encapsulates VERBATIM, INORDER, SLOP,
+    # SORTBY, WITHSORTKEYS, NOCONTENT, DIALECT, RETURN, LIMIT, PARAMS,
+    # TIMEOUT, shard scope, and consistency mode.
+    #
+    # @example Basic pagination
+    #   Valkey::Search::FtSearchOptions.new(
+    #     limit: Valkey::Search::FtSearchLimit.new(offset: 0, count: 10)
+    #   )
+    #
+    # @example Sorted search with specific fields
+    #   Valkey::Search::FtSearchOptions.new(
+    #     sortby: "price", sortby_order: :asc,
+    #     return_fields: [
+    #       Valkey::Search::ReturnField.new("title"),
+    #       Valkey::Search::ReturnField.new("price")
+    #     ]
+    #   )
+    #
+    # @example Vector search with params
+    #   Valkey::Search::FtSearchOptions.new(
+    #     params: { "vec" => vector_bytes },
+    #     dialect: 2
+    #   )
+    #
+    # @see https://valkey.io/commands/ft.search/
+    class FtSearchOptions
+      # @return [Array<ReturnField>, nil] fields to return
+      attr_reader :return_fields
+
+      # @return [Integer, nil] timeout in milliseconds
+      attr_reader :timeout
+
+      # @return [Hash, nil] query parameter key/value pairs
+      attr_reader :params
+
+      # @return [FtSearchLimit, nil] pagination offset/count
+      attr_reader :limit
+
+      # @return [Boolean] return only count, not documents
+      attr_reader :count
+
+      # @return [Boolean] return only document IDs (no field content)
+      attr_reader :nocontent
+
+      # @return [Integer, nil] query dialect version (2)
+      attr_reader :dialect
+
+      # @return [Boolean] disable stemming
+      attr_reader :verbatim
+
+      # @return [Boolean] require proximity terms in order
+      attr_reader :inorder
+
+      # @return [Integer, nil] proximity slop value
+      attr_reader :slop
+
+      # @return [String, nil] field name to sort by
+      attr_reader :sortby
+
+      # @return [Symbol, nil] sort direction (:asc or :desc)
+      attr_reader :sortby_order
+
+      # @return [Boolean] include sort key values in response
+      attr_reader :withsortkeys
+
+      # @return [Symbol, nil] shard scope (:allshards or :someshards)
+      attr_reader :shard_scope
+
+      # @return [Symbol, nil] consistency mode (:consistent or :inconsistent)
+      attr_reader :consistency
+
+      # @param return_fields [Array<ReturnField>, nil] fields to include in results
+      # @param timeout [Integer, nil] query timeout in milliseconds
+      # @param params [Hash, nil] query parameters (for vector search, etc.)
+      # @param limit [FtSearchLimit, nil] pagination
+      # @param count [Boolean] return count only
+      # @param nocontent [Boolean] omit field values from results
+      # @param dialect [Integer, nil] query dialect (2)
+      # @param verbatim [Boolean] disable stemming
+      # @param inorder [Boolean] require term proximity in order
+      # @param slop [Integer, nil] proximity slop
+      # @param sortby [String, nil] sort field name
+      # @param sortby_order [Symbol, nil] :asc or :desc
+      # @param withsortkeys [Boolean] include sort key in response
+      # @param shard_scope [Symbol, nil] :allshards or :someshards
+      # @param consistency [Symbol, nil] :consistent or :inconsistent
+      def initialize(return_fields: nil, timeout: nil, params: nil, limit: nil,
+                     count: false, nocontent: false, dialect: nil,
+                     verbatim: false, inorder: false, slop: nil,
+                     sortby: nil, sortby_order: nil, withsortkeys: false,
+                     shard_scope: nil, consistency: nil)
+        @return_fields = return_fields
+        @timeout = timeout
+        @params = params
+        @limit = limit
+        @count = count
+        @nocontent = nocontent
+        @dialect = dialect
+        @verbatim = verbatim
+        @inorder = inorder
+        @slop = slop
+        @sortby = sortby&.to_s
+        @sortby_order = sortby_order
+        @withsortkeys = withsortkeys
+        @shard_scope = shard_scope
+        @consistency = consistency
+      end
+
+      # Serialize into the argument array appended after index and query
+      # in FT.SEARCH.
+      #
+      # @return [Array<String>]
+      def to_args
+        args = []
+        args << @shard_scope.to_s.upcase if @shard_scope
+        args << @consistency.to_s.upcase if @consistency
+        args << "NOCONTENT" if @nocontent
+        args << "VERBATIM" if @verbatim
+        args << "INORDER" if @inorder
+        args.push("SLOP", @slop.to_s) if @slop
+        if @return_fields
+          return_field_args = @return_fields.flat_map(&:to_args)
+          args.push("RETURN", return_field_args.size.to_s)
+          args.concat(return_field_args)
+        end
+        if @sortby
+          args.push("SORTBY", @sortby)
+          args << @sortby_order.to_s.upcase if @sortby_order
+        end
+        args << "WITHSORTKEYS" if @withsortkeys
+        args.push("TIMEOUT", @timeout.to_s) if @timeout
+        if @params
+          args.push("PARAMS", (@params.size * 2).to_s)
+          @params.each do |name, value|
+            args.push(name.to_s, value.to_s)
+          end
+        end
+        args.concat(@limit.to_args) if @limit
+        args << "COUNT" if @count
+        args.push("DIALECT", @dialect.to_s) if @dialect
+        args
+      end
+    end
+  end
+end

--- a/lib/valkey/search/ft_search_result.rb
+++ b/lib/valkey/search/ft_search_result.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+class Valkey
+  module Search
+    # A single document from an FT.SEARCH result.
+    #
+    # @example
+    #   doc = result.documents.first
+    #   doc.key         # => "doc:1"
+    #   doc.fields      # => {"title" => "hello", "price" => "9.99"}
+    #   doc["title"]    # => "hello"
+    #   doc.sort_key    # => "9.99" (only with WITHSORTKEYS)
+    #
+    class FtSearchDocument
+      # @return [String] the document key
+      attr_reader :key
+
+      # @return [Hash<String, String>] field name/value pairs
+      attr_reader :fields
+
+      # @return [String, nil] sort key value (present only when WITHSORTKEYS is used)
+      attr_reader :sort_key
+
+      # @param key [String] document key
+      # @param fields [Hash<String, String>] document fields
+      # @param sort_key [String, nil] sort key value
+      def initialize(key, fields, sort_key: nil)
+        @key = key
+        @fields = fields
+        @sort_key = sort_key
+      end
+
+      # Shorthand for accessing a field value.
+      #
+      # @param field_name [String] field name
+      # @return [String, nil]
+      def [](field_name)
+        @fields[field_name]
+      end
+
+      # @return [String]
+      def to_s
+        "#<FtSearchDocument key=#{@key.inspect} fields=#{@fields.inspect}>"
+      end
+
+      alias inspect to_s
+    end
+
+    # Structured result from an FT.SEARCH command.
+    #
+    # Wraps the raw response array from glide-core into a typed object
+    # with total result count and an array of {FtSearchDocument} objects.
+    #
+    # @example
+    #   result = client.ft_search("idx", "@title:hello", options: opts)
+    #   result.total_results   # => 2
+    #   result.documents       # => [FtSearchDocument, ...]
+    #   result.documents.first.key    # => "doc:1"
+    #   result.documents.first["title"]  # => "hello world"
+    #
+    class FtSearchResult
+      # @return [Integer] total number of matching documents
+      attr_reader :total_results
+
+      # @return [Array<FtSearchDocument>] documents in this page
+      attr_reader :documents
+
+      # @param total_results [Integer] total matching document count
+      # @param documents [Array<FtSearchDocument>] parsed documents
+      def initialize(total_results, documents)
+        @total_results = total_results
+        @documents = documents
+      end
+
+      # Parse a raw FT.SEARCH response from glide-core.
+      #
+      # glide-core normalizes FT.SEARCH responses into:
+      #   [count, {key => fields_hash, ...}]
+      #
+      # When WITHSORTKEYS is enabled, each document value becomes:
+      #   [sort_key, fields_hash]
+      #
+      # @param raw [Array] raw response from glide-core
+      # @param withsortkeys [Boolean] whether WITHSORTKEYS was used
+      # @return [FtSearchResult]
+      def self.from_raw(raw, withsortkeys: false)
+        return new(0, []) if raw.nil? || raw.empty?
+
+        count = raw[0].is_a?(Integer) ? raw[0] : raw[0].to_i
+        documents = []
+
+        if raw.length > 1 && raw[1].is_a?(Hash)
+          raw[1].each do |key, value|
+            doc_key = key.to_s
+            if withsortkeys && value.is_a?(Array) && value.length == 2
+              sort_key = value[0]&.to_s
+              field_map = normalize_fields(value[1])
+              documents << FtSearchDocument.new(doc_key, field_map, sort_key: sort_key)
+            else
+              field_map = normalize_fields(value)
+              documents << FtSearchDocument.new(doc_key, field_map)
+            end
+          end
+        end
+
+        new(count, documents)
+      end
+
+      # @return [String]
+      def to_s
+        "#<FtSearchResult total=#{@total_results} docs=#{@documents.size}>"
+      end
+
+      alias inspect to_s
+
+      class << self
+        private
+
+        # Normalize field values to a string hash.
+        # Handles both Hash input and Array (key-value pairs) input.
+        #
+        # @param fields [Hash, Array, nil]
+        # @return [Hash<String, String>]
+        def normalize_fields(fields)
+          case fields
+          when Hash
+            fields.each_with_object({}) do |(k, v), h|
+              h[k.to_s] = v.to_s
+            end
+          when Array
+            # Array of alternating [key, val, key, val, ...]
+            result = {}
+            fields.each_slice(2) { |k, v| result[k.to_s] = v.to_s }
+            result
+          else
+            {}
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/lint/cluster_commands.rb
+++ b/test/lint/cluster_commands.rb
@@ -282,40 +282,44 @@ module Lint
       pass "Cluster setslot correctly failed with invalid parameters"
     end
 
-    def test_cluster_failover_on_cluster
-      # Test cluster failover (only works on replica nodes)
-      result = r.cluster_failover
-      # This will fail on master nodes, which is expected
-      case result
-      when "OK"
-        pass "Cluster failover succeeded as expected"
-      when false
-        pass "Cluster failover returned false (not ready for failover)"
-      when Valkey::CommandError
-        pass "Cluster failover correctly failed as expected"
-      else
-        flunk "Unexpected result from cluster_failover: #{result.inspect}"
-      end
-    rescue Valkey::CommandError => e
-      # Expected to fail on master nodes - accept any error message
-      pass "Cluster failover correctly failed on master node as expected: #{e.message}"
+    # CLUSTER FAILOVER must run on a replica and, on default routing, may be
+    # sent to a replica and trigger a *real* failover — which would destabilize
+    # the shared test cluster. So instead of issuing it live, we stub
+    # send_command and assert the arguments the client builds.
+    #
+    # should send "CLUSTER FAILOVER" with no extra args for a coordinated failover
+    def test_cluster_failover_coordinated_sends_no_args
+      assert_equal [], capture_cluster_failover_args
     end
 
-    def test_cluster_force_failover
-      # Test cluster failover with force option - should still fail on master
-      result = r.cluster_failover("FORCE")
-      # This might return false or raise an error on master nodes
-      case result
-      when "OK"
-        pass "Cluster force failover succeeded as expected"
-      when false
-        pass "Cluster force failover returned false (not ready for failover)"
-      else
-        flunk "Unexpected result from cluster force failover: #{result.inspect}"
+    # should append "FORCE" for the :force mode
+    def test_cluster_failover_force_sends_force_arg
+      assert_equal ["FORCE"], capture_cluster_failover_args(:force)
+    end
+
+    # should append "TAKEOVER" for the :takeover mode
+    def test_cluster_failover_takeover_sends_takeover_arg
+      assert_equal ["TAKEOVER"], capture_cluster_failover_args(:takeover)
+    end
+
+    # should raise ArgumentError for an unrecognized mode (incl. strings/booleans)
+    def test_cluster_failover_invalid_mode_raises
+      assert_raises(ArgumentError) { r.cluster_failover(:bogus) }
+      assert_raises(ArgumentError) { r.cluster_failover("FORCE") }
+      assert_raises(ArgumentError) { r.cluster_failover(true) }
+    end
+
+    # Invokes cluster_failover while intercepting send_command, and returns the
+    # argument array the client would have sent — without issuing a real
+    # failover against the cluster.
+    def capture_cluster_failover_args(*mode)
+      captured = nil
+      recorder = lambda do |_request_type, args = [], &_block|
+        captured = args
+        "OK"
       end
-    rescue Valkey::CommandError => e
-      # Expected to fail on master nodes even with force - accept any error message
-      pass "Cluster force failover correctly failed on master node as expected: #{e.message}"
+      r.stub(:send_command, recorder) { r.cluster_failover(*mode) }
+      captured
     end
 
     def test_cluster_set_config_epoch

--- a/test/lint/connection_commands.rb
+++ b/test/lint/connection_commands.rb
@@ -150,11 +150,6 @@ module Lint
       end
     end
 
-    def test_client_getredir
-      redir = r.client_getredir
-      assert_kind_of Integer, redir
-    end
-
     def test_hello_default
       result = r.hello
       # Backend returns array in current implementation
@@ -206,93 +201,6 @@ module Lint
         sleep(0.05) # 50ms between retries
       end
       assert_nil r.client_get_name
-    end
-
-    def test_client_caching
-      # In cluster mode, CLIENT TRACKING and CLIENT CACHING may hit different nodes
-      # so tracking state isn't shared - skip this test in cluster mode
-      skip("CLIENT CACHING requires tracking state to be shared, not reliable in cluster mode") if cluster_mode?
-
-      # CLIENT CACHING YES works with OPTIN mode
-      r.client_tracking("ON", "OPTIN")
-      assert_equal "OK", r.client_caching("YES")
-      r.client_tracking("OFF")
-      # CLIENT CACHING NO requires OPTOUT mode
-      r.client_tracking("ON", "OPTOUT")
-      assert_equal "OK", r.client_caching("NO")
-      r.client_tracking("OFF")
-    end
-
-    def test_client_tracking
-      assert_equal "OK", r.client_tracking("ON")
-      assert_equal "OK", r.client_tracking("OFF")
-    end
-
-    def test_client_tracking_info
-      info = r.client_tracking_info
-      assert_kind_of Array, info
-    end
-
-    def test_client_tracking_with_bcast
-      # Keyword options exercise build_client_tracking_args (BCAST branch).
-      assert_equal "OK", r.client_tracking("ON", bcast: true)
-      assert_equal "OK", r.client_tracking("OFF")
-    end
-
-    def test_client_tracking_with_prefix
-      # PREFIX is only valid alongside BCAST.
-      assert_equal "OK", r.client_tracking("ON", bcast: true, prefix: %w[foo bar])
-      assert_equal "OK", r.client_tracking("OFF")
-    end
-
-    def test_client_tracking_with_optin_optout_keywords
-      # optin: / optout: keyword forms exercise build_client_tracking_args.
-      assert_equal "OK", r.client_tracking("ON", optin: true)
-      assert_equal "OK", r.client_tracking("OFF")
-      assert_equal "OK", r.client_tracking("ON", optout: true)
-      assert_equal "OK", r.client_tracking("OFF")
-    end
-
-    def test_client_tracking_with_noloop
-      assert_equal "OK", r.client_tracking("ON", noloop: true)
-      assert_equal "OK", r.client_tracking("OFF")
-    end
-
-    def test_client_tracking_invalid_status
-      assert_raises(Valkey::CommandError) do
-        r.client_tracking("MAYBE")
-      end
-    end
-
-    def test_client_tracking_info_reflects_state
-      # Tracking state is connection-local; in cluster mode TRACKING and
-      # TRACKINGINFO may hit different nodes, so skip there.
-      skip("CLIENT TRACKINGINFO reflects per-connection state, not reliable in cluster mode") if cluster_mode?
-
-      r.client_tracking("ON")
-      info = r.client_tracking_info
-      assert info.include?("flags"), "tracking info should report flags"
-      assert info.flatten.include?("on"), "flags should report 'on' when tracking enabled"
-
-      r.client_tracking("OFF")
-      info = r.client_tracking_info
-      assert info.flatten.include?("off"), "flags should report 'off' when tracking disabled"
-    end
-
-    def test_client_caching_invalid_mode
-      # CLIENT CACHING requires shared tracking state, not reliable in cluster mode.
-      skip("CLIENT CACHING requires tracking state to be shared, not reliable in cluster mode") if cluster_mode?
-
-      r.client_tracking("ON", "OPTIN")
-      assert_raises(Valkey::CommandError) do
-        r.client_caching("MAYBE")
-      end
-      r.client_tracking("OFF")
-    end
-
-    def test_client_getredir_when_disabled
-      # With no tracking redirection configured, GETREDIR returns -1.
-      assert_equal(-1, r.client_getredir)
     end
 
     def test_quit

--- a/test/lint/connection_commands.rb
+++ b/test/lint/connection_commands.rb
@@ -233,6 +233,68 @@ module Lint
       assert_kind_of Array, info
     end
 
+    def test_client_tracking_with_bcast
+      # Keyword options exercise build_client_tracking_args (BCAST branch).
+      assert_equal "OK", r.client_tracking("ON", bcast: true)
+      assert_equal "OK", r.client_tracking("OFF")
+    end
+
+    def test_client_tracking_with_prefix
+      # PREFIX is only valid alongside BCAST.
+      assert_equal "OK", r.client_tracking("ON", bcast: true, prefix: %w[foo bar])
+      assert_equal "OK", r.client_tracking("OFF")
+    end
+
+    def test_client_tracking_with_optin_optout_keywords
+      # optin: / optout: keyword forms exercise build_client_tracking_args.
+      assert_equal "OK", r.client_tracking("ON", optin: true)
+      assert_equal "OK", r.client_tracking("OFF")
+      assert_equal "OK", r.client_tracking("ON", optout: true)
+      assert_equal "OK", r.client_tracking("OFF")
+    end
+
+    def test_client_tracking_with_noloop
+      assert_equal "OK", r.client_tracking("ON", noloop: true)
+      assert_equal "OK", r.client_tracking("OFF")
+    end
+
+    def test_client_tracking_invalid_status
+      assert_raises(Valkey::CommandError) do
+        r.client_tracking("MAYBE")
+      end
+    end
+
+    def test_client_tracking_info_reflects_state
+      # Tracking state is connection-local; in cluster mode TRACKING and
+      # TRACKINGINFO may hit different nodes, so skip there.
+      skip("CLIENT TRACKINGINFO reflects per-connection state, not reliable in cluster mode") if cluster_mode?
+
+      r.client_tracking("ON")
+      info = r.client_tracking_info
+      assert info.include?("flags"), "tracking info should report flags"
+      assert info.flatten.include?("on"), "flags should report 'on' when tracking enabled"
+
+      r.client_tracking("OFF")
+      info = r.client_tracking_info
+      assert info.flatten.include?("off"), "flags should report 'off' when tracking disabled"
+    end
+
+    def test_client_caching_invalid_mode
+      # CLIENT CACHING requires shared tracking state, not reliable in cluster mode.
+      skip("CLIENT CACHING requires tracking state to be shared, not reliable in cluster mode") if cluster_mode?
+
+      r.client_tracking("ON", "OPTIN")
+      assert_raises(Valkey::CommandError) do
+        r.client_caching("MAYBE")
+      end
+      r.client_tracking("OFF")
+    end
+
+    def test_client_getredir_when_disabled
+      # With no tracking redirection configured, GETREDIR returns -1.
+      assert_equal(-1, r.client_getredir)
+    end
+
     def test_quit
       # NOTE: This test is tricky because QUIT closes the connection
       # We'll skip it in lint tests to avoid connection issues

--- a/test/lint/connection_options.rb
+++ b/test/lint/connection_options.rb
@@ -182,6 +182,8 @@ module Lint
     end
 
     def test_connection_url_parsing_ssl
+      skip("TLS tests disabled via SKIP_TLS_TESTS") if defined?(SKIP_TLS_TESTS) && SKIP_TLS_TESTS
+
       # Test URL parsing with SSL (rediss://)
       # For self-signed certs, we need to provide the CA cert
       client = if cluster_mode?
@@ -208,6 +210,8 @@ module Lint
     end
 
     def test_connection_with_ssl_option
+      skip("TLS tests disabled via SKIP_TLS_TESTS") if defined?(SKIP_TLS_TESTS) && SKIP_TLS_TESTS
+
       # Test ssl option with CA certificate for self-signed cert
       client = if cluster_mode?
                  Valkey.new(
@@ -425,6 +429,8 @@ module Lint
     end
 
     def test_connection_ssl_params_with_file_paths
+      skip("TLS tests disabled via SKIP_TLS_TESTS") if defined?(SKIP_TLS_TESTS) && SKIP_TLS_TESTS
+
       # Test ssl_params with file paths using proper test certificates
       client = if cluster_mode?
                  Valkey.new(
@@ -459,6 +465,8 @@ module Lint
     end
 
     def test_connection_ssl_params_with_openssl_objects
+      skip("TLS tests disabled via SKIP_TLS_TESTS") if defined?(SKIP_TLS_TESTS) && SKIP_TLS_TESTS
+
       # Test ssl_params with OpenSSL objects loaded from test certificates
       # Need to provide CA cert to trust self-signed server certificate
       client = if cluster_mode?

--- a/test/lint/module_commands.rb
+++ b/test/lint/module_commands.rb
@@ -67,6 +67,8 @@ module Lint
           skip("MODULE commands not enabled")
         elsif e.message.include?("No such file") || e.message.include?("cannot open")
           skip("Module file not available at #{MODULE_PATH}")
+        elsif e.message.include?("Error loading")
+          skip("Module failed to load on this engine version")
         else
           raise
         end
@@ -88,6 +90,8 @@ module Lint
           skip("MODULE commands not enabled")
         elsif e.message.include?("No such file") || e.message.include?("cannot open")
           skip("Module file not available at #{MODULE_PATH}")
+        elsif e.message.include?("Error loading")
+          skip("Module failed to load on this engine version")
         else
           raise
         end
@@ -103,6 +107,8 @@ module Lint
           rescue Valkey::CommandError => e
             if e.message.include?("MODULE command not allowed")
               skip("MODULE commands not enabled or module file not available")
+            elsif e.message.include?("Error loading")
+              skip("Module failed to load on this engine version")
             end
             raise
           end
@@ -221,6 +227,8 @@ module Lint
           skip("MODULE commands not enabled")
         elsif e.message.include?("No such file") || e.message.include?("cannot open")
           skip("Module file not available at #{MODULE_PATH}")
+        elsif e.message.include?("Error loading")
+          skip("Module failed to load on this engine version")
         else
           raise
         end
@@ -236,6 +244,8 @@ module Lint
           rescue Valkey::CommandError => e
             if e.message.include?("MODULE command not allowed")
               skip("MODULE commands not enabled or module file not available")
+            elsif e.message.include?("Error loading")
+              skip("Module failed to load on this engine version")
             end
             raise
           end

--- a/test/lint/pubsub_commands.rb
+++ b/test/lint/pubsub_commands.rb
@@ -41,6 +41,9 @@ module Lint
     end
 
     def test_pubsub_shardchannels
+      # PUBSUB SHARDCHANNELS was introduced in Redis 7.0.
+      # Skipped on Redis 6.2 and earlier versions.
+      omit_version("7.0")
       # List all active shard channels
       channels = r.pubsub_shardchannels
       assert_kind_of Array, channels
@@ -52,6 +55,9 @@ module Lint
     end
 
     def test_pubsub_shardchannels_with_pattern
+      # PUBSUB SHARDCHANNELS was introduced in Redis 7.0.
+      # Skipped on Redis 6.2 and earlier versions.
+      omit_version("7.0")
       # List shard channels matching a pattern
       channels = r.pubsub_shardchannels("shard*")
       assert_kind_of Array, channels
@@ -63,6 +69,9 @@ module Lint
     end
 
     def test_pubsub_shardnumsub
+      # PUBSUB SHARDNUMSUB was introduced in Redis 7.0.
+      # Skipped on Redis 6.2 and earlier versions.
+      omit_version("7.0")
       # Get subscriber counts for shard channels
       result = r.pubsub_shardnumsub("shard1", "shard2")
       assert_kind_of Array, result
@@ -74,6 +83,9 @@ module Lint
     end
 
     def test_spublish
+      # SPUBLISH was introduced in Redis 7.0.
+      # Skipped on Redis 6.2 and earlier versions.
+      omit_version("7.0")
       # Publish to a shard channel with no subscribers
       result = r.spublish("test_shard", "Hello, Shard!")
       assert_kind_of Integer, result
@@ -110,6 +122,9 @@ module Lint
     end
 
     def test_pubsub_convenience_method_shardchannels
+      # PUBSUB SHARDCHANNELS was introduced in Redis 7.0.
+      # Skipped on Redis 6.2 and earlier versions.
+      omit_version("7.0")
       channels = r.pubsub(:shardchannels)
       assert_kind_of Array, channels
     rescue Valkey::TimeoutError
@@ -120,6 +135,9 @@ module Lint
     end
 
     def test_pubsub_convenience_method_shardnumsub
+      # PUBSUB SHARDNUMSUB was introduced in Redis 7.0.
+      # Skipped on Redis 6.2 and earlier versions.
+      omit_version("7.0")
       result = r.pubsub(:shardnumsub, "shard1", "shard2")
       assert_kind_of Array, result
     rescue Valkey::TimeoutError

--- a/test/lint/server_commands.rb
+++ b/test/lint/server_commands.rb
@@ -158,29 +158,6 @@ module Lint
       assert [0, 1].include?(result), "Expected unblock to return 0 or 1"
     end
 
-    def test_redis_rb_client_caching
-      # CLIENT CACHING requires shared tracking state, which is not reliable in
-      # cluster mode because TRACKING and CACHING may hit different nodes.
-      skip("CLIENT CACHING requires tracking state to be shared, not reliable in cluster mode") if cluster_mode?
-
-      # The redis-rb dispatcher (r.client(:caching, mode)) forwards to client_caching.
-      # CLIENT CACHING YES works with OPTIN mode.
-      r.client(:tracking, "ON", "OPTIN")
-      assert_equal "OK", r.client(:caching, "YES")
-      r.client(:tracking, "OFF")
-      # CLIENT CACHING NO requires OPTOUT mode.
-      r.client(:tracking, "ON", "OPTOUT")
-      assert_equal "OK", r.client(:caching, "NO")
-      r.client(:tracking, "OFF")
-    end
-
-    def test_redis_rb_client_tracking
-      # The redis-rb dispatcher (r.client(:tracking, status)) forwards to
-      # client_tracking, which requires a status argument.
-      assert_equal "OK", r.client(:tracking, "ON")
-      assert_equal "OK", r.client(:tracking, "OFF")
-    end
-
     def test_client_reply
       assert_equal "OK", r.client(:reply, "ON") # TODO: "OFF" or "SKIP" doesnt work yet
     end
@@ -221,51 +198,6 @@ module Lint
       else
         skip("No client address found to kill")
       end
-    end
-
-    def test_redis_rb_client_tracking_info
-      # The redis-rb dispatcher (r.client(:tracking_info)) forwards to
-      # client_tracking_info, which takes no arguments.
-      assert_kind_of Array, r.client(:tracking_info)
-    end
-
-    def test_redis_rb_client_tracking_with_options
-      # The dispatcher forwards extra positional args to client_tracking,
-      # so broadcast/optin flags can be passed through r.client(:tracking, ...).
-      assert_equal "OK", r.client(:tracking, "ON", "BCAST")
-      assert_equal "OK", r.client(:tracking, "OFF")
-      assert_equal "OK", r.client(:tracking, "ON", "OPTIN")
-      assert_equal "OK", r.client(:tracking, "OFF")
-    end
-
-    def test_redis_rb_client_tracking_symbol_status
-      # Symbol args are coerced to strings (build_command_args calls #to_s) and
-      # Valkey accepts the status case-insensitively.
-      assert_equal "OK", r.client(:tracking, :on)
-      assert_equal "OK", r.client(:tracking, :off)
-    end
-
-    def test_redis_rb_client_tracking_invalid_status
-      assert_raises(Valkey::CommandError) do
-        r.client(:tracking, "MAYBE")
-      end
-    end
-
-    def test_redis_rb_client_caching_invalid_mode
-      # CLIENT CACHING needs shared tracking state, not reliable in cluster mode.
-      skip("CLIENT CACHING requires tracking state to be shared, not reliable in cluster mode") if cluster_mode?
-
-      r.client(:tracking, "ON", "OPTIN")
-      assert_raises(Valkey::CommandError) do
-        r.client(:caching, "MAYBE")
-      end
-      r.client(:tracking, "OFF")
-    end
-
-    def test_redis_rb_client_getredir
-      # extra_client = Valkey.new
-      # extra_client.client('tracking', 'on', 'bcast') # TODO: Ensure tracking is implemented
-      assert_kind_of Integer, r.client(:getredir)
     end
 
     def test_client_no_evict

--- a/test/lint/server_commands.rb
+++ b/test/lint/server_commands.rb
@@ -158,20 +158,27 @@ module Lint
       assert [0, 1].include?(result), "Expected unblock to return 0 or 1"
     end
 
-    def test_client_caching
-      skip("CLIENT CACHING command not implemented in backend yet")
+    def test_redis_rb_client_caching
+      # CLIENT CACHING requires shared tracking state, which is not reliable in
+      # cluster mode because TRACKING and CACHING may hit different nodes.
+      skip("CLIENT CACHING requires tracking state to be shared, not reliable in cluster mode") if cluster_mode?
 
-      # Assuming caching is enabled by default, this should return true
-      response = r.client(:caching)
-      assert_equal true, response
+      # The redis-rb dispatcher (r.client(:caching, mode)) forwards to client_caching.
+      # CLIENT CACHING YES works with OPTIN mode.
+      r.client(:tracking, "ON", "OPTIN")
+      assert_equal "OK", r.client(:caching, "YES")
+      r.client(:tracking, "OFF")
+      # CLIENT CACHING NO requires OPTOUT mode.
+      r.client(:tracking, "ON", "OPTOUT")
+      assert_equal "OK", r.client(:caching, "NO")
+      r.client(:tracking, "OFF")
     end
 
-    def test_client_tracking
-      skip("CLIENT TRACKING command not implemented in backend yet")
-
-      # Assuming tracking is enabled by default, this should return true
-      response = r.client(:tracking)
-      assert_equal true, response
+    def test_redis_rb_client_tracking
+      # The redis-rb dispatcher (r.client(:tracking, status)) forwards to
+      # client_tracking, which requires a status argument.
+      assert_equal "OK", r.client(:tracking, "ON")
+      assert_equal "OK", r.client(:tracking, "OFF")
     end
 
     def test_client_reply
@@ -216,13 +223,46 @@ module Lint
       end
     end
 
-    def test_client_tracking_info
-      skip("CLIENT TRACKING command not implemented in backend yet")
-
+    def test_redis_rb_client_tracking_info
+      # The redis-rb dispatcher (r.client(:tracking_info)) forwards to
+      # client_tracking_info, which takes no arguments.
       assert_kind_of Array, r.client(:tracking_info)
     end
 
-    def test_client_getredir
+    def test_redis_rb_client_tracking_with_options
+      # The dispatcher forwards extra positional args to client_tracking,
+      # so broadcast/optin flags can be passed through r.client(:tracking, ...).
+      assert_equal "OK", r.client(:tracking, "ON", "BCAST")
+      assert_equal "OK", r.client(:tracking, "OFF")
+      assert_equal "OK", r.client(:tracking, "ON", "OPTIN")
+      assert_equal "OK", r.client(:tracking, "OFF")
+    end
+
+    def test_redis_rb_client_tracking_symbol_status
+      # Symbol args are coerced to strings (build_command_args calls #to_s) and
+      # Valkey accepts the status case-insensitively.
+      assert_equal "OK", r.client(:tracking, :on)
+      assert_equal "OK", r.client(:tracking, :off)
+    end
+
+    def test_redis_rb_client_tracking_invalid_status
+      assert_raises(Valkey::CommandError) do
+        r.client(:tracking, "MAYBE")
+      end
+    end
+
+    def test_redis_rb_client_caching_invalid_mode
+      # CLIENT CACHING needs shared tracking state, not reliable in cluster mode.
+      skip("CLIENT CACHING requires tracking state to be shared, not reliable in cluster mode") if cluster_mode?
+
+      r.client(:tracking, "ON", "OPTIN")
+      assert_raises(Valkey::CommandError) do
+        r.client(:caching, "MAYBE")
+      end
+      r.client(:tracking, "OFF")
+    end
+
+    def test_redis_rb_client_getredir
       # extra_client = Valkey.new
       # extra_client.client('tracking', 'on', 'bcast') # TODO: Ensure tracking is implemented
       assert_kind_of Integer, r.client(:getredir)

--- a/test/lint/server_commands.rb
+++ b/test/lint/server_commands.rb
@@ -147,6 +147,9 @@ module Lint
     end
 
     def test_client_set_info
+      # CLIENT SETINFO was introduced in Redis 7.2.
+      # Skipped on Redis 7.0, 6.2, and earlier versions.
+      omit_version("7.2")
       assert_equal "OK", r.client(:set_info, 'lib-name', 'valkey') # TODO: 'implementing lib-var'
       assert_raises(Valkey::CommandError) do
         r.client(:set_info, 'foo', '0.0.1')
@@ -229,6 +232,9 @@ module Lint
     end
 
     def test_client_no_evict
+      # CLIENT NO-EVICT was introduced in Redis 7.0.
+      # Skipped on Redis 6.2 and earlier versions.
+      omit_version("7.0")
       assert_equal "OK", r.client_no_evict(:on)
       assert_equal "OK", r.client_no_evict(:off)
       assert_raises(Valkey::CommandError) do
@@ -237,6 +243,9 @@ module Lint
     end
 
     def test_client_no_touch
+      # CLIENT NO-TOUCH was introduced in Redis 7.2.
+      # Skipped on Redis 7.0, 6.2, and earlier versions.
+      omit_version("7.2")
       assert_equal "OK", r.client_no_touch(:on)
       assert_equal "OK", r.client_no_touch(:off)
       assert_raises(Valkey::CommandError) do
@@ -322,11 +331,17 @@ module Lint
     end
 
     def test_acl_dryrun
+      # ACL DRYRUN was introduced in Redis 7.0.
+      # Skipped on Redis 6.2 and earlier versions.
+      omit_version("7.0")
       result = r.acl_dryrun("default", "get", "key1")
       assert_equal "OK", result
     end
 
     def test_acl_dryrun_denied
+      # ACL DRYRUN was introduced in Redis 7.0.
+      # Skipped on Redis 6.2 and earlier versions.
+      omit_version("7.0")
       r.acl_setuser("limiteduser", "on", ">pass", "~*", "+@read", "-set")
 
       result = r.acl_dryrun("limiteduser", "set", "key1", "value")
@@ -741,10 +756,12 @@ module Lint
     end
 
     def test_command_info
-      # COMMAND INFO without arguments returns info for all commands
-      result = r.command_info
-      assert_kind_of Array, result
-      assert !result.empty?, "Expected COMMAND INFO to return non-empty array"
+      # COMMAND INFO without arguments returns info for all commands (Redis 7.0+)
+      target_version "7.0" do
+        result = r.command_info
+        assert_kind_of Array, result
+        assert !result.empty?, "Expected COMMAND INFO to return non-empty array"
+      end
 
       # COMMAND INFO with specific commands
       result = r.command_info("GET", "SET")

--- a/test/lint/sorted_set_commands.rb
+++ b/test/lint/sorted_set_commands.rb
@@ -673,6 +673,9 @@ module Lint
     end
 
     def test_bzmpop
+      # BZMPOP was introduced in Redis 7.0.
+      # Skipped on Redis 6.2 and earlier versions.
+      omit_version("7.0")
       r.zadd("key1", [[1, "a"], [2, "b"], [3, "c"]])
 
       result = r.bzmpop(0.1, "key1", modifier: "MAX", count: 2)
@@ -703,6 +706,9 @@ module Lint
     def test_zintercard
       # Uses key1/key2 keys across different hash slots
       skip("Cross-slot operation not supported in cluster mode") if cluster_mode?
+      # ZINTERCARD was introduced in Redis 7.0.
+      # Skipped on Redis 6.2 and earlier versions.
+      omit_version("7.0")
 
       r.zadd("key1", [[1, "a"], [2, "b"], [3, "c"]])
       r.zadd("key2", [[1, "b"], [2, "c"], [3, "d"]])
@@ -713,6 +719,9 @@ module Lint
     def test_zintercard_with_limit
       # Uses key1/key2 keys across different hash slots
       skip("Cross-slot operation not supported in cluster mode") if cluster_mode?
+      # ZINTERCARD was introduced in Redis 7.0.
+      # Skipped on Redis 6.2 and earlier versions.
+      omit_version("7.0")
 
       r.zadd("key1", [[1, "a"], [2, "b"], [3, "c"]])
       r.zadd("key2", [[1, "b"], [2, "c"], [3, "d"]])
@@ -721,6 +730,9 @@ module Lint
     end
 
     def test_zmpop
+      # ZMPOP was introduced in Redis 7.0.
+      # Skipped on Redis 6.2 and earlier versions.
+      omit_version("7.0")
       r.zadd("key1", [[1, "a"], [2, "b"], [3, "c"]])
 
       result = r.zmpop("key1", modifier: "MAX", count: 2)

--- a/test/lint/vector_search_commands.rb
+++ b/test/lint/vector_search_commands.rb
@@ -492,6 +492,10 @@ module Lint
           skip("RediSearch module file not available at #{REDISEARCH_MODULE_PATH}")
         elsif e.message.include?("MODULE command not allowed")
           skip("MODULE commands not enabled")
+        elsif e.message.include?("unknown command")
+          skip("MODULE command not supported on this server version")
+        elsif e.message.include?("Error loading the extension")
+          skip("RediSearch module failed to load on this engine")
         else
           raise
         end

--- a/test/lint/vector_search_commands.rb
+++ b/test/lint/vector_search_commands.rb
@@ -453,6 +453,176 @@ module Lint
       skip_if_redisearch_unavailable(e)
     end
 
+    # --- Structured ft_create tests (fields: / options:) ---
+
+    def test_ft_create_structured_text_field
+      ensure_redisearch_loaded
+
+      with_db0 do
+        result = r.ft_create(TEST_INDEX,
+                             fields: [Valkey::Search::TextField.new("title")])
+        assert_equal "OK", result
+        assert index_exists?(TEST_INDEX)
+      end
+    rescue Valkey::CommandError => e
+      skip_if_redisearch_unavailable(e)
+    end
+
+    def test_ft_create_structured_multiple_fields
+      ensure_redisearch_loaded
+
+      with_db0 do
+        result = r.ft_create(TEST_INDEX,
+                             fields: [
+                               Valkey::Search::TextField.new("title", sortable: true),
+                               Valkey::Search::NumericField.new("price", sortable: true),
+                               Valkey::Search::TagField.new("category")
+                             ])
+        assert_equal "OK", result
+        assert index_exists?(TEST_INDEX)
+      end
+    rescue Valkey::CommandError => e
+      skip_if_redisearch_unavailable(e)
+    end
+
+    def test_ft_create_structured_with_options
+      ensure_redisearch_loaded
+
+      with_db0 do
+        result = r.ft_create(TEST_INDEX,
+                             fields: [
+                               Valkey::Search::TextField.new("title"),
+                               Valkey::Search::NumericField.new("price")
+                             ],
+                             options: Valkey::Search::FtCreateOptions.new(
+                               data_type: :hash,
+                               prefixes: ["product:"]
+                             ))
+        assert_equal "OK", result
+        assert index_exists?(TEST_INDEX)
+
+        # Verify it actually indexes prefixed keys
+        r.send_command(Valkey::RequestType::HSET, ["product:1", "title", "Widget", "price", "9.99"])
+        sleep 0.1
+        results = r.ft_search(TEST_INDEX, "Widget")
+        assert_kind_of Array, results
+        count = results[0]
+        assert(count.is_a?(Integer) ? count >= 1 : count.to_i >= 1,
+               "Should find at least one document")
+      end
+    rescue Valkey::CommandError => e
+      skip_if_redisearch_unavailable(e)
+    end
+
+    def test_ft_create_structured_vector_flat
+      ensure_redisearch_loaded
+
+      with_db0 do
+        result = r.ft_create(TEST_INDEX,
+                             fields: [
+                               Valkey::Search::TextField.new("title"),
+                               Valkey::Search::VectorFieldFlat.new("embedding",
+                                                                   dim: 128,
+                                                                   distance_metric: :cosine)
+                             ],
+                             options: Valkey::Search::FtCreateOptions.new(
+                               data_type: :hash,
+                               prefixes: ["doc:"]
+                             ))
+        assert_equal "OK", result
+        assert index_exists?(TEST_INDEX)
+      end
+    rescue Valkey::CommandError => e
+      skip_if_redisearch_unavailable(e)
+    end
+
+    def test_ft_create_structured_vector_hnsw
+      ensure_redisearch_loaded
+
+      with_db0 do
+        result = r.ft_create(TEST_INDEX,
+                             fields: [
+                               Valkey::Search::TextField.new("title"),
+                               Valkey::Search::VectorFieldHnsw.new("embedding",
+                                                                   dim: 768,
+                                                                   distance_metric: :l2,
+                                                                   m: 16,
+                                                                   ef_construction: 200,
+                                                                   ef_runtime: 10)
+                             ],
+                             options: Valkey::Search::FtCreateOptions.new(
+                               data_type: :hash,
+                               prefixes: ["vec:"]
+                             ))
+        assert_equal "OK", result
+        assert index_exists?(TEST_INDEX)
+      end
+    rescue Valkey::CommandError => e
+      skip_if_redisearch_unavailable(e)
+    end
+
+    def test_ft_create_structured_json_data_type
+      ensure_redisearch_loaded
+
+      with_db0 do
+        result = r.ft_create(TEST_INDEX,
+                             fields: [
+                               Valkey::Search::TextField.new("$.title", field_alias: "title"),
+                               Valkey::Search::NumericField.new("$.price", field_alias: "price")
+                             ],
+                             options: Valkey::Search::FtCreateOptions.new(
+                               data_type: :json,
+                               prefixes: ["item:"]
+                             ))
+        assert_equal "OK", result
+        assert index_exists?(TEST_INDEX)
+      end
+    rescue Valkey::CommandError => e
+      skip_if_redisearch_unavailable(e)
+    end
+
+    def test_ft_create_structured_with_stopwords
+      ensure_redisearch_loaded
+
+      with_db0 do
+        result = r.ft_create(TEST_INDEX,
+                             fields: [Valkey::Search::TextField.new("body")],
+                             options: Valkey::Search::FtCreateOptions.new(
+                               stopwords: ["the", "a", "is"]
+                             ))
+        assert_equal "OK", result
+        assert index_exists?(TEST_INDEX)
+      end
+    rescue Valkey::CommandError => e
+      skip_if_redisearch_unavailable(e)
+    end
+
+    def test_ft_create_structured_tag_with_separator
+      ensure_redisearch_loaded
+
+      with_db0 do
+        result = r.ft_create(TEST_INDEX,
+                             fields: [
+                               Valkey::Search::TagField.new("tags", separator: ";",
+                                                            case_sensitive: true)
+                             ],
+                             options: Valkey::Search::FtCreateOptions.new(
+                               data_type: :hash,
+                               prefixes: ["item:"]
+                             ))
+        assert_equal "OK", result
+        assert index_exists?(TEST_INDEX)
+
+        # Verify separator works
+        r.send_command(Valkey::RequestType::HSET, ["item:1", "tags", "ruby;python;go"])
+        sleep 0.1
+        results = r.ft_search(TEST_INDEX, "@tags:{ruby}")
+        assert_kind_of Array, results
+      end
+    rescue Valkey::CommandError => e
+      skip_if_redisearch_unavailable(e)
+    end
+
     private
 
     # RediSearch requires database 0, so we wrap operations to ensure we're on the right DB

--- a/test/lint/vector_search_commands.rb
+++ b/test/lint/vector_search_commands.rb
@@ -623,6 +623,317 @@ module Lint
       skip_if_redisearch_unavailable(e)
     end
 
+    # --- Structured ft_search tests (options:) ---
+
+    def test_ft_search_structured_basic
+      ensure_redisearch_loaded
+
+      with_db0 do
+        r.ft_create(TEST_INDEX, "ON", "HASH", "PREFIX", "1", "doc:", "SCHEMA", "title", "TEXT")
+        r.send_command(Valkey::RequestType::HSET, ["doc:1", "title", "hello world"])
+        r.send_command(Valkey::RequestType::HSET, ["doc:2", "title", "goodbye world"])
+        sleep 0.1
+
+        result = r.ft_search(TEST_INDEX, "hello",
+                             options: Valkey::Search::FtSearchOptions.new)
+        assert_kind_of Valkey::Search::FtSearchResult, result
+        assert result.total_results >= 1
+        assert_kind_of Valkey::Search::FtSearchDocument, result.documents.first
+        assert_equal "hello world", result.documents.first["title"]
+      end
+    rescue Valkey::CommandError => e
+      skip_if_redisearch_unavailable(e)
+    end
+
+    def test_ft_search_structured_with_limit
+      ensure_redisearch_loaded
+
+      with_db0 do
+        r.ft_create(TEST_INDEX, "ON", "HASH", "PREFIX", "1", "doc:", "SCHEMA", "title", "TEXT")
+        5.times do |i|
+          r.send_command(Valkey::RequestType::HSET, ["doc:#{i}", "title", "hello item #{i}"])
+        end
+        sleep 0.1
+
+        result = r.ft_search(TEST_INDEX, "hello",
+                             options: Valkey::Search::FtSearchOptions.new(
+                               limit: Valkey::Search::FtSearchLimit.new(offset: 0, count: 2)
+                             ))
+        assert_kind_of Valkey::Search::FtSearchResult, result
+        assert result.total_results >= 5
+        assert_equal 2, result.documents.size
+      end
+    rescue Valkey::CommandError => e
+      skip_if_redisearch_unavailable(e)
+    end
+
+    def test_ft_search_structured_with_return_fields
+      ensure_redisearch_loaded
+
+      with_db0 do
+        r.ft_create(TEST_INDEX, "ON", "HASH", "PREFIX", "1", "doc:",
+                    "SCHEMA", "title", "TEXT", "price", "NUMERIC")
+        r.send_command(Valkey::RequestType::HSET, ["doc:1", "title", "widget", "price", "9.99"])
+        sleep 0.1
+
+        result = r.ft_search(TEST_INDEX, "widget",
+                             options: Valkey::Search::FtSearchOptions.new(
+                               return_fields: [Valkey::Search::ReturnField.new("title")]
+                             ))
+        assert_kind_of Valkey::Search::FtSearchResult, result
+        assert result.total_results >= 1
+        doc = result.documents.first
+        assert_equal "widget", doc["title"]
+      end
+    rescue Valkey::CommandError => e
+      skip_if_redisearch_unavailable(e)
+    end
+
+    def test_ft_search_structured_sortby
+      ensure_redisearch_loaded
+
+      with_db0 do
+        r.ft_create(TEST_INDEX, "ON", "HASH", "PREFIX", "1", "doc:",
+                    "SCHEMA", "title", "TEXT", "price", "NUMERIC", "SORTABLE")
+        r.send_command(Valkey::RequestType::HSET, ["doc:1", "title", "cheap", "price", "5"])
+        r.send_command(Valkey::RequestType::HSET, ["doc:2", "title", "pricey", "price", "50"])
+        sleep 0.1
+
+        result = r.ft_search(TEST_INDEX, "*",
+                             options: Valkey::Search::FtSearchOptions.new(
+                               sortby: "price", sortby_order: :asc
+                             ))
+        assert_kind_of Valkey::Search::FtSearchResult, result
+        assert_equal 2, result.total_results
+        # First document should be the cheapest
+        assert_equal "5", result.documents.first["price"]
+      end
+    rescue Valkey::CommandError => e
+      skip_if_redisearch_unavailable(e)
+    end
+
+    def test_ft_search_structured_nocontent
+      ensure_redisearch_loaded
+
+      with_db0 do
+        r.ft_create(TEST_INDEX, "ON", "HASH", "PREFIX", "1", "doc:", "SCHEMA", "title", "TEXT")
+        r.send_command(Valkey::RequestType::HSET, ["doc:1", "title", "hello"])
+        sleep 0.1
+
+        result = r.ft_search(TEST_INDEX, "hello",
+                             options: Valkey::Search::FtSearchOptions.new(nocontent: true))
+        assert_kind_of Valkey::Search::FtSearchResult, result
+        assert result.total_results >= 1
+        # Documents should have empty fields when nocontent is used
+        assert_equal({}, result.documents.first.fields)
+      end
+    rescue Valkey::CommandError => e
+      skip_if_redisearch_unavailable(e)
+    end
+
+    def test_ft_search_structured_verbatim
+      ensure_redisearch_loaded
+
+      with_db0 do
+        r.ft_create(TEST_INDEX, "ON", "HASH", "PREFIX", "1", "doc:", "SCHEMA", "title", "TEXT")
+        r.send_command(Valkey::RequestType::HSET, ["doc:1", "title", "running quickly"])
+        sleep 0.1
+
+        # Without verbatim, "run" would match "running" via stemming
+        # With verbatim, "run" should NOT match "running"
+        result = r.ft_search(TEST_INDEX, "run",
+                             options: Valkey::Search::FtSearchOptions.new(verbatim: true))
+        assert_kind_of Valkey::Search::FtSearchResult, result
+        assert_equal 0, result.total_results
+      end
+    rescue Valkey::CommandError => e
+      skip_if_redisearch_unavailable(e)
+    end
+
+    def test_ft_search_raw_still_works
+      ensure_redisearch_loaded
+
+      with_db0 do
+        r.ft_create(TEST_INDEX, "ON", "HASH", "PREFIX", "1", "doc:", "SCHEMA", "title", "TEXT")
+        r.send_command(Valkey::RequestType::HSET, ["doc:1", "title", "hello"])
+        sleep 0.1
+
+        # Verify backward compat: raw args still return raw array
+        results = r.ft_search(TEST_INDEX, "hello")
+        assert_kind_of Array, results
+      end
+    rescue Valkey::CommandError => e
+      skip_if_redisearch_unavailable(e)
+    end
+
+    # --- Structured ft_aggregate tests (options:) ---
+
+    def test_ft_aggregate_structured_groupby_count
+      ensure_redisearch_loaded
+
+      with_db0 do
+        r.ft_create(TEST_INDEX, "ON", "HASH", "PREFIX", "1", "product:",
+                    "SCHEMA", "category", "TAG", "price", "NUMERIC")
+        r.send_command(Valkey::RequestType::HSET, ["product:1", "category", "electronics", "price", "100"])
+        r.send_command(Valkey::RequestType::HSET, ["product:2", "category", "electronics", "price", "200"])
+        r.send_command(Valkey::RequestType::HSET, ["product:3", "category", "books", "price", "50"])
+        sleep 0.1
+
+        results = r.ft_aggregate(TEST_INDEX, "*",
+                                 options: Valkey::Search::FtAggregateOptions.new(
+                                   clauses: [
+                                     Valkey::Search::GroupBy.new(["@category"],
+                                                                reducers: [Valkey::Search::Reducer.new("COUNT", [], name: "count")])
+                                   ]
+                                 ))
+        assert_kind_of Array, results
+      end
+    rescue Valkey::CommandError => e
+      skip_if_redisearch_unavailable(e)
+    end
+
+    def test_ft_aggregate_structured_with_load
+      ensure_redisearch_loaded
+
+      with_db0 do
+        r.ft_create(TEST_INDEX, "ON", "HASH", "PREFIX", "1", "product:",
+                    "SCHEMA", "category", "TAG", "price", "NUMERIC")
+        r.send_command(Valkey::RequestType::HSET, ["product:1", "category", "electronics", "price", "100"])
+        r.send_command(Valkey::RequestType::HSET, ["product:2", "category", "electronics", "price", "200"])
+        sleep 0.1
+
+        results = r.ft_aggregate(TEST_INDEX, "@price:[0 inf]",
+                                 options: Valkey::Search::FtAggregateOptions.new(
+                                   load_fields: ["@price"],
+                                   clauses: [
+                                     Valkey::Search::GroupBy.new(["@category"],
+                                                                reducers: [Valkey::Search::Reducer.new("SUM", ["@price"], name: "total")])
+                                   ]
+                                 ))
+        assert_kind_of Array, results
+      end
+    rescue Valkey::CommandError => e
+      skip_if_redisearch_unavailable(e)
+    end
+
+    def test_ft_aggregate_structured_sortby_limit
+      ensure_redisearch_loaded
+
+      with_db0 do
+        r.ft_create(TEST_INDEX, "ON", "HASH", "PREFIX", "1", "product:",
+                    "SCHEMA", "category", "TAG", "price", "NUMERIC")
+        r.send_command(Valkey::RequestType::HSET, ["product:1", "category", "a", "price", "10"])
+        r.send_command(Valkey::RequestType::HSET, ["product:2", "category", "b", "price", "20"])
+        r.send_command(Valkey::RequestType::HSET, ["product:3", "category", "c", "price", "30"])
+        sleep 0.1
+
+        results = r.ft_aggregate(TEST_INDEX, "*",
+                                 options: Valkey::Search::FtAggregateOptions.new(
+                                   clauses: [
+                                     Valkey::Search::GroupBy.new(["@category"],
+                                                                reducers: [Valkey::Search::Reducer.new("COUNT", [], name: "count")]),
+                                     Valkey::Search::SortBy.new([Valkey::Search::SortProperty.new("@count", :desc)]),
+                                     Valkey::Search::AggregateLimit.new(offset: 0, count: 2)
+                                   ]
+                                 ))
+        assert_kind_of Array, results
+      end
+    rescue Valkey::CommandError => e
+      skip_if_redisearch_unavailable(e)
+    end
+
+    def test_ft_aggregate_structured_apply_filter
+      ensure_redisearch_loaded
+
+      with_db0 do
+        r.ft_create(TEST_INDEX, "ON", "HASH", "PREFIX", "1", "product:",
+                    "SCHEMA", "category", "TAG", "price", "NUMERIC")
+        r.send_command(Valkey::RequestType::HSET, ["product:1", "category", "electronics", "price", "100"])
+        r.send_command(Valkey::RequestType::HSET, ["product:2", "category", "electronics", "price", "200"])
+        sleep 0.1
+
+        results = r.ft_aggregate(TEST_INDEX, "@price:[0 inf]",
+                                 options: Valkey::Search::FtAggregateOptions.new(
+                                   load_fields: ["@price"],
+                                   clauses: [
+                                     Valkey::Search::Apply.new("@price * 1.1", name: "taxed"),
+                                     Valkey::Search::Filter.new("@taxed > 150")
+                                   ]
+                                 ))
+        assert_kind_of Array, results
+      end
+    rescue Valkey::CommandError => e
+      skip_if_redisearch_unavailable(e)
+    end
+
+    def test_ft_aggregate_raw_still_works
+      ensure_redisearch_loaded
+
+      with_db0 do
+        r.ft_create(TEST_INDEX, "ON", "HASH", "PREFIX", "1", "product:",
+                    "SCHEMA", "category", "TAG")
+        r.send_command(Valkey::RequestType::HSET, ["product:1", "category", "books"])
+        sleep 0.1
+
+        # Raw args backward compat
+        results = r.ft_aggregate(TEST_INDEX, "*", "GROUPBY", "1", "@category",
+                                 "REDUCE", "COUNT", "0", "AS", "count")
+        assert_kind_of Array, results
+      end
+    rescue Valkey::CommandError => e
+      skip_if_redisearch_unavailable(e)
+    end
+
+    # --- Structured ft_info tests (options:) ---
+
+    def test_ft_info_structured_default
+      ensure_redisearch_loaded
+
+      with_db0 do
+        r.ft_create(TEST_INDEX, "SCHEMA", "title", "TEXT")
+
+        # options: with empty FtInfoOptions should behave same as no options
+        info = r.ft_info(TEST_INDEX, options: Valkey::Search::FtInfoOptions.new)
+        assert_kind_of Array, info
+        assert info.include?("index_name") || info.any? { |item| item.is_a?(Array) && item.include?("index_name") }
+      end
+    rescue Valkey::CommandError => e
+      skip_if_redisearch_unavailable(e)
+    end
+
+    def test_ft_info_structured_local_scope
+      ensure_redisearch_loaded
+
+      with_db0 do
+        r.ft_create(TEST_INDEX, "SCHEMA", "title", "TEXT")
+
+        # LOCAL scope should work on standalone (it's the default behavior)
+        info = r.ft_info(TEST_INDEX, options: Valkey::Search::FtInfoOptions.new(scope: :local))
+        assert_kind_of Array, info
+      end
+    rescue Valkey::CommandError => e
+      # LOCAL might not be recognized on older search module versions
+      if e.message.include?("unknown command") || e.message.include?("Unknown")
+        skip("FT.INFO scope options not supported on this version")
+      else
+        skip_if_redisearch_unavailable(e)
+      end
+    end
+
+    def test_ft_info_raw_still_works
+      ensure_redisearch_loaded
+
+      with_db0 do
+        r.ft_create(TEST_INDEX, "SCHEMA", "title", "TEXT")
+
+        # Raw call without options still works
+        info = r.ft_info(TEST_INDEX)
+        assert_kind_of Array, info
+      end
+    rescue Valkey::CommandError => e
+      skip_if_redisearch_unavailable(e)
+    end
+
     private
 
     # RediSearch requires database 0, so we wrap operations to ensure we're on the right DB

--- a/test/standalone/valkey_test.rb
+++ b/test/standalone/valkey_test.rb
@@ -8,6 +8,7 @@ class TestStandaloneValkey < Minitest::Test
   include Helper::Client
 
   # ValkeyTests modules for valkey-glide-ruby specific functionality
+  include ValkeyTests::AuthCommands
   include ValkeyTests::Bitpos
   include ValkeyTests::FunctionCommands
   include ValkeyTests::GenericCommands

--- a/test/standalone/valkey_test.rb
+++ b/test/standalone/valkey_test.rb
@@ -11,7 +11,7 @@ class TestStandaloneValkey < Minitest::Test
   include ValkeyTests::AuthCommands
   include ValkeyTests::Bitpos
 
-  # include ValkeyTests::ConnectionLifecycle
+  include ValkeyTests::ConnectionLifecycle
   include ValkeyTests::FailoverCommands
   include ValkeyTests::FunctionCommands
   include ValkeyTests::GenericCommands

--- a/test/standalone/valkey_test.rb
+++ b/test/standalone/valkey_test.rb
@@ -10,7 +10,8 @@ class TestStandaloneValkey < Minitest::Test
   # ValkeyTests modules for valkey-glide-ruby specific functionality
   include ValkeyTests::AuthCommands
   include ValkeyTests::Bitpos
-  include ValkeyTests::ConnectionLifecycle
+
+  # include ValkeyTests::ConnectionLifecycle
   include ValkeyTests::FailoverCommands
   include ValkeyTests::FunctionCommands
   include ValkeyTests::GenericCommands

--- a/test/standalone/valkey_test.rb
+++ b/test/standalone/valkey_test.rb
@@ -10,6 +10,7 @@ class TestStandaloneValkey < Minitest::Test
   # ValkeyTests modules for valkey-glide-ruby specific functionality
   include ValkeyTests::AuthCommands
   include ValkeyTests::Bitpos
+  include ValkeyTests::ConnectionLifecycle
   include ValkeyTests::FailoverCommands
   include ValkeyTests::FunctionCommands
   include ValkeyTests::GenericCommands

--- a/test/standalone/valkey_test.rb
+++ b/test/standalone/valkey_test.rb
@@ -10,6 +10,7 @@ class TestStandaloneValkey < Minitest::Test
   # ValkeyTests modules for valkey-glide-ruby specific functionality
   include ValkeyTests::AuthCommands
   include ValkeyTests::Bitpos
+  include ValkeyTests::FailoverCommands
   include ValkeyTests::FunctionCommands
   include ValkeyTests::GenericCommands
   include ValkeyTests::Scanning

--- a/test/support/helper/cluster.rb
+++ b/test/support/helper/cluster.rb
@@ -73,9 +73,14 @@ module Helper
       valkey
     end
 
-    # TODO: it has to come from the server
+    # Query actual server version from the cluster. Falls back to "0.0" if
+    # detection fails so that version-gated tests skip rather than error.
     def version
-      "7.0"
+      info = valkey.info
+      ver = extract_version_from_info(info)
+      Version.new(ver || "0.0")
+    rescue StandardError
+      Version.new("0.0")
     end
 
     def cluster_mode?
@@ -83,6 +88,20 @@ module Helper
     end
 
     private
+
+    def extract_version_from_info(info)
+      case info
+      when Hash
+        info["valkey_version"] || info["redis_version"]
+      when Array
+        # Could be array of node responses; try first element
+        first = info.first
+        extract_version_from_info(first)
+      when String
+        # Raw INFO string — parse valkey_version or redis_version
+        ::Regexp.last_match(1) if info =~ /(?:valkey|redis)_version:(\S+)/
+      end
+    end
 
     def _new_client(options = {})
       addresses = Helper::Cluster.cluster_addresses

--- a/test/support/helper/generic.rb
+++ b/test/support/helper/generic.rb
@@ -8,6 +8,10 @@ module Helper
 
     alias r valkey
 
+    # Credentials used by the auth helpers (with_acl / with_default_user_password).
+    AUTH_TEST_PASSWORD = "mysecret"
+    ACL_TEST_USERNAME = "johndoe"
+
     def run
       if respond_to?(:around)
         around { super }
@@ -87,33 +91,44 @@ module Helper
       # ACL user must be granted those even though the test only exercises PING/SET.
       # This mirrors the python reference grant (+ping +info +client +cluster ...);
       # +set is intentionally withheld so the disallowed-command test still fails.
-      admin.acl("SETUSER", "johndoe", "on",
+      admin.acl("SETUSER", ACL_TEST_USERNAME, "on",
                 "+ping", "+select", "+command", "+info", "+client",
                 "+cluster|slots", "+cluster|nodes", "+readonly",
-                ">mysecret")
-      yield("johndoe", "mysecret")
+                ">#{AUTH_TEST_PASSWORD}")
+      yield(ACL_TEST_USERNAME, AUTH_TEST_PASSWORD)
     ensure
-      begin
-        admin&.acl("DELUSER", "johndoe")
-      rescue Valkey::BaseError
-        # best-effort restore; never let teardown cascade into other tests
-      ensure
-        admin&.close
-      end
+      admin&.close
+      delete_acl_user(ACL_TEST_USERNAME)
+    end
+
+    # Remove the ACL test user. Mirrors restore_default_user_nopass: run the
+    # cleanup from a fresh privileged (default / no-password) connection rather
+    # than as `johndoe` (which lacks +acl) or via a possibly-stale `admin`.
+    def delete_acl_user(username)
+      client = _new_client
+      client.acl("DELUSER", username)
+    rescue Valkey::BaseError => e
+      warn "[auth-helper] could not delete ACL user `#{username}`: #{e.class}: #{e.message}"
+    ensure
+      client&.close
     end
 
     def with_default_user_password
-      admin = _new_client
-      admin.acl("SETUSER", "default", ">mysecret")
-      yield("default", "mysecret")
+      client = _new_client
+      client.acl("SETUSER", "default", ">#{AUTH_TEST_PASSWORD}")
+      yield("default", AUTH_TEST_PASSWORD)
     ensure
-      begin
-        admin&.acl("SETUSER", "default", "nopass")
-      rescue Valkey::BaseError
-        # best-effort restore; never let teardown cascade into other tests
-      ensure
-        admin&.close
-      end
+      client&.close
+      restore_default_user_nopass
+    end
+
+    def restore_default_user_nopass
+      client = _new_client(password: AUTH_TEST_PASSWORD)
+      client.acl("SETUSER", "default", "nopass")
+    rescue Valkey::BaseError => e
+      warn "[auth-helper] could not reset `default` user to nopass: #{e.class}: #{e.message}"
+    ensure
+      client&.close
     end
   end
 end

--- a/test/support/helper/generic.rb
+++ b/test/support/helper/generic.rb
@@ -86,14 +86,6 @@ module Helper
     end
 
     def with_acl
-      # NOTE: The ACL auth tests intermittently hang the entire standalone suite
-      # in CI. Investigation (PR #113) showed the ACL tests' connection/command
-      # pattern wedges the shared glide-core FFI runtime, after which a later
-      # unrelated FFI command (e.g. FUNCTION LOAD) blocks indefinitely with no
-      # client-side timeout, exceeding the 30-minute job cap. Skipped until the
-      # underlying FFI robustness issue is resolved.
-      skip("ACL auth tests temporarily disabled: cause intermittent CI hang (see PR #113)")
-
       admin = _new_client
       # glide-core runs INFO (and CLIENT) during the connection handshake, so the
       # ACL user must be granted those even though the test only exercises PING/SET.

--- a/test/support/helper/generic.rb
+++ b/test/support/helper/generic.rb
@@ -83,13 +83,23 @@ module Helper
 
     def with_acl
       admin = _new_client
+      # glide-core runs INFO (and CLIENT) during the connection handshake, so the
+      # ACL user must be granted those even though the test only exercises PING/SET.
+      # This mirrors the python reference grant (+ping +info +client +cluster ...);
+      # +set is intentionally withheld so the disallowed-command test still fails.
       admin.acl("SETUSER", "johndoe", "on",
-                "+ping", "+select", "+command", "+cluster|slots", "+cluster|nodes", "+readonly",
+                "+ping", "+select", "+command", "+info", "+client",
+                "+cluster|slots", "+cluster|nodes", "+readonly",
                 ">mysecret")
       yield("johndoe", "mysecret")
     ensure
-      admin.acl("DELUSER", "johndoe")
-      admin.close
+      begin
+        admin&.acl("DELUSER", "johndoe")
+      rescue Valkey::BaseError
+        # best-effort restore; never let teardown cascade into other tests
+      ensure
+        admin&.close
+      end
     end
 
     def with_default_user_password
@@ -97,8 +107,13 @@ module Helper
       admin.acl("SETUSER", "default", ">mysecret")
       yield("default", "mysecret")
     ensure
-      admin.acl("SETUSER", "default", "nopass")
-      admin.close
+      begin
+        admin&.acl("SETUSER", "default", "nopass")
+      rescue Valkey::BaseError
+        # best-effort restore; never let teardown cascade into other tests
+      ensure
+        admin&.close
+      end
     end
   end
 end

--- a/test/support/helper/generic.rb
+++ b/test/support/helper/generic.rb
@@ -86,6 +86,14 @@ module Helper
     end
 
     def with_acl
+      # NOTE: The ACL auth tests intermittently hang the entire standalone suite
+      # in CI. Investigation (PR #113) showed the ACL tests' connection/command
+      # pattern wedges the shared glide-core FFI runtime, after which a later
+      # unrelated FFI command (e.g. FUNCTION LOAD) blocks indefinitely with no
+      # client-side timeout, exceeding the 30-minute job cap. Skipped until the
+      # underlying FFI robustness issue is resolved.
+      skip("ACL auth tests temporarily disabled: cause intermittent CI hang (see PR #113)")
+
       admin = _new_client
       # glide-core runs INFO (and CLIENT) during the connection handshake, so the
       # ACL user must be granted those even though the test only exercises PING/SET.

--- a/test/support/helper/generic.rb
+++ b/test/support/helper/generic.rb
@@ -78,7 +78,8 @@ module Helper
     end
 
     def version
-      Version.new(valkey.info["valkey_version"])
+      info = valkey.info
+      Version.new(info["valkey_version"] || info["redis_version"])
     end
 
     def with_acl

--- a/test/support/helper/ssl.rb
+++ b/test/support/helper/ssl.rb
@@ -1,24 +1,39 @@
 # frozen_string_literal: true
 
 module SslHelper
-  # Path to SSL fixtures directory
+  # Path to SSL certificates directory.
+  # In CI, cluster_manager.py generates certs in valkey-glide/utils/tls_crts/.
+  # For local development, certs can be generated in test/fixtures/ssl/.
   def ssl_fixtures_path
-    File.expand_path("../../fixtures/ssl", __dir__)
+    if ENV["TLS_CERT_DIR"] && Dir.exist?(ENV["TLS_CERT_DIR"])
+      ENV["TLS_CERT_DIR"]
+    else
+      File.expand_path("../../fixtures/ssl", __dir__)
+    end
   end
 
   # Path to CA certificate file
   def ssl_ca_cert_path
-    File.join(ssl_fixtures_path, "ca-cert.pem")
+    # cluster_manager.py uses ca.crt, local fixtures use ca-cert.pem
+    cm_path = File.join(ssl_fixtures_path, "ca.crt")
+    local_path = File.join(ssl_fixtures_path, "ca-cert.pem")
+    File.exist?(cm_path) ? cm_path : local_path
   end
 
-  # Path to client certificate file
+  # Path to client/server certificate file
   def ssl_client_cert_path
-    File.join(ssl_fixtures_path, "client-cert.pem")
+    # cluster_manager.py uses server.crt, local fixtures use client-cert.pem
+    cm_path = File.join(ssl_fixtures_path, "server.crt")
+    local_path = File.join(ssl_fixtures_path, "client-cert.pem")
+    File.exist?(cm_path) ? cm_path : local_path
   end
 
-  # Path to client key file
+  # Path to client/server key file
   def ssl_client_key_path
-    File.join(ssl_fixtures_path, "client-key.pem")
+    # cluster_manager.py uses server.key, local fixtures use client-key.pem
+    cm_path = File.join(ssl_fixtures_path, "server.key")
+    local_path = File.join(ssl_fixtures_path, "client-key.pem")
+    File.exist?(cm_path) ? cm_path : local_path
   end
 
   # Load CA certificate as OpenSSL object

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -25,6 +25,10 @@ DB          = 15
 TIMEOUT = Float(ENV["TIMEOUT"] || 5.0) # Increased from 3.0 to 5.0 for CI stability
 LOW_TIMEOUT = Float(ENV["LOW_TIMEOUT"] || 0.01) # for blocking-command tests
 
+# When SKIP_TLS_TESTS is set to "true", TLS/SSL tests are skipped gracefully.
+# This is used on macOS CI where Docker-based TLS server setup is unavailable.
+SKIP_TLS_TESTS = ENV["SKIP_TLS_TESTS"] == "true"
+
 CLUSTER_NODES = 6.times.map do |i|
   { host: "127.0.0.1", port: 7000 + i }
 end

--- a/test/valkey/auth_commands_test.rb
+++ b/test/valkey/auth_commands_test.rb
@@ -12,14 +12,8 @@
 # - ACL rules are defined per node th inside the block helpers.
 module ValkeyTests
   module AuthCommands
-    # Tests that open a connection with WRONG credentials (server replies
-    # "AuthenticationFailed") intermittently hang the native connection-creation
-    # path and wedge the entire standalone suite (30-min CI timeout). The
-    # missing-credentials/NOAUTH path is NOT affected. Disabled until the
-    # underlying FFI connection-creation race is fixed upstream. See PR #113.
     WRONG_CREDENTIALS_HANG_SKIP =
-      "Disabled: wrong-credentials connect (AuthenticationFailed) intermittently hangs " \
-      "the native connection-creation path and wedges the suite. See PR #113."
+      "Disabled: wrong-credentials tests as it is causing suites to hang. See valkey-glide-ruby/issues/115"
 
     # =========================================================
     # Default user -- connect-time

--- a/test/valkey/auth_commands_test.rb
+++ b/test/valkey/auth_commands_test.rb
@@ -12,6 +12,15 @@
 # - ACL rules are defined per node th inside the block helpers.
 module ValkeyTests
   module AuthCommands
+    # Tests that open a connection with WRONG credentials (server replies
+    # "AuthenticationFailed") intermittently hang the native connection-creation
+    # path and wedge the entire standalone suite (30-min CI timeout). The
+    # missing-credentials/NOAUTH path is NOT affected. Disabled until the
+    # underlying FFI connection-creation race is fixed upstream. See PR #113.
+    WRONG_CREDENTIALS_HANG_SKIP =
+      "Disabled: wrong-credentials connect (AuthenticationFailed) intermittently hangs " \
+      "the native connection-creation path and wedges the suite. See PR #113."
+
     # =========================================================
     # Default user -- connect-time
     # =========================================================
@@ -27,6 +36,7 @@ module ValkeyTests
 
     # should refuse to connect when the default-user password is wrong
     def test_connect_with_wrong_password_raises
+      skip(WRONG_CREDENTIALS_HANG_SKIP)
       with_default_user_password do |_user, _password|
         error = assert_raises(::Valkey::CannotConnectError) do
           _new_client(password: "wrongpass", connect_timeout: 1.0, reconnect_attempts: 0)
@@ -79,6 +89,7 @@ module ValkeyTests
     # should refuse to connect when the ACL user's password is wrong
     def test_connect_with_acl_user_wrong_password_raises
       skip("ACL auth tests only run on standalone mode") if cluster_mode?
+      skip(WRONG_CREDENTIALS_HANG_SKIP)
       with_acl do |username, _password|
         error = assert_raises(::Valkey::CannotConnectError) do
           _new_client(username: username, password: "wrong",
@@ -91,6 +102,7 @@ module ValkeyTests
     # should refuse to connect when the username does not exist
     def test_connect_with_acl_user_unknown_username_raises
       skip("ACL auth tests only run on standalone mode") if cluster_mode?
+      skip(WRONG_CREDENTIALS_HANG_SKIP)
       with_acl do |_username, password|
         error = assert_raises(::Valkey::CannotConnectError) do
           _new_client(username: "nobody", password: password,

--- a/test/valkey/auth_commands_test.rb
+++ b/test/valkey/auth_commands_test.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+# Behavioral authentication tests for valkey-glide-ruby.
+#
+# Unlike uri_connection_test.rb (which connects to a no-auth server and rescues
+# away every failure), these tests actually toggle auth at runtime via the
+# Helper::Generic `with_default_user_password` / `with_acl` block helpers and
+# assert the concrete success/failure behavior.
+#
+# Note:
+# - Credentials are created and torn down per-test.
+# - ACL rules are defined per node th inside the block helpers.
+module ValkeyTests
+  module AuthCommands
+    # =========================================================
+    # Default user -- connect-time
+    # =========================================================
+
+    # should connect and respond to PING when given the correct default-user password
+    def test_connect_with_correct_password_succeeds
+      with_default_user_password do |_user, password|
+        client = _new_client(password: password)
+        assert_equal "PONG", client.ping
+        client.close
+      end
+    end
+
+    # should refuse to connect when the default-user password is wrong
+    def test_connect_with_wrong_password_raises
+      with_default_user_password do |_user, _password|
+        error = assert_raises(::Valkey::CannotConnectError) do
+          _new_client(password: "wrongpass", connect_timeout: 1.0, reconnect_attempts: 0)
+        end
+        # glide-core surfaces a wrong password at connect-time as
+        # "Password authentication failed- AuthenticationFailed" (not the raw
+        # server WRONGPASS, which only appears via the runtime AUTH command).
+        assert_includes error.message, "AuthenticationFailed"
+      end
+    end
+
+    # should refuse to connect when no credentials are supplied to a password-protected server
+    def test_connect_without_password_raises
+      with_default_user_password do |_user, _password|
+        error = assert_raises(::Valkey::CannotConnectError) do
+          _new_client(connect_timeout: 1.0, reconnect_attempts: 0)
+        end
+        assert_includes error.message, "NOAUTH"
+      end
+    end
+
+    # should refuse to connect when given an empty password against a password-protected server
+    def test_connect_with_empty_password_against_auth_server_raises
+      with_default_user_password do |_user, _password|
+        error = assert_raises(::Valkey::CannotConnectError) do
+          _new_client(password: "", connect_timeout: 1.0, reconnect_attempts: 0)
+        end
+        # An empty password is currently treated as "no credentials", so the
+        # server returns NOAUTH (same as the missing-password case). This
+        # empty-vs-missing behavior is implementation-defined and could change.
+        assert_includes error.message, "NOAUTH"
+      end
+    end
+
+    # =========================================================
+    # ACL user -- connect-time (skipped in cluster mode)
+    # =========================================================
+
+    # should connect and respond to PING when given valid ACL user credentials
+    def test_connect_with_acl_user_credentials_succeeds
+      skip("ACL auth tests only run on standalone mode") if cluster_mode?
+      with_acl do |username, password|
+        # Built directly, not via init: johndoe lacks +flushdb.
+        client = _new_client(username: username, password: password)
+        assert_equal "PONG", client.ping
+        client.close
+      end
+    end
+
+    # should refuse to connect when the ACL user's password is wrong
+    def test_connect_with_acl_user_wrong_password_raises
+      skip("ACL auth tests only run on standalone mode") if cluster_mode?
+      with_acl do |username, _password|
+        error = assert_raises(::Valkey::CannotConnectError) do
+          _new_client(username: username, password: "wrong",
+                      connect_timeout: 1.0, reconnect_attempts: 0)
+        end
+        assert_includes error.message, "AuthenticationFailed"
+      end
+    end
+
+    # should refuse to connect when the username does not exist
+    def test_connect_with_acl_user_unknown_username_raises
+      skip("ACL auth tests only run on standalone mode") if cluster_mode?
+      with_acl do |_username, password|
+        error = assert_raises(::Valkey::CannotConnectError) do
+          _new_client(username: "nobody", password: password,
+                      connect_timeout: 1.0, reconnect_attempts: 0)
+        end
+        # An unknown username surfaces the same connect-time auth failure as a
+        # wrong password (the server does not distinguish the two to clients).
+        assert_includes error.message, "AuthenticationFailed"
+      end
+    end
+
+    # should raise when an ACL user runs a command outside its permissions
+    # The FFI maps the permission error to Valkey::CommandError. glide-core
+    # translates the server's NOPERM into a "PermissionDenied" message, so we
+    # assert the class and that distinctive token.
+    def test_acl_user_disallowed_command_raises
+      skip("ACL auth tests only run on standalone mode") if cluster_mode?
+      with_acl do |username, password|
+        # Built directly, not via init: johndoe lacks +flushdb (and +set).
+        client = _new_client(username: username, password: password)
+        begin
+          error = assert_raises(::Valkey::CommandError) do
+            client.set("k", "v")
+          end
+          assert_includes error.message, "PermissionDenied"
+        ensure
+          client.close
+        end
+      end
+    end
+
+    # should return OK when AUTH is called with the correct password
+    def test_auth_command_with_correct_password
+      with_default_user_password do |_user, password|
+        client = _new_client(password: password)
+        assert_equal "OK", client.auth(password)
+        client.close
+      end
+    end
+
+    # should raise when AUTH is called with the wrong password
+    def test_auth_command_with_wrong_password_raises
+      with_default_user_password do |_user, password|
+        client = _new_client(password: password)
+        begin
+          error = assert_raises(::Valkey::CommandError) do
+            client.auth("wrongpass")
+          end
+          # The runtime AUTH command surfaces the raw server WRONGPASS reply
+          # (unlike connect-time failures, which report AuthenticationFailed).
+          assert_includes error.message, "WRONGPASS"
+        ensure
+          client.close
+        end
+      end
+    end
+
+    # should return OK when AUTH is called with a valid username and password
+    def test_auth_command_with_username_and_password
+      skip("ACL auth tests only run on standalone mode") if cluster_mode?
+      with_acl do |username, password|
+        client = _new_client(username: username, password: password)
+        begin
+          # This switches the live connection to the limited johndoe user;
+          # don't run privileged commands on this client afterward.
+          assert_equal "OK", client.auth(username, password)
+        ensure
+          client.close
+        end
+      end
+    end
+  end
+end

--- a/test/valkey/connection_lifecycle_test.rb
+++ b/test/valkey/connection_lifecycle_test.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+# Connection-lifecycle tests: behavior on close and on connection timeout.
+#
+# Mirrors the sibling GLIDE clients:
+#   - test 4 (closed client): go/integTest/standalone_commands_test.go ->
+#     TestPing_ClosedClient; python .../test_async_client.py ->
+#     test_closed_client_raises_error (asserts "the client is closed")
+#   - test 5 (recreation): python -> test_client_recreation_after_close
+#   - test 6 (unavailable host): python -> test_connection_timeout_on_unavailable_host
+#   - test 7 (blocked server): node/tests/GlideClient.test.ts:1279
+#     "should handle connection timeout when client is blocked by long-running command";
+#     python -> test_connection_timeout_when_client_is_blocked
+#
+# All are standalone-shaped and skipped in cluster mode.
+module ValkeyTests
+  module ConnectionLifecycle
+    # =================================================================
+    # Test 4 — command on a closed client
+    # =================================================================
+
+    # should raise a connection error stating the client is closed when a
+    # command is issued after close
+    def test_closed_client_raises_error
+      skip("connection lifecycle tests only run on standalone mode") if cluster_mode?
+
+      client = _new_client
+      client.close
+
+      error = assert_raises(Valkey::ConnectionError) { client.set("foo", "bar") }
+      assert_match(/the client is closed/, error.message)
+    end
+
+    # =================================================================
+    # Test 5 — client recreation after close
+    # =================================================================
+
+    # should let a new client connect and round-trip set/get after a previous
+    # client was closed (the shared FFI pipe stays valid across lifecycles)
+    def test_client_recreation_after_close
+      skip("connection lifecycle tests only run on standalone mode") if cluster_mode?
+
+      key = "lifecycle:recreate"
+
+      client1 = _new_client
+      assert_equal "OK", client1.set(key, "v1")
+      assert_equal "v1", client1.get(key)
+      client1.close
+
+      client2 = _new_client
+      assert_equal "OK", client2.set(key, "v2")
+      assert_equal "v2", client2.get(key)
+      client2.del(key)
+      client2.close
+    end
+
+    # =================================================================
+    # Test 6 — connection timeout on an unavailable host
+    # =================================================================
+
+    # should fail fast (within ~2.5x the connect timeout) instead of hanging
+    # when connecting to an unreachable host
+    def test_connection_timeout_on_unavailable_host
+      skip("connection lifecycle tests only run on standalone mode") if cluster_mode?
+
+      connect_timeout = 1.0
+      # 192.0.2.1 is TEST-NET-1 (RFC 5737), reserved and unroutable, so the
+      # connect attempt hangs until the timeout rather than being refused or
+      # incurring DNS delay.
+      started = monotonic_now
+      assert_raises(Valkey::CannotConnectError) do
+        ::Valkey.new(
+          host: "192.0.2.1",
+          port: 6379,
+          connect_timeout: connect_timeout,
+          reconnect_attempts: 0
+        )
+      end
+      elapsed = monotonic_now - started
+
+      max_allowed = connect_timeout * 2.5
+      assert elapsed < max_allowed,
+             "connect took #{elapsed.round(2)}s, expected < #{max_allowed}s " \
+             "(connect_timeout not being respected)"
+    end
+
+    # =================================================================
+    # Test 7 — connection timeout while the server is blocked
+    # =================================================================
+
+    # should reject a new connection with a small connect timeout while the
+    # server is blocked by a long-running command, yet allow one with a
+    # generous timeout
+    def test_connection_timeout_when_server_is_blocked
+      skip("connection lifecycle tests only run on standalone mode") if cluster_mode?
+      skip("DEBUG SLEEP is not enabled on this server") unless debug_sleep_available?
+
+      blocker = _new_client
+      sleep_seconds = 3
+      blocker_thread = Thread.new do
+        # DEBUG SLEEP blocks the (single-threaded) server for the full duration
+        # even if this client's request times out first; the FFI command call
+        # releases the GVL, so the main thread keeps running.
+        blocker.send_command(Valkey::RequestType::CUSTOM_COMMAND, ["DEBUG", "SLEEP", sleep_seconds.to_s])
+      rescue Valkey::BaseError
+        nil # the assertions below are what matter
+      end
+
+      # Give the server a moment to enter the blocked state.
+      sleep(0.5)
+
+      # A short connection timeout must fail while the server is blocked.
+      assert_raises(Valkey::CannotConnectError) do
+        _new_client(connect_timeout: 0.1, reconnect_attempts: 0)
+      end
+
+      # A generous connection timeout should still connect once the block clears.
+      patient = _new_client(connect_timeout: 10.0)
+      assert_equal "PONG", patient.ping
+      patient.close
+    ensure
+      blocker_thread&.join
+      blocker&.close
+    end
+
+    private
+
+    def monotonic_now
+      Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    end
+
+    # Probes whether DEBUG SLEEP is permitted on the server (it requires
+    # enable-debug-command). Uses the shared client and a zero-length sleep.
+    def debug_sleep_available?
+      r.send_command(Valkey::RequestType::CUSTOM_COMMAND, ["DEBUG", "SLEEP", "0"])
+      true
+    rescue Valkey::CommandError
+      false
+    end
+  end
+end

--- a/test/valkey/connection_lifecycle_test.rb
+++ b/test/valkey/connection_lifecycle_test.rb
@@ -50,7 +50,6 @@ module ValkeyTests
     # when connecting to an unreachable host
     def test_connection_timeout_on_unavailable_host
       skip("connection lifecycle tests only run on standalone mode") if cluster_mode?
-      skip("connect_timeout not enforced by the native sync client for an unreachable host; hangs CI (see PR #114)")
 
       connect_timeout = 1.0
       # 192.0.2.1 is TEST-NET-1 (RFC 5737), reserved and unroutable, so the
@@ -62,7 +61,7 @@ module ValkeyTests
           host: "192.0.2.1",
           port: 6379,
           connect_timeout: connect_timeout,
-          reconnect_attempts: 1
+          reconnect_attempts: 1 # Should be zero however issue #117 blocks this.
         )
       end
       elapsed = monotonic_now - started
@@ -96,7 +95,7 @@ module ValkeyTests
 
       # A short connection timeout must fail while the server is blocked.
       assert_raises(Valkey::CannotConnectError) do
-        _new_client(connect_timeout: 0.1, reconnect_attempts: 1)
+        _new_client(connect_timeout: 0.1, reconnect_attempts: 1) # Should be zero however issue #117 blocks this.
       end
 
       # A generous connection timeout should still connect once the block clears.

--- a/test/valkey/connection_lifecycle_test.rb
+++ b/test/valkey/connection_lifecycle_test.rb
@@ -15,10 +15,6 @@
 # All are standalone-shaped and skipped in cluster mode.
 module ValkeyTests
   module ConnectionLifecycle
-    # =================================================================
-    # Test 4 — command on a closed client
-    # =================================================================
-
     # should raise a connection error stating the client is closed when a
     # command is issued after close
     def test_closed_client_raises_error
@@ -30,10 +26,6 @@ module ValkeyTests
       error = assert_raises(Valkey::ConnectionError) { client.set("foo", "bar") }
       assert_match(/the client is closed/, error.message)
     end
-
-    # =================================================================
-    # Test 5 — client recreation after close
-    # =================================================================
 
     # should let a new client connect and round-trip set/get after a previous
     # client was closed (the shared FFI pipe stays valid across lifecycles)
@@ -53,10 +45,6 @@ module ValkeyTests
       client2.del(key)
       client2.close
     end
-
-    # =================================================================
-    # Test 6 — connection timeout on an unavailable host
-    # =================================================================
 
     # should fail fast (within ~2.5x the connect timeout) instead of hanging
     # when connecting to an unreachable host
@@ -91,10 +79,6 @@ module ValkeyTests
              "connect took #{elapsed.round(2)}s, expected < #{max_allowed}s " \
              "(connect_timeout not being respected)"
     end
-
-    # =================================================================
-    # Test 7 — connection timeout while the server is blocked
-    # =================================================================
 
     # should reject a new connection with a small connect timeout while the
     # server is blocked by a long-running command, yet allow one with a

--- a/test/valkey/connection_lifecycle_test.rb
+++ b/test/valkey/connection_lifecycle_test.rb
@@ -50,13 +50,6 @@ module ValkeyTests
     # when connecting to an unreachable host
     def test_connection_timeout_on_unavailable_host
       skip("connection lifecycle tests only run on standalone mode") if cluster_mode?
-      # DISABLED: the synchronous FFI connect path (create_client_from_uri) does
-      # not honor connection_timeout when the host is unreachable, so Valkey.new
-      # never returns and hangs the entire standalone suite (30-min CI cap on
-      # every matrix cell). The Ruby side forwards connection_timeout and
-      # reconnect_attempts: 0 correctly; the gap is in glide-core's sync client
-      # (the async Python/Node clients this test mirrors do enforce it).
-      # Re-enable once the native fix lands. See PR #114.
       skip("connect_timeout not enforced by the native sync client for an unreachable host; hangs CI (see PR #114)")
 
       connect_timeout = 1.0
@@ -69,7 +62,7 @@ module ValkeyTests
           host: "192.0.2.1",
           port: 6379,
           connect_timeout: connect_timeout,
-          reconnect_attempts: 0
+          reconnect_attempts: 1
         )
       end
       elapsed = monotonic_now - started
@@ -103,7 +96,7 @@ module ValkeyTests
 
       # A short connection timeout must fail while the server is blocked.
       assert_raises(Valkey::CannotConnectError) do
-        _new_client(connect_timeout: 0.1, reconnect_attempts: 0)
+        _new_client(connect_timeout: 0.1, reconnect_attempts: 1)
       end
 
       # A generous connection timeout should still connect once the block clears.

--- a/test/valkey/connection_lifecycle_test.rb
+++ b/test/valkey/connection_lifecycle_test.rb
@@ -62,6 +62,14 @@ module ValkeyTests
     # when connecting to an unreachable host
     def test_connection_timeout_on_unavailable_host
       skip("connection lifecycle tests only run on standalone mode") if cluster_mode?
+      # DISABLED: the synchronous FFI connect path (create_client_from_uri) does
+      # not honor connection_timeout when the host is unreachable, so Valkey.new
+      # never returns and hangs the entire standalone suite (30-min CI cap on
+      # every matrix cell). The Ruby side forwards connection_timeout and
+      # reconnect_attempts: 0 correctly; the gap is in glide-core's sync client
+      # (the async Python/Node clients this test mirrors do enforce it).
+      # Re-enable once the native fix lands. See PR #114.
+      skip("connect_timeout not enforced by the native sync client for an unreachable host; hangs CI (see PR #114)")
 
       connect_timeout = 1.0
       # 192.0.2.1 is TEST-NET-1 (RFC 5737), reserved and unroutable, so the
@@ -132,7 +140,7 @@ module ValkeyTests
     # Probes whether DEBUG SLEEP is permitted on the server (it requires
     # enable-debug-command). Uses the shared client and a zero-length sleep.
     def debug_sleep_available?
-      r.send_command(Valkey::RequestType::CUSTOM_COMMAND, ["DEBUG", "SLEEP", "0"])
+      r.send_command(Valkey::RequestType::CUSTOM_COMMAND, %w[DEBUG SLEEP 0])
       true
     rescue Valkey::CommandError
       false

--- a/test/valkey/failover_commands_test.rb
+++ b/test/valkey/failover_commands_test.rb
@@ -14,6 +14,8 @@ module ValkeyTests
     # should return "OK" and flip the connected primary's role to slave once
     # the coordinated failover to its replica completes.
     def test_failover_promotes_replica_and_returns_ok
+      skip("This sometimes hang. Unsure if it is a client bug. See https://github.com/valkey-io/valkey-glide-ruby/issues/117")
+
       with_standalone_replica do |primary|
         Timeout.timeout(FAILOVER_TEST_DEADLINE) do
           assert_equal "master", primary.info("replication")["role"]

--- a/test/valkey/failover_commands_test.rb
+++ b/test/valkey/failover_commands_test.rb
@@ -14,8 +14,6 @@ module ValkeyTests
     # should return "OK" and flip the connected primary's role to slave once
     # the coordinated failover to its replica completes.
     def test_failover_promotes_replica_and_returns_ok
-      skip("This sometimes hang. Unsure if it is a client bug. See https://github.com/valkey-io/valkey-glide-ruby/issues/117")
-
       with_standalone_replica do |primary|
         Timeout.timeout(FAILOVER_TEST_DEADLINE) do
           assert_equal "master", primary.info("replication")["role"]

--- a/test/valkey/failover_commands_test.rb
+++ b/test/valkey/failover_commands_test.rb
@@ -28,7 +28,7 @@ module ValkeyTests
       assert_equal ["ABORT"], capture_failover_args(abort: true, timeout: 5000)
     end
 
-    # should not emit "FORCE" unless a TO target is supplied
+    # should not send "FORCE" unless a TO target is supplied
     def test_failover_force_without_target_omits_force
       assert_equal [], capture_failover_args(force: true)
     end

--- a/test/valkey/failover_commands_test.rb
+++ b/test/valkey/failover_commands_test.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+# Integration test for the standalone FAILOVER command.
+# NOTE: FAILOVER is a standalone-only command.
+module ValkeyTests
+  module FailoverCommands
+    # should return "OK" and flip the connected primary's role to slave once
+    # the coordinated failover to its replica completes
+    def test_failover_promotes_replica_and_returns_ok
+      with_standalone_replica do |primary|
+        assert_equal "master", primary.info("replication")["role"]
+
+        assert_equal "OK", primary.failover
+
+        assert wait_for_role?(primary, "slave"),
+               "timed out waiting for the primary to become a replica (role:slave)"
+      end
+    end
+
+    # should raise a error when ABORT is requested but no failover is
+    # currently in progress
+    def test_failover_abort_with_no_failover_in_progress_raises
+      assert_raises(Valkey::CommandError) { r.failover(abort: true) }
+    end
+
+    # should send "ABORT" only
+    def test_failover_abort_sends_abort_only
+      assert_equal ["ABORT"], capture_failover_args(abort: true, timeout: 5000)
+    end
+
+    # should not emit "FORCE" unless a TO target is supplied
+    def test_failover_force_without_target_omits_force
+      assert_equal [], capture_failover_args(force: true)
+    end
+
+    # should build "TO host port FORCE TIMEOUT ms" in order for a full request
+    def test_failover_builds_full_arg_list_in_order
+      args = capture_failover_args(to: "127.0.0.1 6380", force: true, timeout: 5000)
+      assert_equal ["TO", "127.0.0.1", "6380", "FORCE", "TIMEOUT", "5000"], args
+    end
+
+    private
+
+    # Replace the send_command method used by failover() with a stub which captures the arguments and returns "OK".
+    # This allows us to see the arguments passed to the failover command without actually executing it.
+    def capture_failover_args(**options)
+      captured = nil
+      stub = lambda do |_request_type, args = [], &_block|
+        captured = args
+        "OK"
+      end
+      r.stub(:send_command, stub) { r.failover(**options) }
+      captured
+    end
+
+    # Start a standalone primary with one replica and yields a
+    # client connected to the primary. Cleans up afterward.
+    def with_standalone_replica
+      cluster = Valkey::TestCluster.new(
+        cluster_mode: false,
+        shard_count: 1,
+        replica_count: 1
+      )
+      primary_addr = cluster.addresses.first
+      client = Valkey.new(host: primary_addr[:host], port: primary_addr[:port], timeout: 5.0)
+      yield(client)
+    rescue Valkey::TestCluster::PythonNotFoundError, Valkey::TestCluster::ScriptNotFoundError => e
+      skip("requires python3 + valkey-glide submodule for replica setup: #{e.message}")
+    ensure
+      client&.close
+      cluster&.close
+    end
+
+    # Polls INFO REPLICATION until role matches (or times out).
+    def wait_for_role?(client, role, attempts: 60, interval: 0.5)
+      attempts.times do
+        return true if client.info("replication")["role"] == role
+
+        sleep(interval)
+      end
+      false
+    end
+  end
+end

--- a/test/valkey/failover_commands_test.rb
+++ b/test/valkey/failover_commands_test.rb
@@ -1,20 +1,35 @@
 # frozen_string_literal: true
 
+require "timeout"
+
 # Integration test for the standalone FAILOVER command.
 # NOTE: FAILOVER is a standalone-only command.
 module ValkeyTests
   module FailoverCommands
+    FAILOVER_TIMEOUT_MS = 10_000
+
+    # Wall-clock backstop, above the wait_for_role? budget (60 * 0.5s = 30s).
+    FAILOVER_TEST_DEADLINE = 45
+
     # should return "OK" and flip the connected primary's role to slave once
-    # the coordinated failover to its replica completes
+    # the coordinated failover to its replica completes.
     def test_failover_promotes_replica_and_returns_ok
       with_standalone_replica do |primary|
-        assert_equal "master", primary.info("replication")["role"]
+        Timeout.timeout(FAILOVER_TEST_DEADLINE) do
+          assert_equal "master", primary.info("replication")["role"]
 
-        assert_equal "OK", primary.failover
+          # FAILOVER's TIMEOUT bounds the wait server-side; without it the wait is
+          # "infinite" and the blocking command never returns. See
+          # https://valkey.io/commands/failover/
+          assert_equal "OK", primary.failover(timeout: FAILOVER_TIMEOUT_MS)
 
-        assert wait_for_role?(primary, "slave"),
-               "timed out waiting for the primary to become a replica (role:slave)"
+          assert wait_for_role?(primary, "slave"),
+                 "timed out waiting for the primary to become a replica (role:slave)"
+        end
       end
+    rescue Timeout::Error
+      flunk("failover did not complete within #{FAILOVER_TEST_DEADLINE}s " \
+            "(client likely hanged during the role transition)")
     end
 
     # should raise a error when ABORT is requested but no failover is

--- a/test/valkey/ft_aggregate_options_test.rb
+++ b/test/valkey/ft_aggregate_options_test.rb
@@ -1,0 +1,231 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestFtAggregateOptions < Minitest::Test
+  # --- Reducer ---
+
+  def test_reducer_count
+    r = Valkey::Search::Reducer.new("COUNT", [], name: "count")
+    assert_equal ["REDUCE", "COUNT", "0", "AS", "count"], r.to_args
+  end
+
+  def test_reducer_sum
+    r = Valkey::Search::Reducer.new("SUM", ["@price"], name: "total")
+    assert_equal ["REDUCE", "SUM", "1", "@price", "AS", "total"], r.to_args
+  end
+
+  def test_reducer_avg
+    r = Valkey::Search::Reducer.new("AVG", ["@score"], name: "avg_score")
+    assert_equal ["REDUCE", "AVG", "1", "@score", "AS", "avg_score"], r.to_args
+  end
+
+  def test_reducer_min_max
+    r = Valkey::Search::Reducer.new("MIN", ["@price"], name: "cheapest")
+    assert_equal ["REDUCE", "MIN", "1", "@price", "AS", "cheapest"], r.to_args
+  end
+
+  def test_reducer_no_name
+    r = Valkey::Search::Reducer.new("COUNT", [])
+    assert_equal ["REDUCE", "COUNT", "0"], r.to_args
+  end
+
+  # --- GroupBy ---
+
+  def test_groupby_single_property
+    gb = Valkey::Search::GroupBy.new(["@category"])
+    assert_equal ["GROUPBY", "1", "@category"], gb.to_args
+  end
+
+  def test_groupby_multiple_properties
+    gb = Valkey::Search::GroupBy.new(["@category", "@brand"])
+    assert_equal ["GROUPBY", "2", "@category", "@brand"], gb.to_args
+  end
+
+  def test_groupby_with_reducers
+    gb = Valkey::Search::GroupBy.new(["@category"],
+                                    reducers: [
+                                      Valkey::Search::Reducer.new("COUNT", [], name: "count"),
+                                      Valkey::Search::Reducer.new("SUM", ["@price"], name: "total")
+                                    ])
+    expected = ["GROUPBY", "1", "@category",
+                "REDUCE", "COUNT", "0", "AS", "count",
+                "REDUCE", "SUM", "1", "@price", "AS", "total"]
+    assert_equal expected, gb.to_args
+  end
+
+  # --- SortProperty ---
+
+  def test_sort_property_asc
+    sp = Valkey::Search::SortProperty.new("@price", :asc)
+    assert_equal ["@price", "ASC"], sp.to_args
+  end
+
+  def test_sort_property_desc
+    sp = Valkey::Search::SortProperty.new("@price", :desc)
+    assert_equal ["@price", "DESC"], sp.to_args
+  end
+
+  # --- SortBy ---
+
+  def test_sortby_single
+    sb = Valkey::Search::SortBy.new([Valkey::Search::SortProperty.new("@price", :asc)])
+    assert_equal ["SORTBY", "2", "@price", "ASC"], sb.to_args
+  end
+
+  def test_sortby_multiple
+    sb = Valkey::Search::SortBy.new([
+                                      Valkey::Search::SortProperty.new("@category", :asc),
+                                      Valkey::Search::SortProperty.new("@price", :desc)
+                                    ])
+    assert_equal ["SORTBY", "4", "@category", "ASC", "@price", "DESC"], sb.to_args
+  end
+
+  def test_sortby_with_max
+    sb = Valkey::Search::SortBy.new(
+      [Valkey::Search::SortProperty.new("@price", :asc)], max: 10
+    )
+    assert_equal ["SORTBY", "2", "@price", "ASC", "MAX", "10"], sb.to_args
+  end
+
+  # --- Apply ---
+
+  def test_apply
+    a = Valkey::Search::Apply.new("@price * 1.1", name: "price_with_tax")
+    assert_equal ["APPLY", "@price * 1.1", "AS", "price_with_tax"], a.to_args
+  end
+
+  # --- Filter ---
+
+  def test_filter
+    f = Valkey::Search::Filter.new("@count > 5")
+    assert_equal ["FILTER", "@count > 5"], f.to_args
+  end
+
+  # --- AggregateLimit ---
+
+  def test_aggregate_limit
+    l = Valkey::Search::AggregateLimit.new(offset: 0, count: 10)
+    assert_equal ["LIMIT", "0", "10"], l.to_args
+  end
+
+  def test_aggregate_limit_with_offset
+    l = Valkey::Search::AggregateLimit.new(offset: 20, count: 5)
+    assert_equal ["LIMIT", "20", "5"], l.to_args
+  end
+
+  # --- FtAggregateOptions ---
+
+  def test_empty_options
+    opts = Valkey::Search::FtAggregateOptions.new
+    assert_equal [], opts.to_args
+  end
+
+  def test_verbatim
+    opts = Valkey::Search::FtAggregateOptions.new(verbatim: true)
+    assert_equal ["VERBATIM"], opts.to_args
+  end
+
+  def test_inorder
+    opts = Valkey::Search::FtAggregateOptions.new(inorder: true)
+    assert_equal ["INORDER"], opts.to_args
+  end
+
+  def test_slop
+    opts = Valkey::Search::FtAggregateOptions.new(slop: 3)
+    assert_equal ["SLOP", "3"], opts.to_args
+  end
+
+  def test_load_all
+    opts = Valkey::Search::FtAggregateOptions.new(load_all: true)
+    assert_equal ["LOAD", "*"], opts.to_args
+  end
+
+  def test_load_fields
+    opts = Valkey::Search::FtAggregateOptions.new(load_fields: ["@price", "@title"])
+    assert_equal ["LOAD", "2", "@price", "@title"], opts.to_args
+  end
+
+  def test_timeout
+    opts = Valkey::Search::FtAggregateOptions.new(timeout: 5000)
+    assert_equal ["TIMEOUT", "5000"], opts.to_args
+  end
+
+  def test_params
+    opts = Valkey::Search::FtAggregateOptions.new(params: { "threshold" => "100" })
+    assert_equal ["PARAMS", "2", "threshold", "100"], opts.to_args
+  end
+
+  def test_dialect
+    opts = Valkey::Search::FtAggregateOptions.new(dialect: 2)
+    assert_equal ["DIALECT", "2"], opts.to_args
+  end
+
+  def test_clauses_groupby
+    opts = Valkey::Search::FtAggregateOptions.new(
+      clauses: [
+        Valkey::Search::GroupBy.new(["@category"],
+                                   reducers: [Valkey::Search::Reducer.new("COUNT", [], name: "count")])
+      ]
+    )
+    expected = ["GROUPBY", "1", "@category", "REDUCE", "COUNT", "0", "AS", "count"]
+    assert_equal expected, opts.to_args
+  end
+
+  def test_clauses_pipeline
+    opts = Valkey::Search::FtAggregateOptions.new(
+      clauses: [
+        Valkey::Search::GroupBy.new(["@category"],
+                                   reducers: [Valkey::Search::Reducer.new("COUNT", [], name: "count")]),
+        Valkey::Search::SortBy.new([Valkey::Search::SortProperty.new("@count", :desc)]),
+        Valkey::Search::AggregateLimit.new(offset: 0, count: 5)
+      ]
+    )
+    expected = [
+      "GROUPBY", "1", "@category", "REDUCE", "COUNT", "0", "AS", "count",
+      "SORTBY", "2", "@count", "DESC",
+      "LIMIT", "0", "5"
+    ]
+    assert_equal expected, opts.to_args
+  end
+
+  def test_combined_full
+    opts = Valkey::Search::FtAggregateOptions.new(
+      verbatim: true,
+      load_fields: ["@price"],
+      timeout: 3000,
+      params: { "min" => "10" },
+      clauses: [
+        Valkey::Search::Filter.new("@price > 10"),
+        Valkey::Search::GroupBy.new(["@category"],
+                                   reducers: [Valkey::Search::Reducer.new("SUM", ["@price"], name: "total")]),
+        Valkey::Search::Apply.new("@total * 0.9", name: "discounted"),
+        Valkey::Search::SortBy.new([Valkey::Search::SortProperty.new("@discounted", :desc)], max: 3)
+      ],
+      dialect: 2
+    )
+    expected = [
+      "VERBATIM",
+      "LOAD", "1", "@price",
+      "TIMEOUT", "3000",
+      "PARAMS", "2", "min", "10",
+      "FILTER", "@price > 10",
+      "GROUPBY", "1", "@category", "REDUCE", "SUM", "1", "@price", "AS", "total",
+      "APPLY", "@total * 0.9", "AS", "discounted",
+      "SORTBY", "2", "@discounted", "DESC", "MAX", "3",
+      "DIALECT", "2"
+    ]
+    assert_equal expected, opts.to_args
+  end
+
+  def test_ordering_load_before_clauses
+    opts = Valkey::Search::FtAggregateOptions.new(
+      load_fields: ["@x"],
+      clauses: [Valkey::Search::Filter.new("@x > 0")],
+      dialect: 2
+    )
+    args = opts.to_args
+    assert args.index("LOAD") < args.index("FILTER")
+    assert args.index("FILTER") < args.index("DIALECT")
+  end
+end

--- a/test/valkey/ft_create_options_test.rb
+++ b/test/valkey/ft_create_options_test.rb
@@ -1,0 +1,174 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestFtCreateOptions < Minitest::Test
+  def test_empty_options
+    opts = Valkey::Search::FtCreateOptions.new
+    assert_equal [], opts.to_args
+  end
+
+  def test_data_type_hash
+    opts = Valkey::Search::FtCreateOptions.new(data_type: :hash)
+    assert_equal ["ON", "HASH"], opts.to_args
+  end
+
+  def test_data_type_json
+    opts = Valkey::Search::FtCreateOptions.new(data_type: :json)
+    assert_equal ["ON", "JSON"], opts.to_args
+  end
+
+  def test_data_type_string_input
+    opts = Valkey::Search::FtCreateOptions.new(data_type: "hash")
+    assert_equal ["ON", "HASH"], opts.to_args
+  end
+
+  def test_single_prefix
+    opts = Valkey::Search::FtCreateOptions.new(prefixes: ["doc:"])
+    assert_equal ["PREFIX", "1", "doc:"], opts.to_args
+  end
+
+  def test_multiple_prefixes
+    opts = Valkey::Search::FtCreateOptions.new(prefixes: ["item:", "product:"])
+    assert_equal ["PREFIX", "2", "item:", "product:"], opts.to_args
+  end
+
+  def test_filter
+    opts = Valkey::Search::FtCreateOptions.new(filter: "@status!='archived'")
+    assert_equal ["FILTER", "@status!='archived'"], opts.to_args
+  end
+
+  def test_default_language
+    opts = Valkey::Search::FtCreateOptions.new(default_language: "spanish")
+    assert_equal ["LANGUAGE", "spanish"], opts.to_args
+  end
+
+  def test_language_field
+    opts = Valkey::Search::FtCreateOptions.new(language_field: "lang")
+    assert_equal ["LANGUAGE_FIELD", "lang"], opts.to_args
+  end
+
+  def test_default_score
+    opts = Valkey::Search::FtCreateOptions.new(default_score: 0.5)
+    assert_equal ["SCORE", "0.5"], opts.to_args
+  end
+
+  def test_score_field
+    opts = Valkey::Search::FtCreateOptions.new(score_field: "priority")
+    assert_equal ["SCORE_FIELD", "priority"], opts.to_args
+  end
+
+  def test_max_text_fields
+    opts = Valkey::Search::FtCreateOptions.new(max_text_fields: true)
+    assert_equal ["MAXTEXTFIELDS"], opts.to_args
+  end
+
+  def test_no_offsets
+    opts = Valkey::Search::FtCreateOptions.new(no_offsets: true)
+    assert_equal ["NOOFFSETS"], opts.to_args
+  end
+
+  def test_temporary
+    opts = Valkey::Search::FtCreateOptions.new(temporary: 3600)
+    assert_equal ["TEMPORARY", "3600"], opts.to_args
+  end
+
+  def test_no_highlight
+    opts = Valkey::Search::FtCreateOptions.new(no_highlight: true)
+    assert_equal ["NOHL"], opts.to_args
+  end
+
+  def test_no_fields
+    opts = Valkey::Search::FtCreateOptions.new(no_fields: true)
+    assert_equal ["NOFIELDS"], opts.to_args
+  end
+
+  def test_no_freqs
+    opts = Valkey::Search::FtCreateOptions.new(no_freqs: true)
+    assert_equal ["NOFREQS"], opts.to_args
+  end
+
+  def test_stopwords
+    opts = Valkey::Search::FtCreateOptions.new(stopwords: ["the", "a", "is"])
+    assert_equal ["STOPWORDS", "3", "the", "a", "is"], opts.to_args
+  end
+
+  def test_stopwords_empty_disables
+    opts = Valkey::Search::FtCreateOptions.new(stopwords: [])
+    assert_equal ["STOPWORDS", "0"], opts.to_args
+  end
+
+  def test_skip_initial_scan
+    opts = Valkey::Search::FtCreateOptions.new(skip_initial_scan: true)
+    assert_equal ["SKIPINITIALSCAN"], opts.to_args
+  end
+
+  def test_combined_typical
+    opts = Valkey::Search::FtCreateOptions.new(
+      data_type: :hash,
+      prefixes: ["product:"],
+      default_language: "english"
+    )
+    expected = ["ON", "HASH", "PREFIX", "1", "product:", "LANGUAGE", "english"]
+    assert_equal expected, opts.to_args
+  end
+
+  def test_combined_full
+    opts = Valkey::Search::FtCreateOptions.new(
+      data_type: :json,
+      prefixes: ["item:", "doc:"],
+      filter: "@active==true",
+      default_language: "french",
+      language_field: "lang",
+      default_score: 0.8,
+      score_field: "priority",
+      max_text_fields: true,
+      no_offsets: true,
+      temporary: 7200,
+      no_highlight: true,
+      no_fields: true,
+      no_freqs: true,
+      stopwords: ["le", "la"],
+      skip_initial_scan: true
+    )
+    expected = [
+      "ON", "JSON",
+      "PREFIX", "2", "item:", "doc:",
+      "FILTER", "@active==true",
+      "LANGUAGE", "french",
+      "LANGUAGE_FIELD", "lang",
+      "SCORE", "0.8",
+      "SCORE_FIELD", "priority",
+      "MAXTEXTFIELDS",
+      "NOOFFSETS",
+      "TEMPORARY", "7200",
+      "NOHL",
+      "NOFIELDS",
+      "NOFREQS",
+      "STOPWORDS", "2", "le", "la",
+      "SKIPINITIALSCAN"
+    ]
+    assert_equal expected, opts.to_args
+  end
+
+  def test_ordering_matches_ft_create_spec
+    # Verify the arg order follows the FT.CREATE specification:
+    # ON type, PREFIX, FILTER, LANGUAGE, LANGUAGE_FIELD, SCORE, SCORE_FIELD,
+    # MAXTEXTFIELDS, NOOFFSETS, TEMPORARY, NOHL, NOFIELDS, NOFREQS, STOPWORDS, SKIPINITIALSCAN
+    opts = Valkey::Search::FtCreateOptions.new(
+      skip_initial_scan: true,
+      data_type: :hash,
+      no_freqs: true,
+      prefixes: ["x:"]
+    )
+    args = opts.to_args
+    on_idx = args.index("ON")
+    prefix_idx = args.index("PREFIX")
+    nofreqs_idx = args.index("NOFREQS")
+    skip_idx = args.index("SKIPINITIALSCAN")
+
+    assert on_idx < prefix_idx, "ON must come before PREFIX"
+    assert prefix_idx < nofreqs_idx, "PREFIX must come before NOFREQS"
+    assert nofreqs_idx < skip_idx, "NOFREQS must come before SKIPINITIALSCAN"
+  end
+end

--- a/test/valkey/ft_info_options_test.rb
+++ b/test/valkey/ft_info_options_test.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestFtInfoOptions < Minitest::Test
+  def test_empty_options
+    opts = Valkey::Search::FtInfoOptions.new
+    assert_equal [], opts.to_args
+  end
+
+  def test_scope_local
+    opts = Valkey::Search::FtInfoOptions.new(scope: :local)
+    assert_equal ["LOCAL"], opts.to_args
+  end
+
+  def test_scope_primary
+    opts = Valkey::Search::FtInfoOptions.new(scope: :primary)
+    assert_equal ["PRIMARY"], opts.to_args
+  end
+
+  def test_scope_cluster
+    opts = Valkey::Search::FtInfoOptions.new(scope: :cluster)
+    assert_equal ["CLUSTER"], opts.to_args
+  end
+
+  def test_shard_scope_allshards
+    opts = Valkey::Search::FtInfoOptions.new(shard_scope: :allshards)
+    assert_equal ["ALLSHARDS"], opts.to_args
+  end
+
+  def test_shard_scope_someshards
+    opts = Valkey::Search::FtInfoOptions.new(shard_scope: :someshards)
+    assert_equal ["SOMESHARDS"], opts.to_args
+  end
+
+  def test_consistency_consistent
+    opts = Valkey::Search::FtInfoOptions.new(consistency: :consistent)
+    assert_equal ["CONSISTENT"], opts.to_args
+  end
+
+  def test_consistency_inconsistent
+    opts = Valkey::Search::FtInfoOptions.new(consistency: :inconsistent)
+    assert_equal ["INCONSISTENT"], opts.to_args
+  end
+
+  def test_combined_scope_and_shard
+    opts = Valkey::Search::FtInfoOptions.new(scope: :cluster, shard_scope: :someshards)
+    assert_equal ["CLUSTER", "SOMESHARDS"], opts.to_args
+  end
+
+  def test_combined_all
+    opts = Valkey::Search::FtInfoOptions.new(
+      scope: :primary, shard_scope: :allshards, consistency: :consistent
+    )
+    assert_equal ["PRIMARY", "ALLSHARDS", "CONSISTENT"], opts.to_args
+  end
+
+  def test_ordering
+    opts = Valkey::Search::FtInfoOptions.new(
+      scope: :cluster, shard_scope: :someshards, consistency: :inconsistent
+    )
+    args = opts.to_args
+    assert args.index("CLUSTER") < args.index("SOMESHARDS")
+    assert args.index("SOMESHARDS") < args.index("INCONSISTENT")
+  end
+end

--- a/test/valkey/ft_search_options_test.rb
+++ b/test/valkey/ft_search_options_test.rb
@@ -1,0 +1,209 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestFtSearchOptions < Minitest::Test
+  # --- FtSearchLimit ---
+
+  def test_search_limit_to_args
+    limit = Valkey::Search::FtSearchLimit.new(offset: 5, count: 20)
+    assert_equal ["LIMIT", "5", "20"], limit.to_args
+  end
+
+  # --- ReturnField ---
+
+  def test_return_field_basic
+    field = Valkey::Search::ReturnField.new("title")
+    assert_equal ["title"], field.to_args
+  end
+
+  def test_return_field_with_alias
+    field = Valkey::Search::ReturnField.new("$.title", field_alias: "title")
+    assert_equal ["$.title", "AS", "title"], field.to_args
+  end
+
+  # --- FtSearchOptions ---
+
+  def test_empty_options
+    opts = Valkey::Search::FtSearchOptions.new
+    assert_equal [], opts.to_args
+  end
+
+  def test_nocontent
+    opts = Valkey::Search::FtSearchOptions.new(nocontent: true)
+    assert_equal ["NOCONTENT"], opts.to_args
+  end
+
+  def test_verbatim
+    opts = Valkey::Search::FtSearchOptions.new(verbatim: true)
+    assert_equal ["VERBATIM"], opts.to_args
+  end
+
+  def test_inorder
+    opts = Valkey::Search::FtSearchOptions.new(inorder: true)
+    assert_equal ["INORDER"], opts.to_args
+  end
+
+  def test_slop
+    opts = Valkey::Search::FtSearchOptions.new(slop: 2)
+    assert_equal ["SLOP", "2"], opts.to_args
+  end
+
+  def test_return_fields
+    opts = Valkey::Search::FtSearchOptions.new(
+      return_fields: [
+        Valkey::Search::ReturnField.new("title"),
+        Valkey::Search::ReturnField.new("price")
+      ]
+    )
+    assert_equal ["RETURN", "2", "title", "price"], opts.to_args
+  end
+
+  def test_return_fields_with_alias
+    opts = Valkey::Search::FtSearchOptions.new(
+      return_fields: [
+        Valkey::Search::ReturnField.new("$.title", field_alias: "title"),
+        Valkey::Search::ReturnField.new("price")
+      ]
+    )
+    # "$.title" + "AS" + "title" = 3 tokens, "price" = 1 token, total = 4
+    assert_equal ["RETURN", "4", "$.title", "AS", "title", "price"], opts.to_args
+  end
+
+  def test_sortby
+    opts = Valkey::Search::FtSearchOptions.new(sortby: "price")
+    assert_equal ["SORTBY", "price"], opts.to_args
+  end
+
+  def test_sortby_with_order
+    opts = Valkey::Search::FtSearchOptions.new(sortby: "price", sortby_order: :asc)
+    assert_equal ["SORTBY", "price", "ASC"], opts.to_args
+  end
+
+  def test_sortby_desc
+    opts = Valkey::Search::FtSearchOptions.new(sortby: "price", sortby_order: :desc)
+    assert_equal ["SORTBY", "price", "DESC"], opts.to_args
+  end
+
+  def test_withsortkeys
+    opts = Valkey::Search::FtSearchOptions.new(sortby: "price", withsortkeys: true)
+    assert_equal ["SORTBY", "price", "WITHSORTKEYS"], opts.to_args
+  end
+
+  def test_timeout
+    opts = Valkey::Search::FtSearchOptions.new(timeout: 5000)
+    assert_equal ["TIMEOUT", "5000"], opts.to_args
+  end
+
+  def test_params
+    opts = Valkey::Search::FtSearchOptions.new(params: { "vec" => "binary_data" })
+    assert_equal ["PARAMS", "2", "vec", "binary_data"], opts.to_args
+  end
+
+  def test_params_multiple
+    opts = Valkey::Search::FtSearchOptions.new(params: { "vec" => "data1", "k" => "5" })
+    assert_equal ["PARAMS", "4", "vec", "data1", "k", "5"], opts.to_args
+  end
+
+  def test_limit
+    opts = Valkey::Search::FtSearchOptions.new(
+      limit: Valkey::Search::FtSearchLimit.new(offset: 0, count: 10)
+    )
+    assert_equal ["LIMIT", "0", "10"], opts.to_args
+  end
+
+  def test_count
+    opts = Valkey::Search::FtSearchOptions.new(count: true)
+    assert_equal ["COUNT"], opts.to_args
+  end
+
+  def test_dialect
+    opts = Valkey::Search::FtSearchOptions.new(dialect: 2)
+    assert_equal ["DIALECT", "2"], opts.to_args
+  end
+
+  def test_shard_scope_allshards
+    opts = Valkey::Search::FtSearchOptions.new(shard_scope: :allshards)
+    assert_equal ["ALLSHARDS"], opts.to_args
+  end
+
+  def test_shard_scope_someshards
+    opts = Valkey::Search::FtSearchOptions.new(shard_scope: :someshards)
+    assert_equal ["SOMESHARDS"], opts.to_args
+  end
+
+  def test_consistency_consistent
+    opts = Valkey::Search::FtSearchOptions.new(consistency: :consistent)
+    assert_equal ["CONSISTENT"], opts.to_args
+  end
+
+  def test_consistency_inconsistent
+    opts = Valkey::Search::FtSearchOptions.new(consistency: :inconsistent)
+    assert_equal ["INCONSISTENT"], opts.to_args
+  end
+
+  def test_combined_typical_search
+    opts = Valkey::Search::FtSearchOptions.new(
+      verbatim: true,
+      sortby: "price", sortby_order: :asc,
+      limit: Valkey::Search::FtSearchLimit.new(offset: 0, count: 10),
+      return_fields: [Valkey::Search::ReturnField.new("title"),
+                      Valkey::Search::ReturnField.new("price")]
+    )
+    expected = ["VERBATIM", "RETURN", "2", "title", "price",
+                "SORTBY", "price", "ASC", "LIMIT", "0", "10"]
+    assert_equal expected, opts.to_args
+  end
+
+  def test_combined_vector_search
+    opts = Valkey::Search::FtSearchOptions.new(
+      params: { "vec" => "blob" },
+      dialect: 2,
+      limit: Valkey::Search::FtSearchLimit.new(offset: 0, count: 5)
+    )
+    expected = ["PARAMS", "2", "vec", "blob", "LIMIT", "0", "5", "DIALECT", "2"]
+    assert_equal expected, opts.to_args
+  end
+
+  def test_ordering_matches_spec
+    # Verify shard/consistency come first, then NOCONTENT/VERBATIM/INORDER/SLOP,
+    # then RETURN, SORTBY, WITHSORTKEYS, TIMEOUT, PARAMS, LIMIT, COUNT, DIALECT
+    opts = Valkey::Search::FtSearchOptions.new(
+      shard_scope: :allshards,
+      consistency: :consistent,
+      nocontent: true,
+      verbatim: true,
+      inorder: true,
+      slop: 1,
+      sortby: "price", sortby_order: :desc,
+      withsortkeys: true,
+      timeout: 1000,
+      params: { "x" => "1" },
+      limit: Valkey::Search::FtSearchLimit.new(offset: 0, count: 5),
+      count: true,
+      dialect: 2
+    )
+    args = opts.to_args
+    # Check ordering of key tokens
+    assert args.index("ALLSHARDS") < args.index("CONSISTENT")
+    assert args.index("CONSISTENT") < args.index("NOCONTENT")
+    assert args.index("NOCONTENT") < args.index("VERBATIM")
+    assert args.index("VERBATIM") < args.index("INORDER")
+    assert args.index("INORDER") < args.index("SLOP")
+    assert args.index("SLOP") < args.index("SORTBY")
+    assert args.index("SORTBY") < args.index("WITHSORTKEYS")
+    assert args.index("WITHSORTKEYS") < args.index("TIMEOUT")
+    assert args.index("TIMEOUT") < args.index("PARAMS")
+    assert args.index("PARAMS") < args.index("LIMIT")
+    assert args.index("LIMIT") < args.index("COUNT")
+    assert args.index("COUNT") < args.index("DIALECT")
+  end
+
+  def test_withsortkeys_accessor
+    opts = Valkey::Search::FtSearchOptions.new(sortby: "price", withsortkeys: true)
+    assert_equal true, opts.withsortkeys
+
+    opts2 = Valkey::Search::FtSearchOptions.new(sortby: "price")
+    assert_equal false, opts2.withsortkeys
+  end
+end

--- a/test/valkey/ft_search_result_test.rb
+++ b/test/valkey/ft_search_result_test.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestFtSearchResult < Minitest::Test
+  # --- FtSearchDocument ---
+
+  def test_document_key
+    doc = Valkey::Search::FtSearchDocument.new("doc:1", { "title" => "hello" })
+    assert_equal "doc:1", doc.key
+  end
+
+  def test_document_fields
+    fields = { "title" => "hello", "price" => "9.99" }
+    doc = Valkey::Search::FtSearchDocument.new("doc:1", fields)
+    assert_equal fields, doc.fields
+  end
+
+  def test_document_bracket_accessor
+    doc = Valkey::Search::FtSearchDocument.new("doc:1", { "title" => "hello" })
+    assert_equal "hello", doc["title"]
+    assert_nil doc["nonexistent"]
+  end
+
+  def test_document_sort_key
+    doc = Valkey::Search::FtSearchDocument.new("doc:1", {}, sort_key: "9.99")
+    assert_equal "9.99", doc.sort_key
+  end
+
+  def test_document_sort_key_nil_by_default
+    doc = Valkey::Search::FtSearchDocument.new("doc:1", {})
+    assert_nil doc.sort_key
+  end
+
+  def test_document_to_s
+    doc = Valkey::Search::FtSearchDocument.new("doc:1", { "x" => "1" })
+    assert_match(/FtSearchDocument/, doc.to_s)
+    assert_match(/doc:1/, doc.to_s)
+  end
+
+  # --- FtSearchResult.from_raw ---
+
+  def test_from_raw_nil
+    result = Valkey::Search::FtSearchResult.from_raw(nil)
+    assert_equal 0, result.total_results
+    assert_equal [], result.documents
+  end
+
+  def test_from_raw_empty
+    result = Valkey::Search::FtSearchResult.from_raw([])
+    assert_equal 0, result.total_results
+    assert_equal [], result.documents
+  end
+
+  def test_from_raw_count_only
+    # When count-only mode is used, response is just [count]
+    result = Valkey::Search::FtSearchResult.from_raw([5])
+    assert_equal 5, result.total_results
+    assert_equal [], result.documents
+  end
+
+  def test_from_raw_normal_response
+    # glide-core normalized format: [count, {key => {field => value}}]
+    raw = [2, { "doc:1" => { "title" => "hello" }, "doc:2" => { "title" => "world" } }]
+    result = Valkey::Search::FtSearchResult.from_raw(raw)
+    assert_equal 2, result.total_results
+    assert_equal 2, result.documents.size
+    assert_equal "doc:1", result.documents[0].key
+    assert_equal "hello", result.documents[0]["title"]
+    assert_equal "doc:2", result.documents[1].key
+    assert_equal "world", result.documents[1]["title"]
+  end
+
+  def test_from_raw_multiple_fields
+    raw = [1, { "doc:1" => { "title" => "hi", "price" => "5.0", "category" => "books" } }]
+    result = Valkey::Search::FtSearchResult.from_raw(raw)
+    assert_equal 1, result.total_results
+    doc = result.documents.first
+    assert_equal "hi", doc["title"]
+    assert_equal "5.0", doc["price"]
+    assert_equal "books", doc["category"]
+  end
+
+  def test_from_raw_empty_fields
+    # NOCONTENT response: documents have empty field maps
+    raw = [2, { "doc:1" => {}, "doc:2" => {} }]
+    result = Valkey::Search::FtSearchResult.from_raw(raw)
+    assert_equal 2, result.total_results
+    assert_equal({}, result.documents[0].fields)
+    assert_equal({}, result.documents[1].fields)
+  end
+
+  def test_from_raw_with_sortkeys
+    # WITHSORTKEYS format: {key => [sort_key, {fields}]}
+    raw = [2, {
+      "doc:1" => ["9.99", { "title" => "cheap", "price" => "9.99" }],
+      "doc:2" => ["19.99", { "title" => "pricey", "price" => "19.99" }]
+    }]
+    result = Valkey::Search::FtSearchResult.from_raw(raw, withsortkeys: true)
+    assert_equal 2, result.total_results
+    assert_equal "9.99", result.documents[0].sort_key
+    assert_equal "cheap", result.documents[0]["title"]
+    assert_equal "19.99", result.documents[1].sort_key
+    assert_equal "pricey", result.documents[1]["title"]
+  end
+
+  def test_from_raw_with_sortkeys_nil_sort_key
+    # When sort field is missing, sort_key is nil
+    raw = [1, { "doc:1" => [nil, { "title" => "no price" }] }]
+    result = Valkey::Search::FtSearchResult.from_raw(raw, withsortkeys: true)
+    assert_nil result.documents[0].sort_key
+    assert_equal "no price", result.documents[0]["title"]
+  end
+
+  def test_from_raw_count_string
+    # glide-core might return count as string
+    raw = ["3", { "doc:1" => { "x" => "1" } }]
+    result = Valkey::Search::FtSearchResult.from_raw(raw)
+    assert_equal 3, result.total_results
+  end
+
+  def test_from_raw_fields_as_array
+    # Handle case where fields come as alternating array [key, val, key, val]
+    raw = [1, { "doc:1" => ["title", "hello", "price", "5"] }]
+    result = Valkey::Search::FtSearchResult.from_raw(raw)
+    assert_equal "hello", result.documents[0]["title"]
+    assert_equal "5", result.documents[0]["price"]
+  end
+
+  def test_from_raw_fields_nil
+    # Handle nil field value gracefully
+    raw = [1, { "doc:1" => nil }]
+    result = Valkey::Search::FtSearchResult.from_raw(raw)
+    assert_equal({}, result.documents[0].fields)
+  end
+
+  def test_result_to_s
+    result = Valkey::Search::FtSearchResult.from_raw([3, { "a" => {} }])
+    assert_match(/FtSearchResult/, result.to_s)
+    assert_match(/total=3/, result.to_s)
+    assert_match(/docs=1/, result.to_s)
+  end
+end

--- a/test/valkey/search_fields_test.rb
+++ b/test/valkey/search_fields_test.rb
@@ -1,0 +1,210 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestSearchFields < Minitest::Test
+  # --- TextField ---
+
+  def test_text_field_basic
+    field = Valkey::Search::TextField.new("title")
+    assert_equal ["title", "TEXT"], field.to_args
+  end
+
+  def test_text_field_with_alias
+    field = Valkey::Search::TextField.new("title", field_alias: "t")
+    assert_equal ["title", "AS", "t", "TEXT"], field.to_args
+  end
+
+  def test_text_field_sortable
+    field = Valkey::Search::TextField.new("title", sortable: true)
+    assert_equal ["title", "TEXT", "SORTABLE"], field.to_args
+  end
+
+  def test_text_field_nostem
+    field = Valkey::Search::TextField.new("title", nostem: true)
+    assert_equal ["title", "TEXT", "NOSTEM"], field.to_args
+  end
+
+  def test_text_field_weight
+    field = Valkey::Search::TextField.new("title", weight: 2.0)
+    assert_equal ["title", "TEXT", "WEIGHT", "2.0"], field.to_args
+  end
+
+  def test_text_field_withsuffixtrie
+    field = Valkey::Search::TextField.new("title", withsuffixtrie: true)
+    assert_equal ["title", "TEXT", "WITHSUFFIXTRIE"], field.to_args
+  end
+
+  def test_text_field_nosuffixtrie
+    field = Valkey::Search::TextField.new("title", nosuffixtrie: true)
+    assert_equal ["title", "TEXT", "NOSUFFIXTRIE"], field.to_args
+  end
+
+  def test_text_field_all_options
+    field = Valkey::Search::TextField.new("title",
+                                         field_alias: "t", nostem: true,
+                                         weight: 5.0, withsuffixtrie: true, sortable: true)
+    expected = ["title", "AS", "t", "TEXT", "NOSTEM", "WEIGHT", "5.0", "WITHSUFFIXTRIE", "SORTABLE"]
+    assert_equal expected, field.to_args
+  end
+
+  # --- NumericField ---
+
+  def test_numeric_field_basic
+    field = Valkey::Search::NumericField.new("price")
+    assert_equal ["price", "NUMERIC"], field.to_args
+  end
+
+  def test_numeric_field_with_alias
+    field = Valkey::Search::NumericField.new("price", field_alias: "p")
+    assert_equal ["price", "AS", "p", "NUMERIC"], field.to_args
+  end
+
+  def test_numeric_field_sortable
+    field = Valkey::Search::NumericField.new("price", sortable: true)
+    assert_equal ["price", "NUMERIC", "SORTABLE"], field.to_args
+  end
+
+  # --- TagField ---
+
+  def test_tag_field_basic
+    field = Valkey::Search::TagField.new("category")
+    assert_equal ["category", "TAG"], field.to_args
+  end
+
+  def test_tag_field_with_alias
+    field = Valkey::Search::TagField.new("category", field_alias: "cat")
+    assert_equal ["category", "AS", "cat", "TAG"], field.to_args
+  end
+
+  def test_tag_field_separator
+    field = Valkey::Search::TagField.new("tags", separator: ";")
+    assert_equal ["tags", "TAG", "SEPARATOR", ";"], field.to_args
+  end
+
+  def test_tag_field_case_sensitive
+    field = Valkey::Search::TagField.new("category", case_sensitive: true)
+    assert_equal ["category", "TAG", "CASESENSITIVE"], field.to_args
+  end
+
+  def test_tag_field_sortable
+    field = Valkey::Search::TagField.new("category", sortable: true)
+    assert_equal ["category", "TAG", "SORTABLE"], field.to_args
+  end
+
+  def test_tag_field_all_options
+    field = Valkey::Search::TagField.new("tags",
+                                        field_alias: "t", separator: "|",
+                                        case_sensitive: true, sortable: true)
+    expected = ["tags", "AS", "t", "TAG", "SEPARATOR", "|", "CASESENSITIVE", "SORTABLE"]
+    assert_equal expected, field.to_args
+  end
+
+  # --- VectorFieldFlat ---
+
+  def test_vector_field_flat_basic
+    field = Valkey::Search::VectorFieldFlat.new("embedding",
+                                               dim: 128, distance_metric: :cosine)
+    expected = ["embedding", "VECTOR", "FLAT", "6",
+                "TYPE", "FLOAT32", "DIM", "128", "DISTANCE_METRIC", "COSINE"]
+    assert_equal expected, field.to_args
+  end
+
+  def test_vector_field_flat_with_alias
+    field = Valkey::Search::VectorFieldFlat.new("embedding",
+                                               dim: 128, distance_metric: :l2,
+                                               field_alias: "vec")
+    expected = ["embedding", "AS", "vec", "VECTOR", "FLAT", "6",
+                "TYPE", "FLOAT32", "DIM", "128", "DISTANCE_METRIC", "L2"]
+    assert_equal expected, field.to_args
+  end
+
+  def test_vector_field_flat_float64
+    field = Valkey::Search::VectorFieldFlat.new("embedding",
+                                               dim: 256, distance_metric: :ip,
+                                               type: :float64)
+    expected = ["embedding", "VECTOR", "FLAT", "6",
+                "TYPE", "FLOAT64", "DIM", "256", "DISTANCE_METRIC", "IP"]
+    assert_equal expected, field.to_args
+  end
+
+  def test_vector_field_flat_with_initial_cap
+    field = Valkey::Search::VectorFieldFlat.new("embedding",
+                                               dim: 128, distance_metric: :cosine,
+                                               initial_cap: 1000)
+    expected = ["embedding", "VECTOR", "FLAT", "8",
+                "TYPE", "FLOAT32", "DIM", "128", "DISTANCE_METRIC", "COSINE",
+                "INITIAL_CAP", "1000"]
+    assert_equal expected, field.to_args
+  end
+
+  def test_vector_field_flat_string_params
+    # Verify symbols and strings both work for distance_metric/type
+    field = Valkey::Search::VectorFieldFlat.new("embedding",
+                                               dim: 64, distance_metric: "cosine",
+                                               type: "float32")
+    expected = ["embedding", "VECTOR", "FLAT", "6",
+                "TYPE", "FLOAT32", "DIM", "64", "DISTANCE_METRIC", "COSINE"]
+    assert_equal expected, field.to_args
+  end
+
+  # --- VectorFieldHnsw ---
+
+  def test_vector_field_hnsw_basic
+    field = Valkey::Search::VectorFieldHnsw.new("embedding",
+                                               dim: 768, distance_metric: :cosine)
+    expected = ["embedding", "VECTOR", "HNSW", "6",
+                "TYPE", "FLOAT32", "DIM", "768", "DISTANCE_METRIC", "COSINE"]
+    assert_equal expected, field.to_args
+  end
+
+  def test_vector_field_hnsw_with_m
+    field = Valkey::Search::VectorFieldHnsw.new("embedding",
+                                               dim: 768, distance_metric: :cosine,
+                                               m: 16)
+    expected = ["embedding", "VECTOR", "HNSW", "8",
+                "TYPE", "FLOAT32", "DIM", "768", "DISTANCE_METRIC", "COSINE",
+                "M", "16"]
+    assert_equal expected, field.to_args
+  end
+
+  def test_vector_field_hnsw_with_ef_construction
+    field = Valkey::Search::VectorFieldHnsw.new("embedding",
+                                               dim: 768, distance_metric: :cosine,
+                                               ef_construction: 200)
+    expected = ["embedding", "VECTOR", "HNSW", "8",
+                "TYPE", "FLOAT32", "DIM", "768", "DISTANCE_METRIC", "COSINE",
+                "EF_CONSTRUCTION", "200"]
+    assert_equal expected, field.to_args
+  end
+
+  def test_vector_field_hnsw_with_ef_runtime
+    field = Valkey::Search::VectorFieldHnsw.new("embedding",
+                                               dim: 768, distance_metric: :cosine,
+                                               ef_runtime: 10)
+    expected = ["embedding", "VECTOR", "HNSW", "8",
+                "TYPE", "FLOAT32", "DIM", "768", "DISTANCE_METRIC", "COSINE",
+                "EF_RUNTIME", "10"]
+    assert_equal expected, field.to_args
+  end
+
+  def test_vector_field_hnsw_all_options
+    field = Valkey::Search::VectorFieldHnsw.new("embedding",
+                                               dim: 768, distance_metric: :l2,
+                                               type: :float32, field_alias: "vec",
+                                               initial_cap: 5000, m: 32,
+                                               ef_construction: 400, ef_runtime: 20)
+    expected = ["embedding", "AS", "vec", "VECTOR", "HNSW", "14",
+                "TYPE", "FLOAT32", "DIM", "768", "DISTANCE_METRIC", "L2",
+                "INITIAL_CAP", "5000", "M", "32",
+                "EF_CONSTRUCTION", "400", "EF_RUNTIME", "20"]
+    assert_equal expected, field.to_args
+  end
+
+  # --- Base Field ---
+
+  def test_base_field_raises_not_implemented
+    field = Valkey::Search::Field.new("test")
+    assert_raises(NotImplementedError) { field.to_args }
+  end
+end


### PR DESCRIPTION
## Summary

Adds a Ruby-idiomatic structured API for Valkey Search (FT.*) commands, bringing the Ruby GLIDE client to feature parity with the other 6 language clients for Search 1.2.

## Changes

### New module: `lib/valkey/search/`

| File | Classes |
|------|---------|
| `field.rb` | Field (base), TextField, NumericField, TagField, VectorFieldFlat, VectorFieldHnsw |
| `ft_create_options.rb` | FtCreateOptions (all index-level options) |
| `ft_search_options.rb` | FtSearchLimit, ReturnField, FtSearchOptions (VERBATIM, INORDER, SLOP, SORTBY, WITHSORTKEYS, NOCONTENT, DIALECT, RETURN, LIMIT, PARAMS, TIMEOUT, shard scope, consistency) |
| `ft_search_result.rb` | FtSearchDocument, FtSearchResult (structured response parsing) |
| `ft_aggregate_options.rb` | Reducer, GroupBy, SortProperty, SortBy, Apply, Filter, AggregateLimit, FtAggregateOptions |
| `ft_info_options.rb` | FtInfoOptions (scope, shard_scope, consistency) |

### Enhanced commands in `vector_search_commands.rb`

- `ft_create` — accepts `fields:` and `options:` keyword args
- `ft_search` — accepts `options:`, returns `FtSearchResult` when structured
- `ft_aggregate` — accepts `options:` with pipeline clauses
- `ft_info` — accepts `options:` for cluster scope

All changes are **backward-compatible** — existing raw-args interface continues to work unchanged.

## Testing

- **129 unit tests** — serialization of all field/options classes
- **23 integration tests** — structured API against live Search module
- All files pass `ruby -c` syntax check

## Design decisions

- Ruby-idiomatic: keyword arguments, symbols, simple classes with `to_args`
- Separate classes for FLAT vs HNSW vector fields (matches Java pattern)
- `FtSearchResult.from_raw` handles both normal and WITHSORTKEYS response formats
- Pipeline clauses for FT.AGGREGATE are composable and order-independent
- Field classes use `to_args` → string array pattern matching the FFI boundary

## What's NOT included (1.3 features, future work)

- New 1.3 reducers and vector range syntax
- FT.SEARCH scorer options
- FT.AGGREGATE LOAD ALL with field filtering