### PR TITLE
Standardize return type and add `flatten_map` option 

### DIFF
--- a/lib/valkey.rb
+++ b/lib/valkey.rb
@@ -291,6 +291,11 @@ class Valkey
     # Store cluster mode flag for response handling (MAP returns Hash in cluster, Array in standalone)
     @cluster_mode = options[:cluster_mode] ? true : false
 
+    # Returns GLIDE Core map as a flattened-map array
+    # Ex: { "key1" => "value1", "key2" => "value2" } becomes ["key1", "value1", "key2", "value2"]
+    # Compatibility for redis-rb 4.x
+    @flatten_map = options[:flatten_map] ? true : false
+
     # Track transactional state for `MULTI` / `EXEC` / `DISCARD` helpers.
     # This avoids Ruby warnings about uninitialised instance variables and
     # gives us a single source of truth for whether we're inside a TX.
@@ -435,7 +440,7 @@ class Valkey
         )
       end
 
-      result = convert_response(res, return_map_as_hash: @cluster_mode, &block)
+      result = convert_response(res, &block)
     ensure
       # Free the native CommandResult (arena + response + error) to prevent memory leak
       Bindings.free_command_result(res) if res && !res.null?
@@ -614,7 +619,7 @@ class Valkey
     [arg_ptrs, arg_lens, buffers]
   end
 
-  def convert_response(res, return_map_as_hash: false, &block)
+  def convert_response(res, &block)
     result = Bindings::CommandResult.new(res)
 
     if result[:response].null?
@@ -670,8 +675,7 @@ class Valkey
           map[map_key] = map_value
         end
 
-        # Return as Hash in cluster mode, flatten to pairs in standalone mode.
-        return_map_as_hash ? map : map.to_a.flatten(1)
+        @flatten_map ? map.to_a.flatten(1) : map
       when ResponseType::SETS
         ptr = response_item[:sets_value]
         count = response_item[:sets_value_len].to_i

--- a/lib/valkey/commands/connection_commands.rb
+++ b/lib/valkey/commands/connection_commands.rb
@@ -70,7 +70,7 @@ class Valkey
       #
       # @param [Integer] protover Protocol version (2 or 3)
       # @param [Hash] options Optional parameters like AUTH, SETNAME
-      # @return [Array] Server information as flat array (TODO: should be Hash for RESP3)
+      # @return [Hash] Server information (server, version, proto, id, mode, role, modules)
       def hello(protover = 3, **options)
         args = [protover]
 

--- a/lib/valkey/commands/list_commands.rb
+++ b/lib/valkey/commands/list_commands.rb
@@ -209,7 +209,7 @@ class Valkey
       #  - when `"RIGHT"` - the elements popped are those from the right of the list
       # @params count [Integer] a number of elements to pop
       #
-      # @return [Array<String, Array<String, Float>>] list of popped elements or nil
+      # @return [Hash, nil] hash mapping key to popped elements, or nil on timeout
       def blmpop(timeout, *keys, modifier: "LEFT", count: nil)
         raise ArgumentError, "Pick either LEFT or RIGHT" unless %w[LEFT RIGHT].include?(modifier)
 
@@ -235,7 +235,7 @@ class Valkey
       #  - when `"RIGHT"` - the elements popped are those from the right of the list
       # @params count [Integer] a number of elements to pop
       #
-      # @return [Array<String, Array<String, Float>>] list of popped elements or nil
+      # @return [Hash, nil] hash mapping key to popped elements, or nil if no elements
       def lmpop(*keys, modifier: "LEFT", count: nil)
         raise ArgumentError, "Pick either LEFT or RIGHT" unless %w[LEFT RIGHT].include?(modifier)
 

--- a/lib/valkey/commands/pubsub_commands.rb
+++ b/lib/valkey/commands/pubsub_commands.rb
@@ -168,7 +168,7 @@ class Valkey
       #     # => ["channel1", 5, "channel2", 3]
       #
       # @param [Array<String>] channels the channels to check
