### PR TITLE
fix(ruby): accept varargs in lpush, rpush, lpushx, rpushx

### DIFF
--- a/lib/valkey/commands/hash_commands.rb
+++ b/lib/valkey/commands/hash_commands.rb
@@ -14,7 +14,7 @@ class Valkey
       #     # => 2
       #
       # @param [String] key
-      # @param [String, Array<String>] field one field, or array of fields
+      # @param [String, Array<String>] field one or more fields, or array of fields
       # @return [Integer] the number of fields that were removed
       def hdel(key, *fields)
         fields.flatten!(1)
@@ -118,7 +118,7 @@ class Valkey
       #     # => ["value1", "value2"]
       #
       # @param [String] key
-      # @param [String, Array<String>] field one field, or array of fields
+      # @param [String, Array<String>] field one or more fields, or array of fields
       # @return [Array<String, nil>] an array of values for the specified fields
       #
       # @see #mapped_hmget
@@ -134,7 +134,7 @@ class Valkey
       #     # => {"field1" => "value1", "field2" => "value2"}
       #
       # @param [String] key
-      # @param [String, Array<String>] field one field, or array of fields
+      # @param [String, Array<String>] field one or more fields, or array of fields
       # @return [Hash] a hash mapping the specified fields to their values
       #
       # @see #hmget
@@ -349,7 +349,7 @@ class Valkey
       #     # => ["value1", "value2"]
       #
       # @param [String] key
-      # @param [String, Array<String>] fields one field, or array of fields
+      # @param [String, Array<String>] fields one or more fields, or array of fields
       # @param [Hash] options
       #   - `:ex => Integer`: Set the specified expire time, in seconds.
       #   - `:px => Integer`: Set the specified expire time, in milliseconds.
@@ -381,7 +381,7 @@ class Valkey
       #
       # @param [String] key
       # @param [Integer] seconds time to live in seconds
-      # @param [String, Array<String>] fields one field, or array of fields
+      # @param [String, Array<String>] fields one or more fields, or array of fields
       # @param [Hash] options
       #   - `:nx => true`: Set expiry only when the field has no expiry.
       #   - `:xx => true`: Set expiry only when the field has an existing expiry.
@@ -411,7 +411,7 @@ class Valkey
       #
       # @param [String] key
       # @param [Integer] unix_time expiry time specified as a UNIX timestamp in seconds
-      # @param [String, Array<String>] fields one field, or array of fields
+      # @param [String, Array<String>] fields one or more fields, or array of fields
       # @param [Hash] options
       #   - `:nx => true`: Set expiry only when the field has no expiry.
       #   - `:xx => true`: Set expiry only when the field has an existing expiry.
@@ -441,7 +441,7 @@ class Valkey
       #
       # @param [String] key
       # @param [Integer] milliseconds time to live in milliseconds
-      # @param [String, Array<String>] fields one field, or array of fields
+      # @param [String, Array<String>] fields one or more fields, or array of fields
       # @param [Hash] options
       #   - `:nx => true`: Set expiry only when the field has no expiry.
       #   - `:xx => true`: Set expiry only when the field has an existing expiry.
@@ -471,7 +471,7 @@ class Valkey
       #
       # @param [String] key
       # @param [Integer] unix_time_ms expiry time specified as a UNIX timestamp in milliseconds
-      # @param [String, Array<String>] fields one field, or array of fields
+      # @param [String, Array<String>] fields one or more fields, or array of fields
       # @param [Hash] options
       #   - `:nx => true`: Set expiry only when the field has no expiry.
       #   - `:xx => true`: Set expiry only when the field has an existing expiry.
@@ -500,7 +500,7 @@ class Valkey
       #     # => [1, 1]
       #
       # @param [String] key
-      # @param [String, Array<String>] fields one field, or array of fields
+      # @param [String, Array<String>] fields one or more fields, or array of fields
       # @return [Array<Integer>] Array of results for each field.
       #   - `1` if the expiration time was successfully removed from the field.
       #   - `-1` if the field exists but has no expiration time.
