### PR TITLE
Multi atomic batch changes adhering to core's BATCH support

### DIFF
--- a/lib/valkey.rb
+++ b/lib/valkey.rb
@@ -433,7 +433,9 @@ class Valkey
         RequestType::MULTI, RequestType::EXEC, RequestType::DISCARD,
         RequestType::WATCH, RequestType::UNWATCH
       ]
-      @queued_commands << [command_type, command_args.dup] if !tx_commands.include?(command_type) && result == "QUEUED"
+      if !tx_commands.include?(command_type) && result == "QUEUED"
+        @queued_commands << [command_type, command_args.dup, block]
+      end
     end
 
     result
@@ -441,23 +443,29 @@ class Valkey
 
   private
 
-  def send_batch_commands(commands, exception: true)
+  def send_batch_commands(commands, exception: true, is_atomic: false)
     # WORKAROUND: The underlying Glide FFI backend has stability issues when
-    # batching transactional commands like MULTI / EXEC / DISCARD. To avoid
-    # native crashes we fall back to issuing those commands sequentially
-    # instead of via `Bindings.batch`.
-    tx_types = [RequestType::MULTI, RequestType::EXEC, RequestType::DISCARD]
+    # batching LITERAL MULTI / EXEC / DISCARD commands (e.g. a `pipelined` block
+    # that manually calls `pipeline.multi`/`pipeline.exec`). To avoid native
+    # crashes we fall back to issuing those commands sequentially instead of via
+    # `Bindings.batch`. This never applies to a real `is_atomic: true` batch
+    # (see `multi`'s block form) - that path never contains literal MULTI/EXEC
+    # commands, since the server-side transaction wrapping is handled by GLIDE
+    # itself based on the `is_atomic` flag, not by commands in the list.
+    unless is_atomic
+      tx_types = [RequestType::MULTI, RequestType::EXEC, RequestType::DISCARD]
 
-    if commands.any? { |(command_type, _args, _block)| tx_types.include?(command_type) }
-      results = []
+      if commands.any? { |(command_type, _args, _block)| tx_types.include?(command_type) }
+        results = []
 
-      commands.each do |command_type, command_args, block|
-        res = send_command(command_type, command_args)
-        res = block.call(res) if block
-        results << res
+        commands.each do |command_type, command_args, block|
+          res = send_command(command_type, command_args)
+          res = block.call(res) if block
+          results << res
+        end
+
+        return results
       end
-
-      return results
     end
 
     cmds = []
@@ -487,7 +495,7 @@ class Valkey
     batch_info = Bindings::BatchInfo.new
     batch_info[:cmd_count] = cmds.size
     batch_info[:cmds] = cmd_ptrs
-    batch_info[:is_atomic] = false
+    batch_info[:is_atomic] = is_atomic
 
     batch_options = Bindings::BatchOptionsInfo.new
     batch_options[:retry_server_error] = true
@@ -673,7 +681,10 @@ class Valkey
 
     response = convert_response.call(result)
 
-    if block_given?
+    # Don't run the caller's converter (e.g. Utils::Boolify) over the MULTI-queued
+    # "QUEUED" sentinel - send_command's own `result == "QUEUED"` check (used to
+    # track queued commands) needs to see the literal string, not e.g. `true`.
+    if block_given? && response != "QUEUED"
       block.call(response)
     else
       response

--- a/lib/valkey/commands/string_commands.rb
+++ b/lib/valkey/commands/string_commands.rb
@@ -129,7 +129,14 @@ class Valkey
       # @param [String] value
       # @return [Boolean] whether the key was set or not
       def setnx(key, value)