-      # @return [Array] channel names and subscriber counts
+      # @return [Hash] channel names mapped to subscriber counts
       #
       # @see https://valkey.io/commands/pubsub-numsub/
       def pubsub_numsub(*channels)
@@ -200,7 +200,7 @@ class Valkey
       #     # => ["shard1", 2, "shard2", 1]
       #
       # @param [Array<String>] channels the shard channels to check
-      # @return [Array] shard channel names and subscriber counts
+      # @return [Hash] shard channel names mapped to subscriber counts
       #
       # @see https://valkey.io/commands/pubsub-shardnumsub/
       def pubsub_shardnumsub(*channels)

--- a/lib/valkey/commands/stream_commands.rb
+++ b/lib/valkey/commands/stream_commands.rb
@@ -565,7 +565,7 @@ class Valkey
       # @param [Hash] options optional parameters
       #   - `:full => true`: return full information including entries
       #   - `:count => Integer`: limit number of entries (requires :full)
-      # @return [Array] stream information as flat array of key-value pairs
+      # @return [Hash] stream information as a hash of key-value pairs
       #
       # @example Get basic stream info
       #   valkey.xinfo_stream("mystream")

--- a/lib/valkey/commands/string_commands.rb
+++ b/lib/valkey/commands/string_commands.rb
@@ -320,7 +320,7 @@ class Valkey
       #   - `:idx => true`: Return the positions of the LCS
       #   - `:min_match_len => Integer`: Minimum match length
       #   - `:with_match_len => true`: Include match length in results
-      # @return [String, Integer, Array] the LCS result based on options
+      # @return [String, Integer, Hash] the LCS result based on options (Hash when idx: true)
       def lcs(key1, key2, len: nil, idx: nil, min_match_len: nil, with_match_len: nil)
         args = [key1, key2]
         args << "LEN" if len

--- a/lib/valkey/commands/vector_search_commands.rb
+++ b/lib/valkey/commands/vector_search_commands.rb
@@ -181,7 +181,7 @@ class Valkey
       #     # => ["index_name", "myIndex", "fields", [...], ...]
       #
       # @param [String] index the index name
-      # @return [Array] index information as array of key-value pairs
+      # @return [Hash] index information as a hash of key-value pairs
       #
       # @see https://redis.io/commands/ft.info/
       def ft_info(index)

--- a/test/lint/connection_commands.rb
+++ b/test/lint/connection_commands.rb
@@ -152,35 +152,20 @@ module Lint
 
     def test_hello_default
       result = r.hello
-      if cluster_mode?
-        assert_kind_of Hash, result
-        assert result.key?("server"), "HELLO response should contain server info"
-      else
-        assert_kind_of Array, result
-        assert result.include?("server"), "HELLO response should contain server info"
-      end
+      assert_kind_of Hash, result
+      assert result.key?("server"), "HELLO response should contain server info"
     end
 
     def test_hello_with_version
       result = r.hello(3)
-      if cluster_mode?
-        assert_kind_of Hash, result
-        assert_equal 3, result["proto"]
-      else
-        assert_kind_of Array, result
-        proto_index = result.index("proto")
-        assert_equal 3, result[proto_index + 1] if proto_index
-      end
+      assert_kind_of Hash, result
+      assert_equal 3, result["proto"]
     end
 
     def test_hello_with_setname
       client_name = "hello_lint_test"
       result = r.hello(3, setname: client_name)
-      if cluster_mode?
-        assert_kind_of Hash, result
-      else
-        assert_kind_of Array, result
-      end
+      assert_kind_of Hash, result
       # In cluster mode, HELLO and CLIENT GETNAME might hit different nodes
       # so we can't reliably assert the name was set
       assert_equal client_name, r.client_get_name unless cluster_mode?

--- a/test/lint/function_commands.rb
+++ b/test/lint/function_commands.rb
@@ -175,7 +175,7 @@ module Lint
     def test_function_stats
       target_version "7.0" do
         stats = r.function_stats
-        assert_kind_of Array, stats
+        assert_kind_of Hash, stats
       end
     end
 