@@ -519,7 +519,7 @@ class Valkey
       #     # => [60, -1]
       #
       # @param [String] key
-      # @param [String, Array<String>] fields one field, or array of fields
+      # @param [String, Array<String>] fields one or more fields, or array of fields
       # @return [Array<Integer>] Array of TTLs in seconds for each field.
       #   - TTL in seconds if the field exists and has a timeout.
       #   - `-1` if the field exists but has no associated expire.
@@ -538,7 +538,7 @@ class Valkey
       #     # => [60000, -1]
       #
       # @param [String] key
-      # @param [String, Array<String>] fields one field, or array of fields
+      # @param [String, Array<String>] fields one or more fields, or array of fields
       # @return [Array<Integer>] Array of TTLs in milliseconds for each field.
       #   - TTL in milliseconds if the field exists and has a timeout.
       #   - `-1` if the field exists but has no associated expire.
@@ -557,7 +557,7 @@ class Valkey
       #     # => [1234567890, -1]
       #
       # @param [String] key
-      # @param [String, Array<String>] fields one field, or array of fields
+      # @param [String, Array<String>] fields one or more fields, or array of fields
       # @return [Array<Integer>] Array of expiration timestamps in seconds for each field.
       #   - Expiration Unix timestamp in seconds if the field exists and has a timeout.
       #   - `-1` if the field exists but has no associated expire.
@@ -576,7 +576,7 @@ class Valkey
       #     # => [1234567890000, -1]
       #
       # @param [String] key
-      # @param [String, Array<String>] fields one field, or array of fields
+      # @param [String, Array<String>] fields one or more fields, or array of fields
       # @return [Array<Integer>] Array of expiration timestamps in milliseconds for each field.
       #   - Expiration Unix timestamp in milliseconds if the field exists and has a timeout.
       #   - `-1` if the field exists but has no associated expire.

--- a/lib/valkey/commands/list_commands.rb
+++ b/lib/valkey/commands/list_commands.rb
@@ -63,44 +63,44 @@ class Valkey
         send_command(RequestType::BLMOVE, args)
       end
 
-      # Prepend one or more values to a list, creating the list if it doesn't exist
+      # Prepend one or more values to a list, creating the list if it doesn't exist.
       #
       # @param [String] key
-      # @param [String, Array<String>] value string value, or array of string values to push
+      # @param [String, Array<String>] value one or more values, or array of values
       # @return [Integer] the length of the list after the push operation
-      def lpush(key, value)
-        send_command(RequestType::LPUSH, [key, *value])
+      def lpush(key, *value)
+        value.flatten!(1)
+        send_command(RequestType::LPUSH, [key].concat(value))
       end
 
-      # Prepend a value to a list, only if the list exists.
+      # Prepend one or more values to a list, only if the list exists.
       #
       # @param [String] key
-      # @param [String] value
+      # @param [String, Array<String>] value one or more values, or array of values
       # @return [Integer] the length of the list after the push operation
-      def lpushx(key, value)
-        send_command(RequestType::LPUSHX, [key, value])
+      def lpushx(key, *value)
+        value.flatten!(1)
+        send_command(RequestType::LPUSHX, [key].concat(value))
       end
 
-      # Append one or more values to a list, creating the list if it doesn't exist
+      # Append one or more values to a list, creating the list if it doesn't exist.
       #
       # @param [String] key
-      # @param [String, Array<String>] value string value, or array of string values to push
+      # @param [String, Array<String>] value one or more values, or array of values
       # @return [Integer] the length of the list after the push operation
-      def rpush(key, value)
-        value = [value] unless value.is_a?(Array)
-
-        args = [key] + value
-
-        send_command(RequestType::RPUSH, args)
+      def rpush(key, *value)
+        value.flatten!(1)
+        send_command(RequestType::RPUSH, [key].concat(value))
       end
 
-      # Append a value to a list, only if the list exists.
+      # Append one or more values to a list, only if the list exists.
       #
       # @param [String] key