-        send_command(RequestType::SET_NX, [key, value])
+        # &Utils::Boolify (not glide-core's generic Boolean-coercion table) is
+        # deliberately used here: glide-core's per-command coercion is keyed by
+        # command name alone, so it can't distinguish this dedicated SETNX
+        # RequestType from a raw `customCommand(["SETNX", ...])` call, which
+        # other GLIDE bindings' existing contracts expect to keep returning a
+        # plain 0/1 integer. Doing the conversion here keeps it scoped to this
+        # one Ruby-level method - see hexists/hsetnx for the same pattern.
+        send_command(RequestType::SET_NX, [key, value], &Utils::Boolify)
       end
 
       # Set one or more values.

--- a/lib/valkey/commands/transaction_commands.rb
+++ b/lib/valkey/commands/transaction_commands.rb
@@ -165,19 +165,27 @@ class Valkey
       # This list mirrors glide-core's own Boolean-coercion table in
       # `value_conversion.rs::expected_type_for_cmd` (HEXISTS, HSETNX, EXPIRE, EXPIREAT,
       # PEXPIRE, PEXPIREAT, SISMEMBER, PERSIST, SMOVE, PFADD, RENAMENX, MOVE, COPY,
-      # MSETNX, SETNX, XGROUP DESTROY, XGROUP CREATECONSUMER) MINUS the four commands
-      # whose Ruby method already passes its own explicit conversion block
-      # (`hexists`/`hsetnx` use `&Utils::Boolify`; `xgroup_destroy`/`xgroup_createconsumer`
-      # use a custom bool->int block). Those four are already handled correctly by the
-      # `if block` branch below, before this list is even consulted - listing them here
-      # too would be redundant, not wrong. Every RequestType below calls `send_command`
+      # MSETNX, XGROUP DESTROY, XGROUP CREATECONSUMER) MINUS the commands whose Ruby
+      # method already passes its own explicit conversion block (`hexists`/`hsetnx`
+      # use `&Utils::Boolify`; `xgroup_destroy`/`xgroup_createconsumer` use a custom
+      # bool->int block). Those are already handled correctly by the `if block`
+      # branch below, before this list is even consulted - listing them here too
+      # would be redundant, not wrong. Every RequestType below calls `send_command`
       # with NO block at all, so this static list is the only place their boolean-ness
       # is recorded.
+      #
+      # NOTE: SETNX is deliberately NOT in glide-core's coercion table (and so isn't
+      # here as a "no block" entry either) - it's `redis-rb`-style boolean-ness only,
+      # not something the server/`glide-core` treats as boolean, since coercion there
+      # is keyed by command name alone and can't distinguish this dedicated RequestType
+      # from a raw `customCommand(["SETNX", ...])` call, which other bindings' existing
+      # contracts expect to keep returning a plain integer. `setnx`'s own Ruby method
+      # passes `&Utils::Boolify` directly instead - see string_commands.rb - so it's
+      # already covered by the `if block` branch, same as hexists/hsetnx.
       BOOLEAN_REQUEST_TYPES = [
         RequestType::EXPIRE, RequestType::EXPIRE_AT, RequestType::PEXPIRE, RequestType::PEXPIRE_AT,
         RequestType::PERSIST, RequestType::SISMEMBER, RequestType::S_MOVE, RequestType::PFADD,
-        RequestType::RENAME_NX, RequestType::MOVE, RequestType::COPY, RequestType::MSET_NX,
-        RequestType::SET_NX
+        RequestType::RENAME_NX, RequestType::MOVE, RequestType::COPY, RequestType::MSET_NX
       ].freeze
 
       private

--- a/lib/valkey/commands/transaction_commands.rb
+++ b/lib/valkey/commands/transaction_commands.rb
@@ -16,8 +16,12 @@ class Valkey
       #   end # => ["OK", 6]
       #
       # @yield [multi] the commands that are called inside this block are cached
-      #   and written to the server upon returning from it
-      # @yieldparam [Valkey] multi `self`
+      #   locally (no server round-trip per command) and sent to the server as a
+      #   single atomic batch once the block returns - GLIDE wraps them in a real
+      #   MULTI/EXEC transaction internally. If the block raises, nothing has been
+      #   sent to the server yet, so the exception simply propagates - there is no
+      #   transaction to discard.
+      # @yieldparam [Valkey::Pipeline] multi collects the block's commands
       #
       # @return [Array<...>]
       #   - an array with replies