--- a/test/lint/list_commands.rb
+++ b/test/lint/list_commands.rb
@@ -195,11 +195,11 @@ module Lint
         assert_nil r.blmpop(0.1, '{1}foo')
 
         r.lpush('{1}foo', %w[a b c d e f g])
-        assert_equal ['{1}foo', ['g']], r.blmpop(0.1, '{1}foo')
-        assert_equal ['{1}foo', %w[f e]], r.blmpop(0.1, '{1}foo', count: 2)
+        assert_equal({ '{1}foo' => ['g'] }, r.blmpop(0.1, '{1}foo'))
+        assert_equal({ '{1}foo' => %w[f e] }, r.blmpop(0.1, '{1}foo', count: 2))
 
         r.lpush('{1}foo2', %w[a b])
-        assert_equal ['{1}foo', ['a']], r.blmpop(0.1, '{1}foo', '{1}foo2', modifier: "RIGHT")
+        assert_equal({ '{1}foo' => ['a'] }, r.blmpop(0.1, '{1}foo', '{1}foo2', modifier: "RIGHT"))
       end
     end
 
@@ -209,11 +209,11 @@ module Lint
 
         r.lpush('{1}foo', %w[a b c d e f g])
 
-        assert_equal ['{1}foo', ['g']], r.lmpop('{1}foo')
-        assert_equal ['{1}foo', %w[f e]], r.lmpop('{1}foo', count: 2)
+        assert_equal({ '{1}foo' => ['g'] }, r.lmpop('{1}foo'))
+        assert_equal({ '{1}foo' => %w[f e] }, r.lmpop('{1}foo', count: 2))
 
         r.lpush('{1}foo2', %w[a b])
-        assert_equal ['{1}foo', ['a']], r.lmpop('{1}foo', '{1}foo2', modifier: "RIGHT")
+        assert_equal({ '{1}foo' => ['a'] }, r.lmpop('{1}foo', '{1}foo2', modifier: "RIGHT"))
       end
     end
   end

--- a/test/lint/pubsub_commands.rb
+++ b/test/lint/pubsub_commands.rb
@@ -31,21 +31,13 @@ module Lint
     def test_pubsub_numsub
       # Get subscriber counts for channels
       result = r.pubsub_numsub("channel1", "channel2")
-      if cluster_mode?
-        assert_kind_of Hash, result
-      else
-        assert_kind_of Array, result
-      end
+      assert_kind_of Hash, result
     end
 
     def test_pubsub_numsub_no_channels
       # Get subscriber counts with no channels specified
       result = r.pubsub_numsub
-      if cluster_mode?
-        assert_kind_of Hash, result
-      else
-        assert_kind_of Array, result
-      end
+      assert_kind_of Hash, result
     end
 
     def test_pubsub_shardchannels
@@ -82,7 +74,7 @@ module Lint
       omit_version("7.0")
       # Get subscriber counts for shard channels
       result = r.pubsub_shardnumsub("shard1", "shard2")
-      assert_kind_of Array, result
+      assert_kind_of Hash, result
     rescue Valkey::TimeoutError
       skip("Shard channel command timed out - cluster may be initializing")
     rescue Valkey::CommandError => e
@@ -126,11 +118,7 @@ module Lint
 
     def test_pubsub_convenience_method_numsub
       result = r.pubsub(:numsub, "channel1", "channel2")
-      if cluster_mode?
-        assert_kind_of Hash, result
-      else
-        assert_kind_of Array, result
-      end
+      assert_kind_of Hash, result
     end
 
     def test_pubsub_convenience_method_shardchannels
@@ -151,7 +139,7 @@ module Lint
       # Skipped on Redis 6.2 and earlier versions.
       omit_version("7.0")
       result = r.pubsub(:shardnumsub, "shard1", "shard2")
-      assert_kind_of Array, result
+      assert_kind_of Hash, result
     rescue Valkey::TimeoutError
       skip("Shard channel command timed out - cluster may be initializing")
     rescue Valkey::CommandError => e

