### PR TITLE
Docs: Update security reference to Valkey org level

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,7 +102,7 @@ This project follows the [Amazon Open Source Code of Conduct](https://aws.github
 
 ## Security
 
-Report security vulnerabilities via [valkey-glide SECURITY.md](https://github.com/valkey-io/valkey-glide/blob/main/SECURITY.md).
+See [SECURITY.md](https://github.com/valkey-io/.github/blob/main/SECURITY.md).
 
 ## Licensing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,0 @@
-# Reporting a Vulnerability
-
-If you believe you've discovered a security vulnerability, please contact the Valkey team at security@lists.valkey.io.
-Please *DO NOT* create an issue.
-We follow a responsible disclosure procedure, so depending on the severity of the issue we may notify Valkey vendors about the issue before releasing it publicly.
-If you would like to be added to our list of vendors, please reach out to the Valkey team at valkey-glide@lists.valkey.io.


### PR DESCRIPTION
### Summary

This PR updates the security doc reference to point to Valkey Org's security documentation.