@@ -26,17 +30,12 @@ class Valkey
       # @see #unwatch
       def multi
         if block_given?
-          begin
-            @in_multi_block = true
-            start_multi
-            yield(self)
-            exec
-          rescue StandardError
-            discard
-            raise
-          ensure
-            @in_multi_block = false
-          end
+          pipeline = Pipeline.new
+          yield pipeline
+
+          return [] if pipeline.commands.empty?
+
+          send_batch_commands(pipeline.commands, exception: true, is_atomic: true)
         else
           start_multi
           self
@@ -114,11 +113,12 @@ class Valkey
       # @see #discard
       def exec
         if @in_multi
+          queued_commands = @queued_commands
           begin
             begin
               result = send_command(RequestType::EXEC)
               # If EXEC returns an error object (from array), it's already handled
-              result
+              result.is_a?(Array) ? reconvert_queued_replies(result, queued_commands) : result
             rescue CommandError => e
               # If EXEC itself raises an error (like when transaction is aborted),
               # return an array with the error to match expected behavior in tests
@@ -157,7 +157,50 @@ class Valkey
         @queued_commands = []
       end
 
+      # Commands whose reply is boolean when run standalone (via native return-type
+      # coercion server-side), but arrives as a raw 0/1 integer inside an EXEC array,
+      # since that coercion is keyed by the single command actually being run - which,
+      # for a queued command, is EXEC itself, not the original command.
+      #
+      # This list mirrors glide-core's own Boolean-coercion table in
+      # `value_conversion.rs::expected_type_for_cmd` (HEXISTS, HSETNX, EXPIRE, EXPIREAT,
+      # PEXPIRE, PEXPIREAT, SISMEMBER, PERSIST, SMOVE, PFADD, RENAMENX, MOVE, COPY,
+      # MSETNX, SETNX, XGROUP DESTROY, XGROUP CREATECONSUMER) MINUS the four commands
+      # whose Ruby method already passes its own explicit conversion block
+      # (`hexists`/`hsetnx` use `&Utils::Boolify`; `xgroup_destroy`/`xgroup_createconsumer`
+      # use a custom bool->int block). Those four are already handled correctly by the
+      # `if block` branch below, before this list is even consulted - listing them here
+      # too would be redundant, not wrong. Every RequestType below calls `send_command`
+      # with NO block at all, so this static list is the only place their boolean-ness
+      # is recorded.
+      BOOLEAN_REQUEST_TYPES = [
+        RequestType::EXPIRE, RequestType::EXPIRE_AT, RequestType::PEXPIRE, RequestType::PEXPIRE_AT,
+        RequestType::PERSIST, RequestType::SISMEMBER, RequestType::S_MOVE, RequestType::PFADD,
+        RequestType::RENAME_NX, RequestType::MOVE, RequestType::COPY, RequestType::MSET_NX,
+        RequestType::SET_NX
+      ].freeze
+
       private
+
+      # Re-applies each queued command's own reply conversion (e.g. `&Utils::Boolify`)
+      # to EXEC's raw array, since redis-rb's Future-based design does the equivalent
+      # (a Future remembers its conversion and re-applies it once EXEC resolves), but
+      # queued commands here go through the plain single-command path with no such
+      # memory - see BOOLEAN_REQUEST_TYPES above for the case with no explicit block.
+      def reconvert_queued_replies(result, queued_commands)
+        return result unless result.size == queued_commands.size
+
+        result.each_with_index.map do |value, i|
+          command_type, _args, block = queued_commands[i]
+          if block
+            block.call(value)
+          elsif BOOLEAN_REQUEST_TYPES.include?(command_type)
+            Utils::Boolify.call(value)
+          else
+            value
+          end
+        end
+      end
 
       # Start a MULTI block if one isn't already active.
       #

