### PR TITLE
Flatten nested Array/Hash command arguments, matching redis-client

### DIFF
--- a/lib/valkey.rb
+++ b/lib/valkey.rb
@@ -378,7 +378,10 @@ class Valkey
       arg_lens.put_ulong(0, 0)
       _buffers = [] # nothing to keep alive
     else
-      arg_ptrs, arg_lens, _buffers = build_command_args(command_args)
+      # Reassign command_args to the (possibly flattened) array build_command_args
+      # actually built arg_ptrs/arg_lens from - see that method for why using the
+      # original, pre-flatten array's size below would go out of sync with them.
+      arg_ptrs, arg_lens, _buffers, command_args = build_command_args(command_args)
     end
 
     # Create OpenTelemetry span if sampling is enabled, as a child of the app's current
@@ -497,7 +500,10 @@ class Valkey
     buffers = [] # Keep references to prevent GC
 
     commands.each do |command_type, command_args, block|
-      arg_ptrs, arg_lens, arg_bufs = build_command_args(command_args)
+      # Reassign to the (possibly flattened) array build_command_args actually
+      # built arg_ptrs/arg_lens from - see that method for why the original,
+      # pre-flatten array's size would go out of sync with them below.
+      arg_ptrs, arg_lens, arg_bufs, command_args = build_command_args(command_args)
 
       cmd = Bindings::CmdInfo.new
       cmd[:request_type] = command_type
@@ -602,9 +608,25 @@ class Valkey
   end
 
   def build_command_args(command_args)
+    # Mirror redis-client's CommandBuilder#generate: flat_map every element,
+    # turning a Hash into alternating key/value pairs (same one-level
+    # auto-flatten redis-client gets from flat_map on a plain Array element
+    # too, as a side effect of flat_map's own semantics - not Hash-specific).
+    # Every existing caller in this codebase already pre-flattens its own
+    # arguments (see e.g. hset/mset/zadd/keys.flatten!), so this is a no-op
+    # for them - it only changes behavior for a caller that passes a raw,
+    # un-flattened Array/Hash straight through, which previously got
+    # silently mis-serialized via Array#to_s/Hash#to_s into one garbled
+    # string argument instead of several real ones.
+    command_args = command_args.flat_map { |el| el.is_a?(Hash) ? el.flatten : el }
+
     # For empty arrays, pass NULL pointers as per Rust FFI contract
     # This matches Go's approach which successfully uses nil pointers
-    return [FFI::Pointer::NULL, FFI::Pointer::NULL, []] if command_args.empty?
+    # Also returns the (possibly flattened) command_args - callers must use
+    # THIS array's size for the FFI arg_count, not their own original
+    # pre-flatten local variable, or arg_count and arg_ptrs/arg_lens go out
+    # of sync when flattening actually changed the element count.
+    return [FFI::Pointer::NULL, FFI::Pointer::NULL, [], []] if command_args.empty?
 
     arg_ptrs = FFI::MemoryPointer.new(:pointer, command_args.size)
     arg_lens = FFI::MemoryPointer.new(:ulong, command_args.size)
@@ -619,7 +641,7 @@ class Valkey
       arg_lens.put_ulong(i * 8, arg.bytesize)
     end
 
-    [arg_ptrs, arg_lens, buffers]
+    [arg_ptrs, arg_lens, buffers, command_args]
   end
 
   def convert_response(res, return_map_as_hash: false, &block)

--- a/lib/valkey.rb
+++ b/lib/valkey.rb
@@ -608,7 +608,10 @@ class Valkey
   # collapsing into one garbled Array#to_s/Hash#to_s string. Returns the
   # flattened command_args too - callers must size arg_count off this returned
   # array, not their original pre-flatten one, or arg_count goes out of sync
-  # with arg_ptrs/arg_lens.
+  # with arg_ptrs/arg_lens. Each element's type is checked against the same
+  # allow-list redis-client's CommandBuilder#generate uses (String, Symbol,
+  # Integer, Float) - anything else, including nil, raises TypeError instead
+  # of being silently coerced via #to_s (e.g. nil.to_s => "").
   def build_command_args(command_args)
     # Flatten nested Arrays/Hashes to match redis-client's behavior.
     command_args = command_args.flat_map { |el| el.is_a?(Hash) ? el.flatten : el }