-      # @param [String] value
+      # @param [String, Array<String>] value one or more values, or array of values
       # @return [Integer] the length of the list after the push operation
-      def rpushx(key, value)
-        send_command(RequestType::RPUSHX, [key, value])
+      def rpushx(key, *value)
+        value.flatten!(1)
+        send_command(RequestType::RPUSHX, [key].concat(value))
       end
 
       # Remove and get the first elements in a list.

--- a/lib/valkey/commands/set_commands.rb
+++ b/lib/valkey/commands/set_commands.rb
@@ -18,7 +18,7 @@ class Valkey
       # Add one or more members to a set.
       #
       # @param [String] key
-      # @param [String, Array<String>] member one member, or array of members
+      # @param [String, Array<String>] member one or more members, or array of members
       # @return [Integer] The number of members that were successfully added
       def sadd(key, *members)
         members.flatten!(1)
@@ -28,7 +28,7 @@ class Valkey
       # Add one or more members to a set.
       #
       # @param [String] key
-      # @param [String, Array<String>] member one member, or array of members
+      # @param [String, Array<String>] member one or more members, or array of members
       # @return [Boolean] Whether at least one member was successfully added.
       def sadd?(key, *members)
         members.flatten!(1)
@@ -38,7 +38,7 @@ class Valkey
       # Remove one or more members from a set.
       #
       # @param [String] key
-      # @param [String, Array<String>] member one member, or array of members
+      # @param [String, Array<String>] member one or more members, or array of members
       # @return [Integer] The number of members that were successfully removed
       def srem(key, *members)
         members.flatten!(1)
@@ -48,7 +48,7 @@ class Valkey
       # Remove one or more members from a set.
       #
       # @param [String] key
-      # @param [String, Array<String>] member one member, or array of members
+      # @param [String, Array<String>] member one or more members, or array of members
       # @return [Boolean] Whether at least one member was successfully removed.
       def srem?(key, *members)
         members.flatten!(1)

--- a/test/lint/hash_commands.rb
+++ b/test/lint/hash_commands.rb
@@ -40,7 +40,18 @@ module Lint
       assert_equal "s2", r.hget("foo", "f2")
     end
 
-    def test_variadic_hdel
+    def test_array_hdel
+      r.hset("foo", "f1", "s1")
+      r.hset("foo", "f2", "s2")
+      r.hset("foo", "f3", "s3")
+
+      assert_equal 2, r.hdel("foo", %w[f1 f2])
+      assert_nil r.hget("foo", "f1")
+      assert_nil r.hget("foo", "f2")
+      assert_equal "s3", r.hget("foo", "f3")
+    end
+
+    def test_splat_hdel
       r.hset("foo", "f1", "s1")
       r.hset("foo", "f2", "s2")
       r.hset("foo", "f3", "s3")

--- a/test/lint/list_commands.rb
+++ b/test/lint/list_commands.rb
@@ -40,8 +40,14 @@ module Lint
       assert_equal "s2", r.lpop("foo")
     end
 
-    def test_variadic_lpush
+    def test_array_lpush
       assert_equal 3, r.lpush("foo", %w[s1 s2 s3])
+      assert_equal 3, r.llen("foo")
+      assert_equal "s3", r.lpop("foo")
+    end
+
+    def test_splat_lpush
+      assert_equal 3, r.lpush("foo", "s1", "s2", "s3")
       assert_equal 3, r.llen("foo")
       assert_equal "s3", r.lpop("foo")
     end
@@ -55,6 +61,22 @@ module Lint
       assert_equal %w[s3 s2], r.lrange("foo", 0, -1)
     end
 
+    def test_array_lpushx
+      r.lpush "foo", "s1"
+      r.lpushx "foo", %w[s2 s3]
+
+      assert_equal 3, r.llen("foo")
+      assert_equal %w[s3 s2 s1], r.lrange("foo", 0, -1)
+    end
+
+    def test_splat_lpushx
+      r.lpush "foo", "s1"
+      r.lpushx "foo", "s2", "s3"
+
+      assert_equal 3, r.llen("foo")
+      assert_equal %w[s3 s2 s1], r.lrange("foo", 0, -1)
+    end
+
     def test_rpush
       r.rpush "foo", "s1"
       r.rpush "foo", "s2"
