### PR TITLE
fix: retain FFI buffers in invoke_script to prevent use-after-free

### DIFF
--- a/lib/valkey.rb
+++ b/lib/valkey.rb
@@ -598,6 +598,9 @@ class Valkey
     { "manual_interval" => { "duration_in_sec" => duration_in_sec } }
   end
 
+  # Returns [ptrs, lens, buffers]. Callers must retain buffers until the FFI call returns.
+  # Otherwise, GC may free the buffers making the ptrs invalid.
+  # TODO: Refactor to return a struct (https://github.com/valkey-io/valkey-glide-ruby/issues/179)
   def build_command_args(command_args)
     # For empty arrays, pass NULL pointers as per Rust FFI contract
     # This matches Go's approach which successfully uses nil pointers

--- a/lib/valkey/commands/scripting_commands.rb
+++ b/lib/valkey/commands/scripting_commands.rb
@@ -253,8 +253,8 @@ class Valkey
       end
 
       def invoke_script(script, args: [], keys: [])
-        arg_ptrs, arg_lens = build_command_args(args)
-        keys_ptrs, keys_lens = build_command_args(keys)
+        arg_ptrs, arg_lens, _arg_bufs = build_command_args(args)
+        keys_ptrs, keys_lens, _keys_bufs = build_command_args(keys)
 
         route = ""
         route_buf = FFI::MemoryPointer.from_string(route)

--- a/lib/valkey/route.rb
+++ b/lib/valkey/route.rb
@@ -67,6 +67,8 @@ class Valkey
     # Returns both the struct and any pinned memory buffers that must remain
     # alive until the FFI call completes.
     #
+    # TODO: Refactor to return a struct (https://github.com/valkey-io/valkey-glide-ruby/issues/179)
+    #
     # @return [Array(Bindings::RouteInfo, Array)] the struct and pinned buffers
     def to_ffi
       info = Bindings::RouteInfo.new


### PR DESCRIPTION
## Summary

- `invoke_script` discarded the buffer objects returned by `build_command_args`, allowing GC to free backing memory during the blocking FFI call
- Retain buffers for both args and keys, matching the pattern in `send_command` and `send_batch_commands`
- Add documentation and TODO refs to #179 for struct refactor