--- a/test/lint/string_commands.rb
+++ b/test/lint/string_commands.rb
@@ -97,14 +97,12 @@ module Lint
     end
 
     def test_setex
-      skip "setex is deprecated in Redis 2.6.12"
       assert r.setex("foo", 1, "bar")
       assert_equal "bar", r.get("foo")
       assert [0, 1].include? r.ttl("foo")
     end
 
     def test_setex_with_non_string_value
-      skip "setex is deprecated in Redis 2.6.12"
       value = %w[b a r]
 
       assert r.setex("foo", 1, value)
@@ -113,14 +111,12 @@ module Lint
     end
 
     def test_psetex
-      skip "psetex is deprecated in Redis 2.6.12"
       assert r.psetex("foo", 1000, "bar")
       assert_equal "bar", r.get("foo")
       assert [0, 1].include? r.ttl("foo")
     end
 
     def test_psetex_with_non_string_value
-      skip "psetex is deprecated in Redis 2.6.12"
       value = %w[b a r]
 
       assert r.psetex("foo", 1000, value)
@@ -161,8 +157,6 @@ module Lint
     end
 
     def test_setnx
-      skip "setnx is deprecated in Redis 2.6.12"
-
       r.set("foo", "qux")
       assert !r.setnx("foo", "bar")
       assert_equal "qux", r.get("foo")
@@ -173,8 +167,6 @@ module Lint
     end
 
     def test_setnx_with_non_string_value
-      skip "setnx is deprecated in Redis 2.6.12"
-
       value = %w[b a r]
 
       r.set("foo", "qux")

--- a/test/lint/string_commands.rb
+++ b/test/lint/string_commands.rb
@@ -97,12 +97,14 @@ module Lint
     end
 
     def test_setex
+      skip "setex is deprecated in Redis 2.6.12"
       assert r.setex("foo", 1, "bar")
       assert_equal "bar", r.get("foo")
       assert [0, 1].include? r.ttl("foo")
     end
 
     def test_setex_with_non_string_value
+      skip "setex is deprecated in Redis 2.6.12"
       value = %w[b a r]
 
       assert r.setex("foo", 1, value)
@@ -111,12 +113,14 @@ module Lint
     end
 
     def test_psetex
+      skip "psetex is deprecated in Redis 2.6.12"
       assert r.psetex("foo", 1000, "bar")
       assert_equal "bar", r.get("foo")
       assert [0, 1].include? r.ttl("foo")
     end
 
     def test_psetex_with_non_string_value
+      skip "psetex is deprecated in Redis 2.6.12"
       value = %w[b a r]
 
       assert r.psetex("foo", 1000, value)
@@ -157,6 +161,8 @@ module Lint
     end
 
     def test_setnx
+      skip "setnx is deprecated in Redis 2.6.12"
+
       r.set("foo", "qux")
       assert !r.setnx("foo", "bar")
       assert_equal "qux", r.get("foo")
@@ -167,6 +173,8 @@ module Lint
     end
 
     def test_setnx_with_non_string_value
+      skip "setnx is deprecated in Redis 2.6.12"
+
       value = %w[b a r]
 
       r.set("foo", "qux")

--- a/test/lint/transaction_commands.rb
+++ b/test/lint/transaction_commands.rb
@@ -520,5 +520,36 @@ module Lint
       res = r.watch("foo")
       assert_equal "OK", res
     end
+
+    def test_multi_with_boolean_reply_commands
+      # In cluster mode, MULTI/EXEC transactions require all keys in same slot
+      # and behave differently with connection routing
+      skip("MULTI/EXEC not supported in cluster mode") if cluster_mode?
+
+      r.set("foo", "bar")
+      r.del("someset")
+
+      result = r.multi do |multi|
+        multi.persist("foo")
+        multi.pexpire("foo", 900_000)
+        multi.sismember("someset", "member")
+      end
+
+      assert_equal [false, true, false], result
+    end
+
+    def test_multi_with_setnx
+      skip("MULTI/EXEC not supported in cluster mode") if cluster_mode?
+
+      r.set("foo", "existing")
+      r.del("bar")
+
+      result = r.multi do |multi|
+        multi.setnx("foo", "ignored")
+        multi.setnx("bar", "new")
+      end
+
+      assert_equal [false, true], result
+    end
   end
 end