@@ -63,8 +85,14 @@ module Lint
       assert_equal "s2", r.rpop("foo")
     end
 
-    def test_variadic_rpush
+    def test_array_rpush
       assert_equal 3, r.rpush("foo", %w[s1 s2 s3])
+      assert_equal 3, r.llen("foo")
+      assert_equal "s3", r.rpop("foo")
+    end
+
+    def test_splat_rpush
+      assert_equal 3, r.rpush("foo", "s1", "s2", "s3")
       assert_equal 3, r.llen("foo")
       assert_equal "s3", r.rpop("foo")
     end
@@ -76,6 +104,22 @@ module Lint
 
       assert_equal 2, r.llen("foo")
       assert_equal %w[s2 s3], r.lrange("foo", 0, -1)
+    end
+
+    def test_array_rpushx
+      r.rpush "foo", "s1"
+      r.rpushx "foo", %w[s2 s3]
+
+      assert_equal 3, r.llen("foo")
+      assert_equal %w[s1 s2 s3], r.lrange("foo", 0, -1)
+    end
+
+    def test_splat_rpushx
+      r.rpush "foo", "s1"
+      r.rpushx "foo", "s2", "s3"
+
+      assert_equal 3, r.llen("foo")
+      assert_equal %w[s1 s2 s3], r.lrange("foo", 0, -1)
     end
 
     def test_llen

--- a/test/lint/set_commands.rb
+++ b/test/lint/set_commands.rb
@@ -10,6 +10,20 @@ module Lint
       assert_equal %w[s1 s2], r.smembers("foo").sort
     end
 
+    def test_array_sadd
+      assert_equal 2, r.sadd("foo", %w[s1 s2])
+      assert_equal 1, r.sadd("foo", %w[s1 s2 s3])
+
+      assert_equal %w[s1 s2 s3], r.smembers("foo").sort
+    end
+
+    def test_splat_sadd
+      assert_equal 2, r.sadd("foo", "s1", "s2")
+      assert_equal 1, r.sadd("foo", "s1", "s2", "s3")
+
+      assert_equal %w[s1 s2 s3], r.smembers("foo").sort
+    end
+
     def test_sadd?
       assert_equal true, r.sadd?("foo", "s1")
       assert_equal true, r.sadd?("foo", "s2")
@@ -18,17 +32,18 @@ module Lint
       assert_equal %w[s1 s2], r.smembers("foo").sort
     end
 
-    def test_variadic_sadd
-      assert_equal 2, r.sadd("foo", %w[s1 s2])
-      assert_equal 1, r.sadd("foo", %w[s1 s2 s3])
+    def test_array_sadd?
+      assert_equal true, r.sadd?("foo", %w[s1 s2])
+      assert_equal true, r.sadd?("foo", %w[s1 s2 s3])
+      assert_equal false, r.sadd?("foo", %w[s1 s2])
 
       assert_equal %w[s1 s2 s3], r.smembers("foo").sort
     end
 
-    def test_variadic_sadd?
-      assert_equal true, r.sadd?("foo", %w[s1 s2])
-      assert_equal true, r.sadd?("foo", %w[s1 s2 s3])
-      assert_equal false, r.sadd?("foo", %w[s1 s2])
+    def test_splat_sadd?
+      assert_equal true, r.sadd?("foo", "s1", "s2")
+      assert_equal true, r.sadd?("foo", "s1", "s2", "s3")
+      assert_equal false, r.sadd?("foo", "s1", "s2")
 
       assert_equal %w[s1 s2 s3], r.smembers("foo").sort
     end
@@ -43,17 +58,7 @@ module Lint
       assert_equal ["s2"], r.smembers("foo")
     end
 
