### PR TITLE
fix(dep): add irb to Gemfile to enable bundle exec bin/console w/ ruby 4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,10 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in valkey.gemspec
 gemspec
 
+# irb dropped out of Ruby's default gems in 4.0; older rubies (down to the
+# gemspec's minimum of 2.6) already ship it and must not have a version pinned.
+gem "irb" if RUBY_VERSION >= "4.0"
+
 gem "rake", "~> 13.0"
 
 gem "minitest", "~> 5.16"


### PR DESCRIPTION
### Summary

Adds irb to the Gemfile for ruby 4.

### Features / Changes
Add irb to the Gemfile with a filter for ruby >= 4. irb was demoted to a gem in ruby 4.

### Testing
I ran through the DEVELOPER.md instructions successfully and was able to run `bundle exec bin/console`.
All these tests pass:
```
bundle exec rubocop
bundle exec rake test:standalone
bundle exec rake test:cluster
```
### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] Documentation is updated (if applicable).
-   [x] Linters have been run (`bundle exec rubocop`) and pass.
-   [x] Destination branch is correct - main