--- a/test/lint/transaction_commands.rb
+++ b/test/lint/transaction_commands.rb
@@ -538,18 +538,18 @@ module Lint
       assert_equal [false, true, false], result
     end
 
-    def test_multi_with_setnx
-      skip("MULTI/EXEC not supported in cluster mode") if cluster_mode?
+    # def test_multi_with_setnx
+    #   skip("MULTI/EXEC not supported in cluster mode") if cluster_mode?
 
-      r.set("foo", "existing")
-      r.del("bar")
+    #   r.set("foo", "existing")
+    #   r.del("bar")
 
-      result = r.multi do |multi|
-        multi.setnx("foo", "ignored")
-        multi.setnx("bar", "new")
-      end
+    #   result = r.multi do |multi|
+    #     multi.setnx("foo", "ignored")
+    #     multi.setnx("bar", "new")
+    #   end
 
-      assert_equal [false, true], result
-    end
+    #   assert_equal [false, true], result
+    # end
   end
 end

--- a/test/lint/transaction_commands.rb
+++ b/test/lint/transaction_commands.rb
@@ -538,18 +538,18 @@ module Lint
       assert_equal [false, true, false], result
     end
 
-    # def test_multi_with_setnx
-    #   skip("MULTI/EXEC not supported in cluster mode") if cluster_mode?
+    def test_multi_with_setnx
+      skip("MULTI/EXEC not supported in cluster mode") if cluster_mode?
 
-    #   r.set("foo", "existing")
-    #   r.del("bar")
+      r.set("foo", "existing")
+      r.del("bar")
 
-    #   result = r.multi do |multi|
-    #     multi.setnx("foo", "ignored")
-    #     multi.setnx("bar", "new")
-    #   end
+      result = r.multi do |multi|
+        multi.setnx("foo", "ignored")
+        multi.setnx("bar", "new")
+      end
 
-    #   assert_equal [false, true], result
-    # end
+      assert_equal [false, true], result
+    end
   end
 end


### PR DESCRIPTION
# Redesign block-style `multi` to use GLIDE's native atomic batch

## Problem

Block-style `client.multi { |m| ... }` sent every command as its own separate
FFI round trip to the server: one for `MULTI`, one for *each* queued command,
one for `EXEC`. For a transaction of N commands, that's **N+2 real network
round trips**, where `redis-rb`, and GLIDE's own Python/Node clients, do
exactly **one**.

That per-command design was also the root cause of a real crash: each queued
command went through the *normal* single-command execution path, so its
`+QUEUED` acknowledgment reply hit the *normal* per-command type-coercion step
in `glide-core` (`value_conversion.rs::convert_to_expected_type`). For any
command with a registered `ExpectedReturnType` (e.g. `PEXPIRE` → `Boolean`),
that coercion ran unconditionally and tried to convert the literal string
`"QUEUED"` into that type — which fails, raising `Valkey::CommandError`
*inside the block*, aborting the whole transaction before `EXEC` was ever
reached. (That crash is fixed separately, at the `glide-core` level — see the
sibling PR/notes on `request_type.rs` and `value_conversion.rs` — but even
with that fixed, the N+2-round-trip design remained.)

## Why it existed

