### PR TITLE
fix(ruby): backport flatten args, nil rejection, and use-after-free fix

### DIFF
--- a/lib/valkey.rb
+++ b/lib/valkey.rb
@@ -346,8 +346,9 @@ class Valkey
       arg_ptrs.put_pointer(0, FFI::MemoryPointer.new(1))
       arg_lens.put_ulong(0, 0)
       _buffers = [] # nothing to keep alive
+      flattened_args = command_args
     else
-      arg_ptrs, arg_lens, _buffers = build_command_args(command_args)
+      arg_ptrs, arg_lens, _buffers, flattened_args = build_command_args(command_args)
     end
 
     # Create OpenTelemetry span if sampling is enabled, as a child of the app's current
@@ -379,7 +380,7 @@ class Valkey
           @connection,
           channel,
           command_type,
-          command_args.size,
+          flattened_args.size,
           arg_ptrs,
           arg_lens,
           route_info.to_ptr,
@@ -395,7 +396,7 @@ class Valkey
           @connection,
           channel,
           command_type,
-          command_args.size,
+          flattened_args.size,
           arg_ptrs,
           arg_lens,
           route_buf,
@@ -476,12 +477,12 @@ class Valkey
     buffers = [] # Keep references to prevent GC
 
     commands.each do |command_type, command_args, block|
-      arg_ptrs, arg_lens, arg_bufs = build_command_args(command_args)
+      arg_ptrs, arg_lens, arg_bufs, flattened_args = build_command_args(command_args)
 
       cmd = Bindings::CmdInfo.new
       cmd[:request_type] = command_type
       cmd[:args] = arg_ptrs
-      cmd[:arg_count] = command_args.size
+      cmd[:arg_count] = flattened_args.size
       cmd[:args_len] = arg_lens
 
       cmds << cmd
@@ -580,28 +581,43 @@ class Valkey
     { "manual_interval" => { "duration_in_sec" => duration_in_sec } }
   end
 
-  # Returns [ptrs, lens, buffers]. Callers must retain buffers until the FFI call returns.
-  # Otherwise, GC may free the buffers making the ptrs invalid.
-  # TODO: Refactor to return a struct (https://github.com/valkey-io/valkey-glide-ruby/issues/179)
+  # Builds the FFI arg_ptrs/arg_lens/buffers for command_args, flattening nested
+  # Array/Hash elements first (mirroring redis-client's CommandBuilder#generate)
+  # so callers like hset(key, [field, value]) serialize correctly instead of
+  # collapsing into one garbled Array#to_s/Hash#to_s string. Returns the
+  # flattened command_args too - callers must size arg_count off this returned
+  # array, not their original pre-flatten one, or arg_count goes out of sync
+  # with arg_ptrs/arg_lens. Each element's type is checked against the same
+  # allow-list redis-client's CommandBuilder#generate uses (String, Symbol,
+  # Integer, Float) - anything else, including nil, raises TypeError instead
+  # of being silently coerced via #to_s (e.g. nil.to_s => "").
   def build_command_args(command_args)
+    # Flatten nested Arrays/Hashes to match redis-client's behavior.
+    command_args = command_args.flat_map { |el| el.is_a?(Hash) ? el.flatten : el }
+
     # For empty arrays, pass NULL pointers as per Rust FFI contract
     # This matches Go's approach which successfully uses nil pointers
-    return [FFI::Pointer::NULL, FFI::Pointer::NULL, []] if command_args.empty?
+    return [FFI::Pointer::NULL, FFI::Pointer::NULL, [], []] if command_args.empty?
 
     arg_ptrs = FFI::MemoryPointer.new(:pointer, command_args.size)
     arg_lens = FFI::MemoryPointer.new(:ulong, command_args.size)
     buffers = []
 
     command_args.each_with_index do |arg, i|
-      arg = arg.to_s # Ensure we convert to string
+      arg = case arg
+            when String, Symbol, Integer, Float
+              arg.to_s
+            else
+              raise TypeError, "Unsupported command argument type: #{arg.class}"
+            end
 
-      buf = FFI::MemoryPointer.from_string(arg.to_s)
+      buf = FFI::MemoryPointer.from_string(arg)
       buffers << buf # prevent garbage collection
       arg_ptrs.put_pointer(i * FFI::Pointer.size, buf)
       arg_lens.put_ulong(i * 8, arg.bytesize)
     end
 
-    [arg_ptrs, arg_lens, buffers]
+    [arg_ptrs, arg_lens, buffers, command_args]
   end
 
   def convert_response(res, &block)

--- a/lib/valkey/commands/generic_commands.rb
+++ b/lib/valkey/commands/generic_commands.rb
@@ -581,7 +581,10 @@ class Valkey
       private
 
       # Flattens Arrays and Hashes (to alternating key/value) and stringifies
-      # Integers/Floats, matching `redis-client`'s documented `#call`/`#call_v` behavior.
+      # Integers/Floats/Symbols, matching `redis-client`'s documented
+      # `#call`/`#call_v` behavior - including its type check: any leaf that
+      # isn't a String/Symbol/Integer/Float (e.g. `nil`) raises `TypeError`
+      # instead of being silently coerced to `""` via `#to_s`.
       #
       # @example
       #   flatten_call_args(["CMD", [1, [2, 3]], { "a" => 1, "b" => [2, 3] }])