@@ -622,9 +625,14 @@ class Valkey
     buffers = []
 
     command_args.each_with_index do |arg, i|
-      arg = arg.to_s # Ensure we convert to string
+      arg = case arg
+            when String, Symbol, Integer, Float
+              arg.to_s
+            else
+              raise TypeError, "Unsupported command argument type: #{arg.class}"
+            end
 
-      buf = FFI::MemoryPointer.from_string(arg.to_s)
+      buf = FFI::MemoryPointer.from_string(arg)
       buffers << buf # prevent garbage collection
       arg_ptrs.put_pointer(i * FFI::Pointer.size, buf)
       arg_lens.put_ulong(i * 8, arg.bytesize)

--- a/lib/valkey.rb
+++ b/lib/valkey.rb
@@ -377,11 +377,9 @@ class Valkey
       arg_ptrs.put_pointer(0, FFI::MemoryPointer.new(1))
       arg_lens.put_ulong(0, 0)
       _buffers = [] # nothing to keep alive
+      flattened_args = command_args
     else
-      # Reassign command_args to the (possibly flattened) array build_command_args
-      # actually built arg_ptrs/arg_lens from - see that method for why using the
-      # original, pre-flatten array's size below would go out of sync with them.
-      arg_ptrs, arg_lens, _buffers, command_args = build_command_args(command_args)
+      arg_ptrs, arg_lens, _buffers, flattened_args = build_command_args(command_args)
     end
 
     # Create OpenTelemetry span if sampling is enabled, as a child of the app's current
@@ -413,7 +411,7 @@ class Valkey
           @connection,
           channel,
           command_type,
-          command_args.size,
+          flattened_args.size,
           arg_ptrs,
           arg_lens,
           route_info.to_ptr,
@@ -429,7 +427,7 @@ class Valkey
           @connection,
           channel,
           command_type,
-          command_args.size,
+          flattened_args.size,
           arg_ptrs,
           arg_lens,
           route_buf,
@@ -500,15 +498,12 @@ class Valkey
     buffers = [] # Keep references to prevent GC
 
     commands.each do |command_type, command_args, block|
-      # Reassign to the (possibly flattened) array build_command_args actually
-      # built arg_ptrs/arg_lens from - see that method for why the original,
-      # pre-flatten array's size would go out of sync with them below.
-      arg_ptrs, arg_lens, arg_bufs, command_args = build_command_args(command_args)
+      arg_ptrs, arg_lens, arg_bufs, flattened_args = build_command_args(command_args)
 
       cmd = Bindings::CmdInfo.new
       cmd[:request_type] = command_type
       cmd[:args] = arg_ptrs
-      cmd[:arg_count] = command_args.size
+      cmd[:arg_count] = flattened_args.size
       cmd[:args_len] = arg_lens
 
       cmds << cmd
@@ -607,25 +602,19 @@ class Valkey
     { "manual_interval" => { "duration_in_sec" => duration_in_sec } }
   end
 
+  # Builds the FFI arg_ptrs/arg_lens/buffers for command_args, flattening nested
+  # Array/Hash elements first (mirroring redis-client's CommandBuilder#generate)
+  # so callers like hset(key, [field, value]) serialize correctly instead of
+  # collapsing into one garbled Array#to_s/Hash#to_s string. Returns the
+  # flattened command_args too - callers must size arg_count off this returned
+  # array, not their original pre-flatten one, or arg_count goes out of sync
+  # with arg_ptrs/arg_lens.
   def build_command_args(command_args)
-    # Mirror redis-client's CommandBuilder#generate: flat_map every element,
-    # turning a Hash into alternating key/value pairs (same one-level
-    # auto-flatten redis-client gets from flat_map on a plain Array element
-    # too, as a side effect of flat_map's own semantics - not Hash-specific).
-    # Every existing caller in this codebase already pre-flattens its own
-    # arguments (see e.g. hset/mset/zadd/keys.flatten!), so this is a no-op
-    # for them - it only changes behavior for a caller that passes a raw,
-    # un-flattened Array/Hash straight through, which previously got
-    # silently mis-serialized via Array#to_s/Hash#to_s into one garbled
-    # string argument instead of several real ones.
+    # Flatten nested Arrays/Hashes to match redis-client's behavior.
     command_args = command_args.flat_map { |el| el.is_a?(Hash) ? el.flatten : el }
 
     # For empty arrays, pass NULL pointers as per Rust FFI contract
     # This matches Go's approach which successfully uses nil pointers
