### PR TITLE
Distributed Tracing (Parent Context Propagation) for valkey-glide-ruby

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -66,4 +66,5 @@ Metrics/ModuleLength:
     - 'lib/valkey/utils.rb'
     - 'lib/valkey/commands/*.rb'
     - 'lib/valkey/bindings.rb'
+    - 'lib/valkey/opentelemetry.rb'
     - 'test/**/*.rb'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@
 ### Changes
 
 * Ruby: Add Alpine Linux (musl libc) support for x86_64 and aarch64 — runtime detection of musl libc, CI/CD pipeline for native builds, and prebuilt `libglide_ffi.so` for musl targets ([#143](https://github.com/valkey-io/valkey-glide-ruby/pull/143))
+* Ruby: Add distributed tracing support — `Valkey::OpenTelemetry.set_parent_span_context_provider` (and `init(parent_span_context_provider:)`) let an app propagate its current W3C trace context into command/pipeline spans, so they become children of the app's trace instead of independent root spans, matching the Node.js client's `parentSpanContextProvider` behavior.

--- a/README.md
+++ b/README.md
@@ -238,6 +238,50 @@ client.set("key", "value")  # traced when sampling applies
 
 OpenTelemetry can only be initialized **once per process**. Spans are created in the FFI layer when sampling is enabled.
 
+### Distributed tracing (parent context propagation)
+
+By default, every command span is an independent root span — it doesn't nest under your
+application's request trace. To fix that, register a `parent_span_context_provider`: a
+callable invoked before every command that returns the current W3C trace context (or `nil`
+when there isn't one). When it returns a valid context, the command/pipeline span is created
+as a **child** of it instead of an independent span.
+
+```ruby
+require "valkey"
+require "opentelemetry/sdk" # if your app uses the real opentelemetry-ruby gem
+
+Valkey::OpenTelemetry.init(
+  traces: { endpoint: "http://localhost:4318/v1/traces", sample_percentage: 10 }
+)
+
+Valkey::OpenTelemetry.set_parent_span_context_provider do
+  span = ::OpenTelemetry::Trace.current_span
+  next nil unless span.context.valid?
+
+  {
+    trace_id: span.context.hex_trace_id,
+    span_id: span.context.hex_span_id,
+    trace_flags: span.context.trace_flags.sampled? ? 1 : 0,
+    tracestate: span.context.tracestate.to_s
+  }
+end
+```
+
+The provider must return either `nil` or a Hash with `:trace_id` (32-char lowercase hex),
+`:span_id` (16-char lowercase hex), `:trace_flags` (Integer 0-255), and `:tracestate`
+(String or `nil`). Anything else is rejected with a warning and treated as `nil` — a broken
+provider degrades to independent root spans, it never raises into your command path.
+
+You can also pass `parent_span_context_provider:` directly to `init(...)` instead of calling
+`set_parent_span_context_provider` separately.
+
+**Note on the `OpenTelemetry` constant name:** `Valkey::OpenTelemetry` (this gem's module) and
+the real `opentelemetry-ruby` gem's top-level `::OpenTelemetry` module are unrelated constants
+and don't collide. But if you write a provider block from code that's lexically nested inside
+`Valkey` (uncommon for typical app-level code), a bare `OpenTelemetry::Trace` reference would
+resolve to `Valkey::OpenTelemetry::Trace` (undefined) instead of the real gem — always use the
+leading-`::` form, `::OpenTelemetry::Trace`, as in the example above.
+
 ## Examples
 
 Runnable examples are in [examples/](./examples/):

--- a/examples/opentelemetry.rb
+++ b/examples/opentelemetry.rb
@@ -41,10 +41,29 @@ end
 client.del("otel_key", "otel_pipe_1")
 client.close
 
+# Distributed tracing: register a parent_span_context_provider so command spans
+# become children of the app's current trace instead of independent root spans.
+# Here we hand-roll a fake W3C trace context (no dependency on the real
+# opentelemetry-ruby gem); in a real app this would read from
+# ::OpenTelemetry::Trace.current_span.context (see README).
+fake_trace_id = "4bf92f3577b34da6a3ce929d0e0e4736"
+fake_span_id = "00f067aa0ba902b7"
+
+Valkey::OpenTelemetry.set_parent_span_context_provider do
+  { trace_id: fake_trace_id, span_id: fake_span_id, trace_flags: 1, tracestate: nil }
+end
+
+client = Valkey.new(host: host, port: port)
+client.set("otel_traced_key", "value") # span will be a child of fake_trace_id/fake_span_id
+client.close
+
+Valkey::OpenTelemetry.set_parent_span_context_provider(nil)
+
 # Allow exporter flush
 sleep 2
 
 puts "OpenTelemetry initialized: #{Valkey::OpenTelemetry.initialized?}"
 puts "Traces file: #{TRACES_FILE} (#{File.size?(TRACES_FILE) || 0} bytes)"
 puts "Metrics file: #{METRICS_FILE} (#{File.size?(METRICS_FILE) || 0} bytes)"
-puts "Done."
+puts "Done. Inspect #{TRACES_FILE} - the SET span for otel_traced_key should have " \
+     "trace_id=#{fake_trace_id} and parent_span_id=#{fake_span_id}."

--- a/lib/valkey.rb
+++ b/lib/valkey.rb
@@ -380,13 +380,20 @@ class Valkey
       arg_ptrs, arg_lens, _buffers = build_command_args(command_args)
     end
 
-    # Create OpenTelemetry span if sampling is enabled
-    # TODO: add parent span propagation via create_otel_span_with_parent
-    # to support distributed tracing context (see Go client base_client.go for reference)
+    # Create OpenTelemetry span if sampling is enabled, as a child of the app's current
+    # span context when a parent_span_context_provider is registered (see Valkey::OpenTelemetry).
     span_ptr = 0
     if OpenTelemetry.should_sample?
       begin
-        span_ptr = Bindings.create_otel_span(command_type)
+        parent_ctx = OpenTelemetry.parent_span_context
+        span_ptr = if parent_ctx
+                     Bindings.create_otel_span_with_trace_context(
+                       command_type, parent_ctx[:trace_id], parent_ctx[:span_id],
+                       parent_ctx[:trace_flags], parent_ctx[:tracestate]
+                     )
+                   else
+                     Bindings.create_otel_span(command_type)
+                   end
       rescue StandardError => e
         # Log error but continue execution - tracing is non-critical
         warn "Failed to create OpenTelemetry span: #{e.message}"
@@ -489,13 +496,19 @@ class Valkey
     batch_options[:timeout] = 0 # No timeout
     batch_options[:route_info] = FFI::Pointer::NULL
 
-    # Create OpenTelemetry span for batch operation if sampling is enabled
-    # TODO: add parent span propagation via create_batch_otel_span_with_parent
-    # to support distributed tracing context (see Go client base_client.go for reference)
+    # Create OpenTelemetry span for batch operation if sampling is enabled, as a child of
+    # the app's current span context when a parent_span_context_provider is registered.
     span_ptr = 0
     if OpenTelemetry.should_sample?
       begin
-        span_ptr = Bindings.create_batch_otel_span
+        parent_ctx = OpenTelemetry.parent_span_context
+        span_ptr = if parent_ctx
+                     Bindings.create_batch_otel_span_with_trace_context(
+                       parent_ctx[:trace_id], parent_ctx[:span_id], parent_ctx[:trace_flags], parent_ctx[:tracestate]
+                     )
+                   else
+                     Bindings.create_batch_otel_span
+                   end
       rescue StandardError => e
         warn "Failed to create OpenTelemetry batch span: #{e.message}"
         span_ptr = 0

--- a/lib/valkey/bindings.rb
+++ b/lib/valkey/bindings.rb
@@ -326,6 +326,21 @@ class Valkey
 
     attach_function :create_batch_otel_span, [], :uint64 # returns span pointer (u64) or 0 on failure
 
+    attach_function :create_otel_span_with_trace_context, [
+      :int,    # request_type (RequestType enum value)
+      :string, # trace_id (32-char lowercase hex, or nil for an independent span)
+      :string, # span_id (16-char lowercase hex, or nil for an independent span)
+      :uint8,  # trace_flags
+      :string  # trace_state (W3C tracestate header, or nil)
+    ], :uint64 # returns span pointer (u64); falls back to an independent span on invalid context
+
+    attach_function :create_batch_otel_span_with_trace_context, [
+      :string, # trace_id (32-char lowercase hex, or nil for an independent span)
+      :string, # span_id (16-char lowercase hex, or nil for an independent span)
+      :uint8,  # trace_flags
+      :string  # trace_state (W3C tracestate header, or nil)
+    ], :uint64 # returns span pointer (u64); falls back to an independent batch span on invalid context
+
     attach_function :drop_otel_span, [
       :uint64 # span_ptr to close
     ], :void

--- a/lib/valkey/opentelemetry.rb
+++ b/lib/valkey/opentelemetry.rb
@@ -44,6 +44,7 @@ class Valkey
   module OpenTelemetry
     @initialized = false
     @config = nil
+    @parent_span_context_provider = nil
 
     class << self
       # Initialize OpenTelemetry in the Valkey GLIDE core.
@@ -67,12 +68,16 @@ class Valkey
       # @param flush_interval_ms [Integer, nil] Flush interval in milliseconds (default: 5000)
       #   Must be a positive integer
       #
+      # @param parent_span_context_provider [Proc, nil] Optional callable returning a Hash describing
+      #   the current application span context (see {set_parent_span_context_provider}). Equivalent to
+      #   calling {set_parent_span_context_provider} separately; provided here for convenience.
+      #
       # @raise [ArgumentError] if neither traces nor metrics is provided
       # @raise [ArgumentError] if sample_percentage is not between 0-100
       # @raise [RuntimeError] if initialization fails
       #
       # @return [void]
-      def init(traces: nil, metrics: nil, flush_interval_ms: nil)
+      def init(traces: nil, metrics: nil, flush_interval_ms: nil, parent_span_context_provider: nil)
         if @initialized
           warn "Valkey::OpenTelemetry already initialized - ignoring new configuration"
           return
@@ -106,6 +111,7 @@ class Valkey
 
         @initialized = true
         @config = { traces: traces, metrics: metrics, flush_interval_ms: flush_interval_ms }
+        set_parent_span_context_provider(parent_span_context_provider) if parent_span_context_provider
 
         puts "✅ Valkey OpenTelemetry initialized successfully"
         puts "   Traces: #{traces ? traces[:endpoint] : 'disabled'}"
@@ -135,15 +141,87 @@ class Valkey
       # @return [Hash, nil] the configuration hash or nil if not initialized
       attr_reader :config
 
+      # Register a callable that returns the current application span context, so that
+      # spans created for Valkey commands become children of it instead of independent
+      # root spans. This is how distributed tracing context (e.g. from the Rails request
+      # span) is propagated into the native OpenTelemetry spans created for each command.
+      #
+      # @param callable [Proc, nil] Called with no arguments before each command. Must return
+      #   either nil (no active context - the command gets an independent span) or a Hash with:
+      #   - :trace_id [String] 32-character lowercase hex trace ID
+      #   - :span_id [String] 16-character lowercase hex span ID
+      #   - :trace_flags [Integer] 0-255
+      #   - :tracestate [String, nil] W3C tracestate header, optional
+      #   Pass nil (and no block) to clear a previously registered provider.
+      #
+      # @example
+      #   Valkey::OpenTelemetry.set_parent_span_context_provider do
+      #     span = ::OpenTelemetry::Trace.current_span
+      #     next nil unless span.context.valid?
+      #
+      #     {
+      #       trace_id: span.context.hex_trace_id,
+      #       span_id: span.context.hex_span_id,
+      #       trace_flags: span.context.trace_flags.sampled? ? 1 : 0,
+      #       tracestate: span.context.tracestate.to_s
+      #     }
+      #   end
+      #
+      # @return [void]
+      def set_parent_span_context_provider(callable = nil, &block)
+        @parent_span_context_provider = block || callable
+      end
+
+      # Invoke the registered parent-span-context provider (if any) and return a validated
+      # context Hash, or nil if no provider is registered, the provider returned nil, the
+      # provider raised, or the returned context failed validation.
+      #
+      # @return [Hash, nil]
+      def parent_span_context
+        return nil unless @parent_span_context_provider
+
+        ctx = @parent_span_context_provider.call
+        return nil if ctx.nil?
+
+        validate_parent_span_context!(ctx)
+        ctx
+      rescue StandardError => e
+        warn "Valkey::OpenTelemetry parent_span_context_provider failed: #{e.message}"
+        nil
+      end
+
       # Reset initialization state (for testing only).
       #
       # @api private
       def reset!
         @initialized = false
         @config = nil
+        @parent_span_context_provider = nil
       end
 
       private
+
+      def validate_parent_span_context!(ctx)
+        raise ArgumentError, "parent span context must be a Hash, got: #{ctx.class}" unless ctx.is_a?(Hash)
+
+        unless ctx[:trace_id].is_a?(String) && ctx[:trace_id].match?(/\A[0-9a-f]{32}\z/)
+          raise ArgumentError, "trace_id must be a 32-character lowercase hex string, got: #{ctx[:trace_id].inspect}"
+        end
+
+        unless ctx[:span_id].is_a?(String) && ctx[:span_id].match?(/\A[0-9a-f]{16}\z/)
+          raise ArgumentError, "span_id must be a 16-character lowercase hex string, got: #{ctx[:span_id].inspect}"
+        end
+
+        trace_flags = ctx[:trace_flags]
+        unless trace_flags.is_a?(Integer) && trace_flags >= 0 && trace_flags <= 255
+          raise ArgumentError, "trace_flags must be an integer between 0 and 255, got: #{trace_flags.inspect}"
+        end
+
+        tracestate = ctx[:tracestate]
+        return if tracestate.nil? || tracestate.is_a?(String)
+
+        raise ArgumentError, "tracestate must be a String or nil, got: #{tracestate.class}"
+      end
 
       def build_config(traces, metrics, flush_interval_ms)
         config_struct = Bindings::OpenTelemetryConfig.new

--- a/test/standalone/valkey_test.rb
+++ b/test/standalone/valkey_test.rb
@@ -44,3 +44,9 @@ class TestStandaloneOpenTelemetry < Minitest::Test
     false
   end
 end
+
+# Pure unit tests for the parent-span-context provider API - no connection, no native
+# OTel init, so this runs in its own class independent of server/mode.
+class TestOpenTelemetryProvider < Minitest::Test
+  include ValkeyTests::OpenTelemetryProvider
+end

--- a/test/valkey/opentelemetry_provider_test.rb
+++ b/test/valkey/opentelemetry_provider_test.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+# Unit tests for Valkey::OpenTelemetry's parent-span-context provider: registration,
+# validation of the Hash a provider returns, and the resilience behavior (a provider
+# that raises, or returns something malformed, must never propagate into the caller).
+#
+# These are pure unit tests: no connection, no real native OTel init, no server needed.
+# setup/teardown only touch the provider itself (never @initialized/@config), since
+# TestStandaloneOpenTelemetry (opentelemetry_test.rb) initializes native OTel exactly
+# once per process and other tests rely on that state staying put.
+module ValkeyTests
+  module OpenTelemetryProvider
+    VALID_CONTEXT = {
+      trace_id: "0af7651916cd43dd8448eb211c80319c",
+      span_id: "b7ad6b7169203331",
+      trace_flags: 1,
+      tracestate: "congo=t61rcWkgMzE"
+    }.freeze
+
+    def setup
+      super if defined?(super)
+      ::Valkey::OpenTelemetry.set_parent_span_context_provider(nil)
+    end
+
+    def teardown
+      ::Valkey::OpenTelemetry.set_parent_span_context_provider(nil)
+      super if defined?(super)
+    end
+
+    def test_no_provider_registered_returns_nil
+      assert_nil ::Valkey::OpenTelemetry.parent_span_context
+    end
+
+    def test_valid_context_is_returned_unchanged
+      ::Valkey::OpenTelemetry.set_parent_span_context_provider { VALID_CONTEXT }
+
+      assert_equal VALID_CONTEXT, ::Valkey::OpenTelemetry.parent_span_context
+    end
+
+    def test_provider_returning_nil_context_returns_nil
+      ::Valkey::OpenTelemetry.set_parent_span_context_provider { nil }
+
+      assert_nil ::Valkey::OpenTelemetry.parent_span_context
+    end
+
+    def test_nil_tracestate_is_accepted
+      ctx = VALID_CONTEXT.merge(tracestate: nil)
+      ::Valkey::OpenTelemetry.set_parent_span_context_provider { ctx }
+
+      assert_equal ctx, ::Valkey::OpenTelemetry.parent_span_context
+    end
+
+    def test_invalid_trace_id_is_rejected
+      ctx = VALID_CONTEXT.merge(trace_id: "not-hex")
+      ::Valkey::OpenTelemetry.set_parent_span_context_provider { ctx }
+
+      _, err = capture_io { assert_nil ::Valkey::OpenTelemetry.parent_span_context }
+
+      assert_match(/trace_id/, err)
+    end
+
+    def test_invalid_span_id_is_rejected
+      ctx = VALID_CONTEXT.merge(span_id: "tooshort")
+      ::Valkey::OpenTelemetry.set_parent_span_context_provider { ctx }
+
+      _, err = capture_io { assert_nil ::Valkey::OpenTelemetry.parent_span_context }
+
+      assert_match(/span_id/, err)
+    end
+
+    def test_out_of_range_trace_flags_is_rejected
+      ctx = VALID_CONTEXT.merge(trace_flags: 256)
+      ::Valkey::OpenTelemetry.set_parent_span_context_provider { ctx }
+
+      _, err = capture_io { assert_nil ::Valkey::OpenTelemetry.parent_span_context }
+
+      assert_match(/trace_flags/, err)
+    end
+
+    def test_non_string_tracestate_is_rejected
+      ctx = VALID_CONTEXT.merge(tracestate: 12_345)
+      ::Valkey::OpenTelemetry.set_parent_span_context_provider { ctx }
+
+      _, err = capture_io { assert_nil ::Valkey::OpenTelemetry.parent_span_context }
+
+      assert_match(/tracestate/, err)
+    end
+
+    def test_provider_raising_is_caught
+      ::Valkey::OpenTelemetry.set_parent_span_context_provider { raise "boom" }
+
+      _, err = capture_io { assert_nil ::Valkey::OpenTelemetry.parent_span_context }
+
+      assert_match(/boom/, err)
+    end
+
+    def test_clearing_provider_with_nil
+      ::Valkey::OpenTelemetry.set_parent_span_context_provider { VALID_CONTEXT }
+      ::Valkey::OpenTelemetry.set_parent_span_context_provider(nil)
+
+      assert_nil ::Valkey::OpenTelemetry.parent_span_context
+    end
+
+    def test_set_parent_span_context_provider_accepts_a_proc
+      provider = proc { VALID_CONTEXT }
+      ::Valkey::OpenTelemetry.set_parent_span_context_provider(provider)
+
+      assert_equal VALID_CONTEXT, ::Valkey::OpenTelemetry.parent_span_context
+    end
+
+    # Exercises init(parent_span_context_provider:) without touching real native OTel
+    # state: Bindings.init_open_telemetry is stubbed, and @initialized/@config are
+    # saved and restored so this test is safe regardless of run order relative to
+    # TestStandaloneOpenTelemetry's once-per-process native initialization.
+    def test_init_accepts_parent_span_context_provider_kwarg
+      original_initialized = ::Valkey::OpenTelemetry.instance_variable_get(:@initialized)
+      original_config = ::Valkey::OpenTelemetry.config
+      ::Valkey::OpenTelemetry.instance_variable_set(:@initialized, false)
+
+      Valkey::Bindings.stub(:init_open_telemetry, FFI::Pointer::NULL) do
+        ::Valkey::OpenTelemetry.init(
+          traces: { endpoint: "file:///tmp/valkey_ruby_provider_kwarg_test.json" },
+          parent_span_context_provider: -> { VALID_CONTEXT }
+        )
+      end
+
+      assert_equal VALID_CONTEXT, ::Valkey::OpenTelemetry.parent_span_context
+    ensure
+      ::Valkey::OpenTelemetry.instance_variable_set(:@initialized, original_initialized)
+      ::Valkey::OpenTelemetry.instance_variable_set(:@config, original_config)
+    end
+  end
+end

--- a/test/valkey/opentelemetry_test.rb
+++ b/test/valkey/opentelemetry_test.rb
@@ -23,6 +23,7 @@ module ValkeyTests
 
     def teardown
       cleanup_test_files
+      ::Valkey::OpenTelemetry.set_parent_span_context_provider(nil)
       super if defined?(super)
     end
 
@@ -121,6 +122,18 @@ module ValkeyTests
         counts[name] = span_names.count(name)
       end
       counts
+    end
+
+    # Read full span objects (not just names) from the exported file, so tests can
+    # assert on trace_id/parent_span_id to prove parent-context propagation.
+    def read_spans(file_path)
+      spans = []
+      File.readlines(file_path).each do |line|
+        spans << JSON.parse(line)
+      rescue JSON::ParserError
+        # Skip malformed lines
+      end
+      spans
     end
 
     # Test 1: Initialization with file exporter
@@ -319,6 +332,63 @@ module ValkeyTests
 
       # Just verify no errors occurred
       # Actual sampling verification would be non-deterministic
+    end
+
+    # Test 9: A registered parent_span_context_provider makes the command span a
+    # child of the given remote context (single-command / send_command path).
+    def test_command_span_is_child_of_parent_context_when_provider_registered
+      skip("OpenTelemetry tests only run on standalone mode") if cluster_mode?
+      assert ::Valkey::OpenTelemetry.initialized?
+
+      cleanup_test_files
+
+      trace_id = "4bf92f3577b34da6a3ce929d0e0e4736"
+      span_id = "00f067aa0ba902b7"
+
+      ::Valkey::OpenTelemetry.set_parent_span_context_provider do
+        { trace_id: trace_id, span_id: span_id, trace_flags: 1, tracestate: nil }
+      end
+
+      client = ::Valkey.new(host: "localhost", port: 6379)
+      client.set("otel_parent_ctx_key", "value")
+      client.close
+
+      wait_for_spans(TRACES_FILE, %w[SET], expected_counts: { "SET" => 1 }, timeout: 10.0)
+
+      span = read_spans(TRACES_FILE).find { |s| s["name"] == "SET" }
+      refute_nil span, "expected a SET span to be exported"
+      assert_equal trace_id, span["trace_id"]
+      assert_equal span_id, span["parent_span_id"]
+    end
+
+    # Test 10: Same as above, but for the non-transactional pipeline/batch path
+    # (send_batch_commands), which creates one Batch span for the whole pipeline.
+    def test_batch_span_is_child_of_parent_context_when_provider_registered
+      skip("OpenTelemetry tests only run on standalone mode") if cluster_mode?
+      assert ::Valkey::OpenTelemetry.initialized?
+
+      cleanup_test_files
+
+      trace_id = "5bf92f3577b34da6a3ce929d0e0e4737"
+      span_id = "11f067aa0ba902b8"
+
+      ::Valkey::OpenTelemetry.set_parent_span_context_provider do
+        { trace_id: trace_id, span_id: span_id, trace_flags: 1, tracestate: nil }
+      end
+
+      client = ::Valkey.new(host: "localhost", port: 6379)
+      client.pipelined do |pipeline|
+        pipeline.set("otel_parent_ctx_batch_1", "v1")
+        pipeline.get("otel_parent_ctx_batch_1")
+      end
+      client.close
+
+      wait_for_spans(TRACES_FILE, ["Batch"], expected_counts: { "Batch" => 1 }, timeout: 10.0)
+
+      span = read_spans(TRACES_FILE).find { |s| s["name"] == "Batch" }
+      refute_nil span, "expected a Batch span to be exported"
+      assert_equal trace_id, span["trace_id"]
+      assert_equal span_id, span["parent_span_id"]
     end
   end
 end


### PR DESCRIPTION
# Distributed Tracing (Parent Context Propagation) for valkey-glide-ruby

## Problem

`Valkey::OpenTelemetry` could create spans for commands, but every span was an
**independent root span**. `lib/valkey.rb` only ever called the parentless
`create_otel_span` / `create_batch_otel_span`, with `# TODO: add parent span
propagation` comments left unimplemented. As a result, Redis/Valkey command
spans never nested under an application's request trace — breaking the
"one connected trace per request" story that Ruby's
`opentelemetry-instrumentation-redis` provides for redis-rb today.

The Node.js GLIDE client already solves this: an app registers a
`parentSpanContextProvider` callback; before each command the client asks
for the current trace context and, if valid, creates the command span as a
**child** of that remote W3C context instead of a root span. The Rust FFI
core already shipped the native functions needed for this
(`create_otel_span_with_trace_context` / `create_batch_otel_span_with_trace_context`)
— they just weren't attached or called from Ruby. This change ports that
capability to Ruby.

## What changed

### `lib/valkey/bindings.rb`
Attached the two existing Rust FFI functions:

```ruby
attach_function :create_otel_span_with_trace_context,
                 [:int, :string, :string, :uint8, :string], :uint64
attach_function :create_batch_otel_span_with_trace_context,
                 [:string, :string, :uint8, :string], :uint64
```

`:string` params marshal a Ruby `nil` to a `NULL` pointer automatically,
matching Rust's nullable `trace_state`.

### `lib/valkey/opentelemetry.rb`
New public API on `Valkey::OpenTelemetry`:

- **`set_parent_span_context_provider(callable = nil, &block)`** — registers a
  callable invoked before every command. Pass `nil` (no block) to clear it.
- **`parent_span_context`** — invokes the registered provider, validates the
  result, and returns a Hash or `nil`. Never raises: a provider that throws,
  or returns something malformed, is caught, logged with `warn`, and treated
  as "no parent context" (falls back to an independent span).
- **`init(..., parent_span_context_provider: nil)`** — optional kwarg,
  equivalent to calling `set_parent_span_context_provider` separately.

Validation rules (checked before the value ever reaches the FFI call):

| Field | Rule |
|---|---|
| `trace_id` | String matching `/\A[0-9a-f]{32}\z/` |
| `span_id` | String matching `/\A[0-9a-f]{16}\z/` |
| `trace_flags` | Integer in `0..255` |
| `tracestate` | `nil` or String |

The Rust core still validates and falls back to an independent span on any
malformed remote context, so Ruby-side validation only needs to catch
obviously-wrong shapes before making the FFI call.

### `lib/valkey.rb`
Both command-dispatch paths now check for a parent context before creating a
span, and use the trace-context-aware FFI function when one is present:

- `send_command` (single commands)
- `send_batch_commands` (non-transactional pipelines — one `Batch` span for
  the whole pipeline)

Everything downstream (the actual `Bindings.command`/`Bindings.batch` call,
the `ensure`-block `drop_otel_span`) is unchanged — only *how* `span_ptr` is
created changes.

**Known, intentionally out-of-scope limitation:** if a pipelined block
contains `MULTI`/`EXEC`/`DISCARD`, `send_batch_commands` bypasses
`Bindings.batch` entirely and replays each queued command through
`send_command` individually (a pre-existing stability workaround for native
crashes in transactional batches). That means a `MULTI...EXEC` transaction
still gets **N independent spans** instead of one transaction span — this
change doesn't alter that. It does still improve: each of those N spans now
correctly links to the app's parent trace instead of being N disconnected
root spans.

## Usage

```ruby
require "valkey"
require "opentelemetry/sdk" # if your app uses the real opentelemetry-ruby gem

Valkey::OpenTelemetry.init(
  traces: { endpoint: "http://localhost:4318/v1/traces", sample_percentage: 10 }
)

Valkey::OpenTelemetry.set_parent_span_context_provider do
  span = ::OpenTelemetry::Trace.current_span
  next nil unless span.context.valid?

  {
    trace_id: span.context.hex_trace_id,
    span_id: span.context.hex_span_id,
    trace_flags: span.context.trace_flags.sampled? ? 1 : 0,
    tracestate: span.context.tracestate.to_s
  }
end
```

**Note on the `OpenTelemetry` constant name:** `Valkey::OpenTelemetry` (this
gem) and the real `opentelemetry-ruby` gem's top-level `::OpenTelemetry` are
unrelated constants and don't collide. But a bare `OpenTelemetry::Trace`
reference written from code lexically nested inside `Valkey` would resolve to
the (nonexistent) `Valkey::OpenTelemetry::Trace` instead of the real gem —
always use the leading-`::` form, `::OpenTelemetry::Trace`, as above.

## Files touched

| File | Change |
|---|---|
| `lib/valkey/bindings.rb` | New FFI bindings |
| `lib/valkey/opentelemetry.rb` | Provider registration/validation API |
| `lib/valkey.rb` | Wire both command paths to use parent context when available |
| `test/valkey/opentelemetry_provider_test.rb` | New — 12 unit tests (validation, resilience) |
| `test/valkey/opentelemetry_test.rb` | +2 integration tests (end-to-end trace linkage), `read_spans` helper |
| `test/standalone/valkey_test.rb` | New `TestOpenTelemetryProvider` class |
| `README.md` | New "Distributed tracing" section |
| `examples/opentelemetry.rb` | Extended with a provider demo |
| `CHANGELOG.md` | Pending entry |
| `.rubocop.yml` | Added `opentelemetry.rb` to `Metrics/ModuleLength` exclusions |

## Verification performed

- `bundle exec rubocop` — clean on all changed files.
- All 12 new unit tests pass (no server required).
- Both new end-to-end integration tests pass against a real local server —
  confirmed via the exported span JSON (`span_exporter_file.rs` writes
  `trace_id`/`span_id`/`parent_span_id` per span) that the resulting span's
  `trace_id` and `parent_span_id` exactly match the injected context.
  ```