--- a/test/lint/stream_commands.rb
+++ b/test/lint/stream_commands.rb
@@ -368,12 +368,8 @@ module Lint
 
       # Get basic stream info
       info = r.xinfo_stream("mystream")
-      if cluster_mode?
-        assert_kind_of Hash, info
-      else
-        assert_kind_of Array, info
-        assert_operator info.length, :>, 0
-      end
+      assert_kind_of Hash, info
+      assert_operator info.length, :>, 0
 
       r.del "mystream"
     end

--- a/test/lint/string_commands.rb
+++ b/test/lint/string_commands.rb
@@ -337,32 +337,32 @@ module Lint
         r.mset('{1}key1', 'ohmytext', '{1}key2', 'mynewtext')
         assert_equal "mytext", r.lcs('{1}key1', '{1}key2')
 
-        assert_equal ["matches", [
-          [
-            [4, 7],
-            [5, 8]
-          ],
-          [
-            [2, 3],
-            [0, 1]
-          ]
-        ], "len", 6], r.lcs('{1}key1', '{1}key2', idx: true)
+        assert_equal({ "matches" => [
+                       [
+                         [4, 7],
+                         [5, 8]
+                       ],
+                       [
+                         [2, 3],
+                         [0, 1]
+                       ]
+                     ], "len" => 6 }, r.lcs('{1}key1', '{1}key2', idx: true))
 
-        assert_equal ["matches", [
-          [
-            [4, 7],
-            [5, 8]
-          ]
-        ], "len", 6], r.lcs('{1}key1', '{1}key2', idx: true, min_match_len: 4)
+        assert_equal({ "matches" => [
+                       [
+                         [4, 7],
+                         [5, 8]
+                       ]
+                     ], "len" => 6 }, r.lcs('{1}key1', '{1}key2', idx: true, min_match_len: 4))
       end
 
-      assert_equal ["matches", [
-        [
-          [4, 7],
-          [5, 8],
-          4
-        ]
-      ], "len", 6], r.lcs('{1}key1', '{1}key2', idx: true, min_match_len: 4, with_match_len: true)
+      assert_equal({ "matches" => [
+                     [
+                       [4, 7],
+                       [5, 8],
+                       4
+                     ]
+                   ], "len" => 6 }, r.lcs('{1}key1', '{1}key2', idx: true, min_match_len: 4, with_match_len: true))
     end
   end
 end

--- a/test/lint/vector_search_commands.rb
+++ b/test/lint/vector_search_commands.rb
@@ -132,13 +132,12 @@ module Lint
         r.ft_create(TEST_INDEX, "SCHEMA", "title", "TEXT")
 
         # Get index info
-        # Note: FT.INFO returns a complex Map structure that may not be fully supported yet
+        # Note: FT.INFO returns a MAP structure from glide-core
         info = r.ft_info(TEST_INDEX)
-        assert_kind_of Array, info
+        assert_kind_of Hash, info
 
         # Info should contain index_name
-        assert info.include?("index_name") || info.any? { |item| item.is_a?(Array) && item.include?("index_name") },
-               "Info should contain index_name"
+        assert info.key?("index_name"), "Info should contain index_name"
       end
     rescue Valkey::CommandError => e
       skip_if_redisearch_unavailable(e)

--- a/test/standalone/valkey_test.rb
+++ b/test/standalone/valkey_test.rb
@@ -23,6 +23,7 @@ class TestStandaloneValkey < Minitest::Test
   include ValkeyTests::Statistics
   include ValkeyTests::URIConnection
   include ValkeyTests::Utils
+  include ValkeyTests::FlattenMap
 
   # Property-based test modules for eval/evalsha
   include ValkeyTests::EvalEvalshaBasicProperties

--- a/test/valkey/flatten_map_test.rb
+++ b/test/valkey/flatten_map_test.rb
@@ -4,23 +4,36 @@ module ValkeyTests
   module FlattenMap
     # Verifies the MAP response type branch in convert_response:
     #   @flatten_map ? map.to_a.flatten(1) : map
