### PR TITLE
Updating eval & evalsha to adhere to flexible positional form like re…

### DIFF
--- a/lib/valkey/commands/scripting_commands.rb
+++ b/lib/valkey/commands/scripting_commands.rb
@@ -137,12 +137,21 @@ class Valkey
       # @example Execute script that returns different data types
       #   valkey.eval("return {1, 'hello', true, nil}")
       #     # => [1, "hello", true, nil]
+      # @example Positional form, matching redis-rb's eval(script, keys, argv)
+      #   valkey.eval("return KEYS[1] .. ARGV[1]", ["mykey"], ["myarg"])
+      #     # => "mykeynyarg"
       # Since the eval is not available in the rust backend
       # using the load and invoke script
-      def eval(script, keys: [], args: [])
+      def eval(script, *rest, keys: nil, args: nil)
         # Validate script parameter
         raise ArgumentError, "script must be a string" unless script.is_a?(String)
         raise ArgumentError, "script cannot be empty" if script.empty?
+
+        # Accept redis-rb's flexible positional form - eval(script, keys, argv)
+        # - in addition to the keyword form, mirroring the same treatment
+        # applied to evalsha (see that method for the full rationale).
+        keys ||= rest[0] || []
+        args ||= rest[1] || []
 
         # Validate and convert keys and args to strings
         begin
@@ -181,12 +190,21 @@ class Valkey
       #   rescue Valkey::CommandError => e
       #     puts "Script not found: #{e.message}"
       #   end
+      # @example Positional form, matching redis-rb's evalsha(sha, keys, argv)
+      #   valkey.evalsha(sha, ["user"], ["123"])
+      #     # => "user:123"
       # Since evalsha is not available in rust backend
       # using invoke script
-      def evalsha(sha, keys: [], args: [])
+      def evalsha(sha, *rest, keys: nil, args: nil)
         # Validate SHA1 hash parameter
         raise ArgumentError, "sha1 hash must be a string" unless sha.is_a?(String)
         raise ArgumentError, "sha1 hash must be a 40-character hexadecimal string" unless valid_sha1?(sha)
+
+        # Accept redis-rb's flexible positional form - evalsha(sha, keys, argv)
+        # - in addition to the keyword form, so code written against redis-rb's
+        # API (e.g. redis_display_id) doesn't need to special-case this client.
+        keys ||= rest[0] || []
+        args ||= rest[1] || []
 
         # Validate and convert keys and args to strings
         begin


### PR DESCRIPTION
# Accept redis-rb's flexible positional args in `eval`/`evalsha`

## Problem

`eval`/`evalsha` only accept `keys`/`args` as keyword arguments:

```ruby
def evalsha(sha, keys: [], args: [])
def eval(script, keys: [], args: [])
```

`redis-rb`'s equivalents are both built on a single flexible, variadic
helper:

```ruby
def evalsha(*args)
  _eval(:evalsha, args)
end

def _eval(cmd, args)
  script = args.shift
  options = args.pop if args.last.is_a?(Hash)
  keys = args.shift || options[:keys] || []
  argv = args.shift || options[:argv] || []
  send_command([cmd, script, keys.length] + keys + argv)
end
```

which happily accepts `redis.evalsha(sha, keys_array, argv_array)` -
plain positional arguments, no labels. Any code written against
`redis-rb` this way (found via a real migration: a shared internal gem,
`redis_display_id`, calls `redis.evalsha(sha, [:keys], keys)` internally)
breaks immediately against this gem with:

```
ArgumentError: wrong number of arguments (given 3, expected 1)
```

- not because the *data* is wrong, but because Ruby rejects extra
positional arguments before ever considering whether they were meant for
`keys:`/`args:`.

## What changed

**`lib/valkey/commands/scripting_commands.rb`** - `eval` and `evalsha`
both gained a splat, with the keyword defaults changed from `[]` to
`nil` so a positional value can fill the same slot:

```ruby
def evalsha(sha, *rest, keys: nil, args: nil)
  ...
  keys ||= rest[0] || []
  args ||= rest[1] || []
  ...
end

def eval(script, *rest, keys: nil, args: nil)
  ...
  keys ||= rest[0] || []
  args ||= rest[1] || []
  ...
end
```

Both calling styles now work identically:

```ruby
valkey.evalsha(sha, keys: ["user"], args: ["123"])   # keyword (unchanged)
valkey.evalsha(sha, ["user"], ["123"])               # positional (new)
```

No change to `invoke_script`, the FFI layer, or return-value handling -
this is purely a Ruby-level argument-parsing change in the two public
wrapper methods.

## Verification

- Both calling styles produce identical results against a live server:
  ```
  evalsha keyword form:    v.evalsha(sha, keys: [:keys], args: keys) => "100"
  evalsha positional form: v.evalsha(sha, [:keys], keys)             => "100"
  eval keyword form:       v.eval(script, keys: ["user"], args: ["123"]) => "user:123"
  eval positional form:    v.eval(script, ["user"], ["123"])             => "user:123"
  ```