-    # Also returns the (possibly flattened) command_args - callers must use
-    # THIS array's size for the FFI arg_count, not their own original
-    # pre-flatten local variable, or arg_count and arg_ptrs/arg_lens go out
-    # of sync when flattening actually changed the element count.
     return [FFI::Pointer::NULL, FFI::Pointer::NULL, [], []] if command_args.empty?
 
     arg_ptrs = FFI::MemoryPointer.new(:pointer, command_args.size)

--- a/lib/valkey/commands/generic_commands.rb
+++ b/lib/valkey/commands/generic_commands.rb
@@ -580,15 +580,15 @@ class Valkey
 
       private
 
-      # Flattens Arrays and Hashes (to alternating key/value), matching
-      # `redis-client`'s documented `#call`/`#call_v` behavior. Leaf values are
-      # left as-is - `build_command_args` type-checks and stringifies them, so
-      # an unsupported leaf (e.g. `nil`) raises `TypeError` there instead of
-      # being silently coerced to `""` here.
+      # Flattens Arrays and Hashes (to alternating key/value) and stringifies
+      # Integers/Floats/Symbols, matching `redis-client`'s documented
+      # `#call`/`#call_v` behavior - including its type check: any leaf that
+      # isn't a String/Symbol/Integer/Float (e.g. `nil`) raises `TypeError`
+      # instead of being silently coerced to `""` via `#to_s`.
       #
       # @example
       #   flatten_call_args(["CMD", [1, [2, 3]], { "a" => 1, "b" => [2, 3] }])
-      #   # => ["CMD", 1, 2, 3, "a", 1, "b", 2, 3]
+      #   # => ["CMD", "1", "2", "3", "a", "1", "b", "2", "3"]
       def flatten_call_args(args)
         acc = []
         # Ruby doesn't have a built in queue, so we use a reversed stack instead
@@ -603,8 +603,10 @@ class Valkey
             stack.concat(arg.reverse)
           when Hash
             arg.to_a.reverse_each { |pair| stack.concat(pair.reverse) }
+          when String, Symbol, Integer, Float
+            acc << arg.to_s
           else
-            acc << arg
+            raise TypeError, "Unsupported command argument type: #{arg.class}"
           end
         end
 

--- a/lib/valkey/commands/generic_commands.rb
+++ b/lib/valkey/commands/generic_commands.rb
@@ -580,12 +580,15 @@ class Valkey
 
       private
 
-      # Flattens Arrays and Hashes (to alternating key/value) and stringifies
-      # Integers/Floats, matching `redis-client`'s documented `#call`/`#call_v` behavior.
+      # Flattens Arrays and Hashes (to alternating key/value), matching
+      # `redis-client`'s documented `#call`/`#call_v` behavior. Leaf values are
+      # left as-is - `build_command_args` type-checks and stringifies them, so
+      # an unsupported leaf (e.g. `nil`) raises `TypeError` there instead of
+      # being silently coerced to `""` here.
       #
       # @example
       #   flatten_call_args(["CMD", [1, [2, 3]], { "a" => 1, "b" => [2, 3] }])
-      #   # => ["CMD", "1", "2", "3", "a", "1", "b", "2", "3"]
+      #   # => ["CMD", 1, 2, 3, "a", 1, "b", 2, 3]
       def flatten_call_args(args)
         acc = []
         # Ruby doesn't have a built in queue, so we use a reversed stack instead
@@ -601,7 +604,7 @@ class Valkey
           when Hash
             arg.to_a.reverse_each { |pair| stack.concat(pair.reverse) }
           else
-            acc << arg.to_s
+            acc << arg
           end
         end
 

--- a/lib/valkey/commands/scripting_commands.rb
+++ b/lib/valkey/commands/scripting_commands.rb
@@ -271,8 +271,13 @@ class Valkey
       end
 
       def invoke_script(script, args: [], keys: [])