-    # Uses HELLO (returns MAP from glide-core) as representative command.
+
+    def flatten_client
+      @flatten_client ||= begin
+        address = Helper::Client.server_address
+        Valkey.new(host: address[:host], port: address[:port], timeout: TIMEOUT, flatten_map: true)
+      end
+    end
+
+    def teardown_flatten_client
+      @flatten_client&.close
+      @flatten_client = nil
+    end
+
+    # Hook into existing teardown
+    def teardown
+      teardown_flatten_client
+      super
+    end
+
+    # --- Core flatten_map behavior ---
 
     def test_flatten_map_default_returns_hash
-      address = Helper::Client.server_address
-      client = Valkey.new(host: address[:host], port: address[:port], timeout: TIMEOUT)
-      result = client.hello
+      result = r.hello
       assert_kind_of Hash, result
       assert %w[valkey redis].include?(result["server"]), "Expected server to be valkey or redis"
       assert_equal "standalone", result["mode"]
-    ensure
-      client&.close
     end
 
     def test_flatten_map_true_returns_flat_array
-      address = Helper::Client.server_address
-      client = Valkey.new(host: address[:host], port: address[:port], timeout: TIMEOUT, flatten_map: true)
-      result = client.hello
+      result = flatten_client.hello
 
       assert_kind_of Array, result
       server_idx = result.index("server")
@@ -30,8 +43,73 @@ module ValkeyTests
       mode_idx = result.index("mode")
       refute_nil mode_idx, "Expected 'mode' key in flattened array"
       assert_equal "standalone", result[mode_idx + 1]
+    end
+
+    # --- Commands with Hashify post-processing blocks ---
+    # These must return correct results regardless of flatten_map
+
+    def test_flatten_map_hgetall
+      flatten_client.hset("_fm_hash", "a", "1", "b", "2")
+      result = flatten_client.hgetall("_fm_hash")
+
+      assert_kind_of Hash, result
+      assert_equal({ "a" => "1", "b" => "2" }, result)
     ensure
-      client&.close
+      flatten_client.del("_fm_hash")
+    end
+
+    def test_flatten_map_config_get
+      result = flatten_client.config_get("maxmemory")
+
+      assert_kind_of Hash, result
+      assert result.key?("maxmemory")
+    end
+
+    def test_flatten_map_xrange
+      flatten_client.xadd("_fm_stream", { "f1" => "v1" }, id: "1-0")
+      flatten_client.xadd("_fm_stream", { "f2" => "v2" }, id: "2-0")
+
+      result = flatten_client.xrange("_fm_stream", "-", "+")
+      assert_kind_of Array, result
+      assert_equal 2, result.length
+      assert_equal "1-0", result[0][0]
+      assert_includes result[0][1].flatten, "f1"
+    ensure
+      flatten_client.del("_fm_stream")
+    end
+
+    def test_flatten_map_xrevrange
+      flatten_client.xadd("_fm_stream2", { "f1" => "v1" }, id: "1-0")
+      flatten_client.xadd("_fm_stream2", { "f2" => "v2" }, id: "2-0")
+
+      result = flatten_client.xrevrange("_fm_stream2")
+      assert_kind_of Array, result
+      assert_equal 2, result.length
+      assert_equal "2-0", result[0][0]
+    ensure
+      flatten_client.del("_fm_stream2")
+    end
+
+    def test_flatten_map_xread
+      flatten_client.xadd("_fm_xread", { "k" => "v" }, id: "1-0")
+
+      result = flatten_client.xread(["_fm_xread"], ["0"])
+      assert_kind_of Hash, result
+      assert result.key?("_fm_xread")
+      assert_kind_of Array, result["_fm_xread"]
+    ensure
+      flatten_client.del("_fm_xread")
+    end
+
+    def test_flatten_map_hrandfield_with_values
+      flatten_client.hset("_fm_hrand", "a", "1", "b", "2", "c", "3")
+
+      result = flatten_client.hrandfield("_fm_hrand", 2, with_values: true)
+      assert_kind_of Array, result
+      assert_equal 2, result.length
+      assert_equal 2, result[0].length
+    ensure
+      flatten_client.del("_fm_hrand")
     end
   end
 end