-    def test_srem?
-      r.sadd("foo", "s1")
-      r.sadd("foo", "s2")
-
-      assert_equal true, r.srem?("foo", "s1")
-      assert_equal false, r.srem?("foo", "s3")
-
-      assert_equal ["s2"], r.smembers("foo")
-    end
-
-    def test_variadic_srem
+    def test_array_srem
       r.sadd("foo", "s1")
       r.sadd("foo", "s2")
       r.sadd("foo", "s3")
@@ -65,13 +70,47 @@ module Lint
       assert_equal ["s2"], r.smembers("foo")
     end
 
-    def test_variadic_srem?
+    def test_splat_srem
+      r.sadd("foo", "s1")
+      r.sadd("foo", "s2")
+      r.sadd("foo", "s3")
+
+      assert_equal 1, r.srem("foo", "s1", "aaa")
+      assert_equal 0, r.srem("foo", "bbb", "ccc", "ddd")
+      assert_equal 1, r.srem("foo", "eee", "s3")
+
+      assert_equal ["s2"], r.smembers("foo")
+    end
+
+    def test_srem?
+      r.sadd("foo", "s1")
+      r.sadd("foo", "s2")
+
+      assert_equal true, r.srem?("foo", "s1")
+      assert_equal false, r.srem?("foo", "s3")
+
+      assert_equal ["s2"], r.smembers("foo")
+    end
+
+    def test_array_srem?
       r.sadd("foo", "s1")
       r.sadd("foo", "s2")
       r.sadd("foo", "s3")
 
       assert_equal true, r.srem?("foo", %w[s1 aaa])
       assert_equal false, r.srem?("foo", %w[bbb ccc ddd])
+      assert_equal true, r.srem?("foo", %w[eee s3])
+
+      assert_equal ["s2"], r.smembers("foo")
+    end
+
+    def test_splat_srem?
+      r.sadd("foo", "s1")
+      r.sadd("foo", "s2")
+      r.sadd("foo", "s3")
+
+      assert_equal true, r.srem?("foo", "s1", "aaa")
+      assert_equal false, r.srem?("foo", "bbb", "ccc", "ddd")
       assert_equal true, r.srem?("foo", "eee", "s3")
 
       assert_equal ["s2"], r.smembers("foo")


### PR DESCRIPTION
### Summary

Accept the redis-rb varargs form for `lpush`, `rpush`, `lpushx`, and `rpushx` (e.g. `rpush("key", "a", "b", "c")`). Also aligns `@param` documentation and lint test naming conventions across list, set, and hash command modules for consistency.

### Issue link

Closes #188

### Features / Changes

- Change `lpush`, `lpushx`, `rpush`, `rpushx` signatures from `(key, value)` to `(key, *value)` with `flatten!(1)`, matching the pattern used by `sadd`, `srem`, and `hdel`.
- All three calling forms now work and are tested:
  - Single value: `rpush("key", "a")`
  - Array-wrapped: `rpush("key", ["a", "b", "c"])`
  - Varargs/splat: `rpush("key", "a", "b", "c")`
- Updated `@param` documentation across `list_commands.rb`, `set_commands.rb`, and `hash_commands.rb` to use consistent wording: "one or more values/members/fields, or array of values/members/fields".
- Standardised lint test naming to `test_<command>` / `test_array_<command>` / `test_splat_<command>` convention across all variadic commands (list, set, hash).

### Testing

- Added `test_splat_lpush`, `test_splat_lpushx`, `test_splat_rpush`, `test_splat_rpushx` covering the new varargs form.
- Added `test_array_lpushx`, `test_array_rpushx` covering the Array form for pushx commands.
- Added `test_splat_sadd`, `test_splat_sadd_bool`, `test_splat_srem`, `test_splat_srem_bool`, `test_splat_hdel` to complete coverage for existing variadic commands.
- Renamed existing tests to follow the new naming convention.
- All 27 relevant tests pass against a local Valkey 8.x standalone server.
- RuboCop passes with no offenses.

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [x] Documentation is updated (if applicable).
- [x] Linters have been run (`bundle exec rubocop`) and pass.
- [x] Destination branch is correct - release-1.0