### PR TITLE
fix(ruby): reject nil and unsupported types in command args

### DIFF
--- a/lib/valkey.rb
+++ b/lib/valkey.rb
@@ -593,9 +593,14 @@ class Valkey
     buffers = []
 
     command_args.each_with_index do |arg, i|
-      arg = arg.to_s # Ensure we convert to string
+      arg = case arg
+            when String, Symbol, Integer, Float
+              arg.to_s
+            else
+              raise TypeError, "Unsupported command argument type: #{arg.class}"
+            end
 
-      buf = FFI::MemoryPointer.from_string(arg.to_s)
+      buf = FFI::MemoryPointer.from_string(arg)
       buffers << buf # prevent garbage collection
       arg_ptrs.put_pointer(i * FFI::Pointer.size, buf)
       arg_lens.put_ulong(i * 8, arg.bytesize)

--- a/test/standalone/valkey_test.rb
+++ b/test/standalone/valkey_test.rb
@@ -24,6 +24,7 @@ class TestStandaloneValkey < Minitest::Test
   include ValkeyTests::URIConnection
   include ValkeyTests::Utils
   include ValkeyTests::FlattenMap
+  include ValkeyTests::ArgTypeValidation
 
   # Property-based test modules for eval/evalsha
   include ValkeyTests::EvalEvalshaBasicProperties

--- a/test/valkey/arg_type_validation_test.rb
+++ b/test/valkey/arg_type_validation_test.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module ValkeyTests
+  # Tests that nil and other unsupported types are rejected with TypeError
+  # instead of being silently coerced to empty string via #to_s (fixes #191).
+  module ArgTypeValidation
+    def test_nil_arg_raises_type_error
+      assert_raises(TypeError) { r.set("key", nil) }
+    end
+
+    def test_nil_key_raises_type_error
+      assert_raises(TypeError) { r.get(nil) }
+    end
+
+    def test_array_arg_raises_type_error
+      assert_raises(TypeError) { r.set("key", [1, 2, 3]) }
+    end
+
+    def test_hash_arg_raises_type_error
+      assert_raises(TypeError) { r.set("key", { a: 1 }) }
+    end
+
+    def test_string_arg_accepted
+      assert_equal "OK", r.set("arg_type:str", "hello")
+      assert_equal "hello", r.get("arg_type:str")
+    end
+
+    def test_symbol_arg_accepted
+      assert_equal "OK", r.set("arg_type:sym", :world)
+      assert_equal "world", r.get("arg_type:sym")
+    end
+
+    def test_integer_arg_accepted
+      assert_equal "OK", r.set("arg_type:int", 42)
+      assert_equal "42", r.get("arg_type:int")
+    end
+
+    def test_float_arg_accepted
+      assert_equal "OK", r.set("arg_type:float", 3.14)
+      assert_equal "3.14", r.get("arg_type:float")
+    end
+
+    def test_nil_in_call_raises_type_error
+      assert_raises(TypeError) { r.call("SET", "key", nil) }
+    end
+
+    def test_type_error_message_includes_class_name
+      err = assert_raises(TypeError) { r.set("key", nil) }
+      assert_match(/NilClass/, err.message)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Minimal backport of the #191 fix to `release-1.0`. Raises `TypeError` for `nil`, `Array`, `Hash`, and other unsupported types in `build_command_args` instead of silently coercing them via `#to_s` (which turns `nil` into empty string `""`).

Only `String`, `Symbol`, `Integer`, and `Float` are accepted — matching `redis-client`'s behavior.

Fixes #191

## What's different from main

This is a targeted fix only — it does **not** include the Array/Hash flattening refactor or the scripting use-after-free fix from the full squash commit on main (`9005f65`). Those changes are independent improvements that can be brought over separately if needed.

## Changes

- `lib/valkey.rb` — type-check guard in `build_command_args`
- `test/valkey/arg_type_validation_test.rb` — new test module
- `test/standalone/valkey_test.rb` — include new module

## Testing

- `bundle exec rubocop` ✅
- New tests cover rejection of nil/Array/Hash and acceptance of String/Symbol/Integer/Float