-        arg_ptrs, arg_lens = build_command_args(args)
-        keys_ptrs, keys_lens = build_command_args(keys)
+        # Must hold onto the returned buffers (_arg_bufs/_keys_bufs) for the
+        # lifetime of this method - they back arg_ptrs/keys_ptrs, and letting
+        # them go out of scope (e.g. by only capturing the first 2 return
+        # values) makes them eligible for GC before the native call below
+        # reads through those pointers, corrupting ARGV/KEYS with freed memory.
+        arg_ptrs, arg_lens, _arg_bufs, flattened_args = build_command_args(args)
+        keys_ptrs, keys_lens, _keys_bufs, flattened_keys = build_command_args(keys)
 
         route = ""
         route_buf = FFI::MemoryPointer.from_string(route)
@@ -285,10 +290,10 @@ class Valkey
             @connection,
             0,
             sha,
-            keys.size,
+            flattened_keys.size,
             keys_ptrs,
             keys_lens,
-            args.size,
+            flattened_args.size,
             arg_ptrs,
             arg_lens,
             route_buf,

--- a/lib/valkey/commands/string_commands.rb
+++ b/lib/valkey/commands/string_commands.rb
@@ -85,7 +85,12 @@ class Valkey
       #   - `:get => true`: Return the old string stored at key, or nil if key did not exist.
       # @return [String, Boolean] `"OK"` or true, false if `:nx => true` or `:xx => true`
       def set(key, value, ex: nil, px: nil, exat: nil, pxat: nil, nx: nil, xx: nil, keepttl: nil, get: nil)
-        args = [key, value]
+        # value.to_s (matching redis-rb): a non-String value (e.g. an Array,
+        # in test_set_and_get_with_non_string_value) must become ONE opaque
+        # value here, not get flattened as if it were a multi-value list -
+        # see build_command_args's flat_map fix for why this must happen
+        # before command_args is built, not be left to that generic layer.
+        args = [key, value.to_s]
         args << "EX" << ex if ex
         args << "PX" << px if px
         args << "EXAT" << exat if exat
@@ -110,7 +115,7 @@ class Valkey
       # @param [String] value
       # @return [String] `"OK"`
       def setex(key, ttl, value)
-        send_command(RequestType::SET_EX, [key, ttl, value])
+        send_command(RequestType::SET_EX, [key, ttl, value.to_s])
       end
 
       # Set the time to live in milliseconds of a key.
@@ -120,7 +125,7 @@ class Valkey
       # @param [String] value
       # @return [String] `"OK"`
       def psetex(key, ttl, value)
-        send_command(RequestType::PSET_EX, [key, Integer(ttl), value])
+        send_command(RequestType::PSET_EX, [key, Integer(ttl), value.to_s])
       end
 
       # Set the value of a key, only if the key does not exist.
@@ -136,7 +141,7 @@ class Valkey
         # other GLIDE bindings' existing contracts expect to keep returning a
         # plain 0/1 integer. Doing the conversion here keeps it scoped to this
         # one Ruby-level method - see hexists/hsetnx for the same pattern.
-        send_command(RequestType::SET_NX, [key, value], &Utils::Boolify)
+        send_command(RequestType::SET_NX, [key, value.to_s], &Utils::Boolify)
       end
 
       # Set one or more values.
@@ -259,7 +264,7 @@ class Valkey
       # @param [String] value
       # @return [Integer] length of the string after it was modified
       def setrange(key, offset, value)
-        send_command(RequestType::SET_RANGE, [key, offset, value])
+        send_command(RequestType::SET_RANGE, [key, offset, value.to_s])
       end
 
       # Get a substring of the string stored at key.


### PR DESCRIPTION
# Flatten nested Array/Hash command arguments, matching redis-client