@@ -600,8 +603,10 @@ class Valkey
             stack.concat(arg.reverse)
           when Hash
             arg.to_a.reverse_each { |pair| stack.concat(pair.reverse) }
-          else
+          when String, Symbol, Integer, Float
             acc << arg.to_s
+          else
+            raise TypeError, "Unsupported command argument type: #{arg.class}"
           end
         end
 

--- a/lib/valkey/commands/scripting_commands.rb
+++ b/lib/valkey/commands/scripting_commands.rb
@@ -253,8 +253,13 @@ class Valkey
       end
 
       def invoke_script(script, args: [], keys: [])
-        arg_ptrs, arg_lens, _arg_bufs = build_command_args(args)
-        keys_ptrs, keys_lens, _keys_bufs = build_command_args(keys)
+        # Must hold onto the returned buffers (_arg_bufs/_keys_bufs) for the
+        # lifetime of this method - they back arg_ptrs/keys_ptrs, and letting
+        # them go out of scope (e.g. by only capturing the first 2 return
+        # values) makes them eligible for GC before the native call below
+        # reads through those pointers, corrupting ARGV/KEYS with freed memory.
+        arg_ptrs, arg_lens, _arg_bufs, flattened_args = build_command_args(args)
+        keys_ptrs, keys_lens, _keys_bufs, flattened_keys = build_command_args(keys)
 
         route = ""
         route_buf = FFI::MemoryPointer.from_string(route)
@@ -267,10 +272,10 @@ class Valkey
             @connection,
             0,
             sha,
-            keys.size,
+            flattened_keys.size,
             keys_ptrs,
             keys_lens,
-            args.size,
+            flattened_args.size,
             arg_ptrs,
             arg_lens,
             route_buf,

--- a/lib/valkey/commands/string_commands.rb
+++ b/lib/valkey/commands/string_commands.rb
@@ -85,7 +85,12 @@ class Valkey
       #   - `:get => true`: Return the old string stored at key, or nil if key did not exist.
       # @return [String, Boolean] `"OK"` or true, false if `:nx => true` or `:xx => true`
       def set(key, value, ex: nil, px: nil, exat: nil, pxat: nil, nx: nil, xx: nil, keepttl: nil, get: nil)
-        args = [key, value]
+        # value.to_s (matching redis-rb): a non-String value (e.g. an Array,
+        # in test_set_and_get_with_non_string_value) must become ONE opaque
+        # value here, not get flattened as if it were a multi-value list -
+        # see build_command_args's flat_map fix for why this must happen
+        # before command_args is built, not be left to that generic layer.
+        args = [key, value.to_s]
         args << "EX" << ex if ex
         args << "PX" << px if px
         args << "EXAT" << exat if exat
@@ -110,7 +115,7 @@ class Valkey
       # @param [String] value
       # @return [String] `"OK"`
       def setex(key, ttl, value)
-        send_command(RequestType::SET_EX, [key, ttl, value])
+        send_command(RequestType::SET_EX, [key, ttl, value.to_s])
       end
 
       # Set the time to live in milliseconds of a key.
@@ -120,7 +125,7 @@ class Valkey
       # @param [String] value
       # @return [String] `"OK"`
       def psetex(key, ttl, value)
-        send_command(RequestType::PSET_EX, [key, Integer(ttl), value])
+        send_command(RequestType::PSET_EX, [key, Integer(ttl), value.to_s])
       end
 
       # Set the value of a key, only if the key does not exist.
@@ -129,7 +134,14 @@ class Valkey
       # @param [String] value
       # @return [Boolean] whether the key was set or not
       def setnx(key, value)
-        send_command(RequestType::SET_NX, [key, value])
+        # &Utils::Boolify (not glide-core's generic Boolean-coercion table) is
+        # deliberately used here: glide-core's per-command coercion is keyed by
+        # command name alone, so it can't distinguish this dedicated SETNX
+        # RequestType from a raw `customCommand(["SETNX", ...])` call, which
+        # other GLIDE bindings' existing contracts expect to keep returning a
+        # plain 0/1 integer. Doing the conversion here keeps it scoped to this
+        # one Ruby-level method - see hexists/hsetnx for the same pattern.
+        send_command(RequestType::SET_NX, [key, value.to_s], &Utils::Boolify)
       end
 
       # Set one or more values.
@@ -252,7 +264,7 @@ class Valkey
       # @param [String] value
       # @return [Integer] length of the string after it was modified
       def setrange(key, offset, value)
-        send_command(RequestType::SET_RANGE, [key, offset, value])
+        send_command(RequestType::SET_RANGE, [key, offset, value.to_s])
       end
 
       # Get a substring of the string stored at key.


### PR DESCRIPTION
## Summary

Cherry-pick of 9005f65 ("Flatten nested Array/Hash command arguments, matching redis-client (#176)") from `main` to `release-1.0`.

Fixes #191

## What's included

1. **Nil/unsupported type rejection**: `build_command_args` raises `TypeError` for `nil`, and any type not in `[String, Symbol, Integer, Float]`, instead of silently coercing via `#to_s`
2. **Array/Hash flattening**: `client.call("MGET", ["key1", "key2", "key3"])` correctly flattens `["key1", "key2", "key3"]` to 3 separate args instead of sending `"[\"key1\", \"key2\", \"key3\"]"` as one arg.

## Testing

- `bundle exec rubocop` ✅ (no offenses)
- Original commit was CI-tested on main via PR #176