--- a/test/valkey/flatten_map_test.rb
+++ b/test/valkey/flatten_map_test.rb
@@ -11,7 +11,7 @@ module ValkeyTests
       client = Valkey.new(host: address[:host], port: address[:port], timeout: TIMEOUT)
       result = client.hello
       assert_kind_of Hash, result
-      assert_equal "valkey", result["server"]
+      assert %w[valkey redis].include?(result["server"]), "Expected server to be valkey or redis"
       assert_equal "standalone", result["mode"]
     ensure
       client&.close
@@ -25,7 +25,7 @@ module ValkeyTests
       assert_kind_of Array, result
       server_idx = result.index("server")
       refute_nil server_idx, "Expected 'server' key in flattened array"
-      assert_equal "valkey", result[server_idx + 1]
+      assert %w[valkey redis].include?(result[server_idx + 1]), "Expected server value to be valkey or redis"
 
       mode_idx = result.index("mode")
       refute_nil mode_idx, "Expected 'mode' key in flattened array"

--- a/test/valkey/flatten_map_test.rb
+++ b/test/valkey/flatten_map_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module ValkeyTests
+  module FlattenMap
+    # Verifies the MAP response type branch in convert_response:
+    #   @flatten_map ? map.to_a.flatten(1) : map
+    # Uses HELLO (returns MAP from glide-core) as representative command.
+
+    def test_flatten_map_default_returns_hash
+      address = Helper::Client.server_address
+      client = Valkey.new(host: address[:host], port: address[:port], timeout: TIMEOUT)
+      result = client.hello
+      assert_kind_of Hash, result
+      assert_equal "valkey", result["server"]
+      assert_equal "standalone", result["mode"]
+    ensure
+      client&.close
+    end
+
+    def test_flatten_map_true_returns_flat_array
+      address = Helper::Client.server_address
+      client = Valkey.new(host: address[:host], port: address[:port], timeout: TIMEOUT, flatten_map: true)
+      result = client.hello
+
+      assert_kind_of Array, result
+      server_idx = result.index("server")
+      refute_nil server_idx, "Expected 'server' key in flattened array"
+      assert_equal "valkey", result[server_idx + 1]
+
+      mode_idx = result.index("mode")
+      refute_nil mode_idx, "Expected 'mode' key in flattened array"
+      assert_equal "standalone", result[mode_idx + 1]
+    ensure
+      client&.close
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Standardized return type to always convert GLIDE Core map to Ruby Hash. A `flatten_map` option is added as backward compatibility that matches redis-rb 4.x return types. 

## Changes

- `lib/valkey.rb`: Add `@flatten_map` instance variable from `options[:flatten_map]`; replace the `return_map_as_hash` / `@cluster_mode` conditional with `@flatten_map`
- Test updates: Remove `if cluster_mode?` branching that previously differentiated Hash (cluster) vs Array (standalone) — MAP responses are now always Hash by default regardless of mode
- `test/valkey/flatten_map_test.rb`: New integration test verifying both branches using HELLO command

## Usage

```ruby
# Default: MAP responses return as Hash
client = Valkey.new(host: "localhost", port: 6379)
client.hello  # => {"server"=>"valkey", "version"=>"9.0.2", ...}

# redis-rb 4.x compat: MAP responses flattened to Array
client = Valkey.new(host: "localhost", port: 6379, flatten_map: true)
client.hello  # => ["server", "valkey", "version", "9.0.2", ...]
```

## Testing

- `bundle exec rubocop` — passes
- `bundle exec rake test:standalone` — 770 tests, 0 failures
- `bundle exec rake test:cluster` — 776 tests, 0 failures

## Checklist

- [x] Related to one change
- [x] Tests added/updated
- [x] Linters pass
- [ ] Destination branch: release-1.0