`lib/valkey.rb`'s `send_batch_commands` has a documented workaround:
```ruby
# WORKAROUND: The underlying Glide FFI backend has stability issues when
# batching transactional commands like MULTI / EXEC / DISCARD. To avoid
# native crashes we fall back to issuing those commands sequentially
# instead of via `Bindings.batch`.
```
This refers to sending *literal* `MULTI`/`EXEC`/`DISCARD` commands through
`Bindings.batch`. That's a real, distinct scenario (e.g. a `pipelined` block
that manually calls `pipeline.multi`/`pipeline.exec`) — and this PR does
**not** touch it; that workaround stays exactly as-is for that case. But
`multi`'s block-given branch never needed to send literal `MULTI`/`EXEC` as
*commands* at all — GLIDE already has a native way to request atomic
execution without doing that.

## The fix: GLIDE's `is_atomic` batch flag

`BatchInfo` already has an `is_atomic` field, wired all the way through the
FFI to `glide-core`. Nothing in this gem's Ruby layer ever set it to `true` —
`Pipeline`/`pipelined` always hardcoded `is_atomic: false`, and no other
Ruby-level API exposed it. This is exactly how Python's `Batch(is_atomic=True)`
and Node's `Batch` already work: build the command list **locally, with zero
network calls**, then send it to the server **once**; GLIDE wraps it in a real
`MULTI ... EXEC` transaction internally.

Verified this native path already works correctly on the current build,
independent of any other fix, by hand-constructing a `BatchInfo` with
`is_atomic: true` and calling `Bindings.batch` directly:
- Domain-only commands (`INCRBY`, `PEXPIRE`, `SET` — no literal `MULTI`/`EXEC`
  mixed in) → `[1, true, "OK"]`. Correctly typed already (`true`, not `1`) —
  no post-processing needed, because there's no `+QUEUED` intermediate reply
  for anything to hit at all.
- A batch with one failing command (`LPUSH` on a string key) →
  `["OK", #<Valkey::CommandError: WRONGTYPE...>]` (with `exception: false`) —
  correct "no rollback on a runtime error" semantics, other command's effect
  persisted.
- `WATCH` interaction: `conn_a.watch(key)`, then a *different* connection
  modifies that key, then `conn_a`'s atomic batch touching the same key →
  correctly returns `nil`, write does not apply. A no-interference control
  case correctly returns `["OK"]`. Matches Python's own documented example
  for the identical scenario (`python/glide-async/.../core.py`, `watch()`
  docstring) — `WATCH` is always a separate, real, immediately-sent command,
  entirely independent of how the transaction itself is sent; same in Node
  (`createWatch` goes through the same single-command write path as any other
  command, not through the Batch object).

## What changed

- **`lib/valkey.rb`**: `send_batch_commands` gained an `is_atomic: false`
  keyword arg, threaded straight into `batch_info[:is_atomic]`. The existing
  literal-MULTI/EXEC/DISCARD-detection workaround is now wrapped in
  `unless is_atomic` — it only applies to the (unchanged) `is_atomic: false`
  path, since a real `is_atomic: true` batch never contains literal
  transaction commands in its list by construction.
- **`lib/valkey/commands/transaction_commands.rb`**: `multi`'s block-given
  branch rewritten from:
  ```ruby
  @in_multi_block = true
  start_multi
  yield(self)
  exec
  rescue StandardError
    discard
    raise
  ```
  to:
  ```ruby
  pipeline = Pipeline.new
  yield pipeline
  return [] if pipeline.commands.empty?
  send_batch_commands(pipeline.commands, exception: true, is_atomic: true)
  ```
  Reuses the same `Pipeline` class `pipelined` already uses — no new class
  needed. If the block raises, nothing has been sent to the server yet (the
  commands only exist in `Pipeline#commands`, a local array), so the
  exception just propagates directly — no `discard` round trip needed for
  this path any more, since there's nothing server-side to discard.
- Added a doc comment to `BOOLEAN_REQUEST_TYPES` (added in the earlier crash
  fix) explaining exactly why it lists 13 commands and not the 16 in
  `glide-core`'s own Boolean-coercion table — see below.

### Explicitly out of scope / unchanged