This PR fixes the [issue](https://github.com/valkey-io/valkey-glide-ruby/issues/175)

## Problem

Any command call that passes a nested `Array`/`Hash` as one of its
arguments - e.g. `hset(key, [field, value])` - silently sends a corrupted
command instead of raising or working correctly:

```ruby
valkey.hset("k", ["field", "value"])
# ResponseError: wrong number of arguments for 'hset' command
```

This specific shape - `hset(key, [field, value])`, passing a single
key-value pair as a 2-element `Array` rather than as two separate
positional arguments or a `Hash` - is a real, if slightly unusual, calling
style: it works fine against `redis-rb`, so any code migrating from
`redis-rb` that happens to build its arguments this way breaks silently
against this client instead of raising a clear error at the call site
that made the mistake obvious. Depending on how the caller handles
errors, this can surface far from the actual bug - e.g. as a downstream
read coming back empty, rather than as the write itself failing loudly.

## Root cause

`build_command_args` (`lib/valkey.rb`) converts each **top-level** element
of the command array to a string and stops there - no flattening:

```ruby
command_args.each_with_index do |arg, i|
  arg = arg.to_s # Ensure we convert to string
  ...
end
```

So `[key, [field, value]]` turns the nested array into a single string via
`Array#to_s` (`'["field", "value"]'`) - one garbled argument instead of
two real ones, leaving the server with an odd/wrong argument count.

`redis-rb`'s underlying transport (`redis-client`'s `CommandBuilder
.generate`) does not have this problem, because it builds commands with
`flat_map`:

```ruby
command = args.flat_map do |element|
  case element
  when Hash
    element.flatten
  else
    element
  end
end
```

`flat_map` auto-flattens *any* Array-valued block result by one level -
this isn't Hash-specific, it's an incidental side effect of `flat_map`'s
own semantics. That's why `redis.hset(key, [field, value])` has always
worked correctly under `redis-rb`, even though nothing in `hset`'s own
code explicitly flattens that particular shape.

## What changed

**`lib/valkey.rb`**

- `build_command_args`: now does the same `flat_map` transform before
  building the FFI buffers, so a nested `Array`/`Hash` argument gets
  flattened exactly like `redis-client` does it:
  ```ruby
  command_args = command_args.flat_map { |el| el.is_a?(Hash) ? el.flatten : el }
  ```
- `send_command` / `send_batch_commands`: both were passing the FFI layer
  the **original**, pre-flatten array's `.size` as `arg_count`, while
  `arg_ptrs`/`arg_lens` were being built from the (now correctly
  flattened) array - two different lengths, silently out of sync. Fixed
  by having `build_command_args` also return the flattened array itself,
  and reassigning the caller's local `command_args` to it before using
  `.size` anywhere. This is the actual reason the `build_command_args`
  change alone didn't fix anything on its own - the count sent to the FFI
  call was still wrong even after the pointers were built correctly.

**`lib/valkey/commands/string_commands.rb`**

- `set`, `setex`, `psetex`, `setnx`, `setrange` now explicitly call
  `value.to_s` themselves, matching `redis-rb`'s own exact convention for
  these five methods specifically. Without this, a deliberately-passed
  non-`String` value (e.g. `%w[b a r]`, exercised by this gem's own
  `test_*_with_non_string_value` tests - a *single opaque value* meant to
  be stringified as a whole) would now be ambiguous with a genuine
  multi-value list and get incorrectly flattened instead of stringified,
  changing the argument count and breaking the command.

### Deliberately NOT changed: every other value-taking command

Checked `redis-rb`'s own source for `linsert`, `lrem`, `lset`, `hsetnx`,
`append` (and confirmed empirically for `lset`): none of them call
`.to_s` either, and `redis-rb` itself raises the identical `wrong number
of arguments` error if you pass an `Array` as their "value" argument.
There's no established contract for these to safely accept a non-`String`
value in the first place - on either client - so leaving them unchanged
matches real `redis-rb` behavior exactly, rather than speculatively
hardening past what's actually guaranteed anywhere.

## Verification

- Original repro fixed:
  ```ruby
  valkey.hset("k", ["field", "value"])  # => 1
  valkey.hgetall("k")                    # => {"field"=>"value"}
  ```
- Full suite: 560 tests, 0 errors (1 pre-existing, unrelated failure -
  `test_library_name_is_set`, fails identically with or without this
  change).
- Confirmed real `redis-rb` raises the exact same error as this client
  for `lset(key, index, ["a", "b"])` - i.e. the untouched methods aren't a
  newly-introduced gap, they're consistent with the reference client.
- Side-by-side against `redis-rb` for the original bug: identical
  results on both (`hset(key, [field, value])` → `1`, `hgetall` →
  `{"field"=>"value"}`, on both clients).
