### PR TITLE
ci: fix and sync dependabot config

### DIFF
--- a/.github/depdendabot.yml
+++ b/.github/depdendabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 5
+    # Wait 7 days before proposing updates to newly published versions —
+    # protects against malicious/unstable early releases (supply chain).
+    # See: https://semgrep.dev/r?q=dependabot-missing-cooldown
+    cooldown:
+      default-days: 7
+    groups:
+      patch-updates:
+        update-types:
+          - "patch"
+      minor-updates:
+        update-types:
+          - "minor"
+    labels:
+      - "dependencies"
+      - "github-actions"


### PR DESCRIPTION
### Summary

The repo's Dependabot config was committed as `.github/depdendabot.yml` — a misspelling of `dependabot.yml`. GitHub only reads `.github/dependabot.yml`, so the file was inert and **no GitHub Actions version updates ever ran**.

This renames it to the correct path and aligns the `github-actions` entry with the `valkey-glide` monorepo config, so the workflow action pins actually get weekly update PRs.

### Features / Changes

- Remove misspelled `.github/depdendabot.yml`.
- Add `.github/dependabot.yml` matching the monorepo's `github-actions` block:
  - weekly schedule (Monday 09:00)
  - `open-pull-requests-limit: 5`
  - grouped `patch-updates` / `minor-updates`
  - labels: `dependencies`, `github-actions`

Scope kept minimal (github-actions only), matching the sibling `valkey-py` repo. No `bundler` entry added.

### Testing

- Validated the new YAML parses.
- No CI/runtime behavior changes beyond enabling Dependabot's Actions update PRs.

### Checklist

-   [ ] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] Documentation is updated (if applicable).
-   [x] Linters have been run (`bundle exec rubocop`) and pass.
-   [x] Destination branch is correct - main