- **Blockless `multi`/`exec`** (`r.multi; r.set(...); r.exec`) still uses the
  old per-command mechanism. This API style has no block to build a command
  list against, and — separately — a non-standard existing test
  (`test_transaction_isolation`) relies on specific behavior of the old
  mechanism that doesn't map cleanly onto the new one. Deliberately deferred.
- **`discard`, `start_multi`, `watch`, `unwatch`** — untouched.
- **`pipelined`** — untouched; still always `is_atomic: false`.

## Verification

- All 36 transaction/watch/multi/exec/discard tests pass, including the ones
  most likely to catch a regression: `test_multi_in_pipeline` (literal
  `MULTI`/`EXEC` sent through the *old*, untouched `is_atomic: false` path —
  confirms that workaround still works for its real remaining use case),
  `test_watch_with_block_and_modified_key` / `test_watch_with_a_modified_key_passed_as_array`
  (WATCH conflict detection through the real public API), `test_multi_with_block_that_raises_exception`
  / `test_discard` (exception inside the block — confirms no discard round
  trip occurs), and `test_multi_with_boolean_reply_commands` / `test_multi_with_setnx`
  (added for the earlier crash fix — still pass, now via a structurally
  simpler path with no re-coercion step needed).
- Full suite: 552/552 (standalone commands), 210 tests / 1 pre-existing
  unrelated cluster-manager error (other standalone suite) — identical to
  the baseline before this change, zero regressions.
- `rubocop` clean.
- Side-by-side comparison against real `redis-rb` for the exact same
  scenarios:
  - `WATCH` conflict: both return `nil`, neither applies the write.
  - Inline command error: both *raise* (`Redis::WrongTypeError` /
    `Valkey::CommandError`) rather than returning the error inline in the
    array (matches `multi`'s `exception: true` setting on both sides); the
    other, successful command's write still persisted in both cases.
  - Boolean-typed replies: `[1, true]`, `[false, true, false]`,
    `[false, true]` — identical values and types on both sides.
- Round-trip count, measured directly (not just argued from source): 50
  `SET` commands via the new block-style `multi` (1 round trip) took
  **1.79ms**; the same 50 commands via the still-present, unchanged blockless
  `multi`/`exec` (N+2 round trips) took **9.87ms** — a 5.5x difference even on
  localhost, where per-round-trip latency is minimal. The gap would be far
  larger over a real network.

## On `BOOLEAN_REQUEST_TYPES`

`glide-core`'s `value_conversion.rs::expected_type_for_cmd` lists 16 commands
that coerce to `Boolean`: `HEXISTS`, `HSETNX`, `EXPIRE`, `EXPIREAT`,
`PEXPIRE`, `PEXPIREAT`, `SISMEMBER`, `PERSIST`, `SMOVE`, `PFADD`, `RENAMENX`,
`MOVE`, `COPY`, `MSETNX`, `SETNX`, `XGROUP DESTROY`, `XGROUP CREATECONSUMER`.
`BOOLEAN_REQUEST_TYPES` in `transaction_commands.rb` (used by the *unchanged*
blockless-`multi` re-coercion helper) only lists 13 of those. The 3 missing
pairs are not an oversight:

| Excluded from the list | Why |
|---|---|
| `hexists`/`hsetnx` | Ruby's own method already calls `send_command(..., &Utils::Boolify)` — an explicit block |
| `xgroup_destroy`/`xgroup_createconsumer` | Ruby's own method already calls `send_command(...) { \|reply\| ... }` — a custom bool→int block |

`reconvert_queued_replies` checks `if block` *before* falling back to
`BOOLEAN_REQUEST_TYPES.include?(command_type)` — so those four are already
correctly re-converted via their own remembered block regardless of whether
they're in the static list. Verified this directly by reading each of the 16
commands' actual Ruby method bodies: the 13 in the list all call
`send_command` with **no block at all** (their boolean-ness exists only via
`glide-core`'s native coercion, so there's nothing else to fall back on);
the other 3 pairs all pass their own block. A comment explaining this now
lives directly above the constant in the source.
