### PR TITLE
fix(ruby): keep OpenTelemetry FFI config reference

### DIFF
--- a/lib/valkey/opentelemetry.rb
+++ b/lib/valkey/opentelemetry.rb
@@ -45,6 +45,10 @@ class Valkey
     @initialized = false
     @config = nil
     @parent_span_context_provider = nil
+    # Retains the FFI config struct wrappers and endpoint buffers passed to the
+    # native init so their memory isn't GC'd while the native layer holds their
+    # raw addresses. See build_config / init.
+    @config_refs = nil
 
     class << self
       # Initialize OpenTelemetry in the Valkey GLIDE core.
@@ -97,8 +101,18 @@ class Valkey
           raise ArgumentError, "flush_interval_ms must be a positive integer, got: #{flush_interval_ms}"
         end
 
-        # Build the configuration
-        config = build_config(traces, metrics, flush_interval_ms)
+        # Build the configuration.
+        #
+        # build_config returns the config struct plus a "keep_alive" set of the
+        # nested FFI struct wrappers and endpoint buffers. The config struct only
+        # stores their raw addresses, so those objects must stay referenced until
+        # after the native call finishes reading them — otherwise GC could free
+        # the endpoint buffers and leave config->traces/metrics->endpoint
+        # dangling (use-after-free). Mirrors the buffer pinning in
+        # build_command_args. Stashing them in @config_refs keeps them alive for
+        # the process lifetime (init is one-time), which covers the native call.
+        config, keep_alive = build_config(traces, metrics, flush_interval_ms)
+        @config_refs = keep_alive
 
         # Call the FFI function
         error_ptr = Bindings.init_open_telemetry(config)
@@ -197,6 +211,7 @@ class Valkey
         @initialized = false
         @config = nil
         @parent_span_context_provider = nil
+        @config_refs = nil
       end
 
       private
@@ -226,12 +241,18 @@ class Valkey
       def build_config(traces, metrics, flush_interval_ms)
         config_struct = Bindings::OpenTelemetryConfig.new
 
+        # Objects referenced only by raw address from config_struct. They must
+        # outlive the Bindings.init_open_telemetry call, so we collect and return
+        # them for the caller to pin (config_struct only stores their addresses).
+        keep_alive = [config_struct]
+
         # Configure traces if provided
         if traces
           validate_endpoint!(traces[:endpoint], "traces")
 
           traces_struct = Bindings::OpenTelemetryTracesConfig.new
-          traces_struct[:endpoint] = FFI::MemoryPointer.from_string(traces[:endpoint])
+          endpoint_ptr = FFI::MemoryPointer.from_string(traces[:endpoint])
+          traces_struct[:endpoint] = endpoint_ptr
 
           if traces[:sample_percentage]
             traces_struct[:has_sample_percentage] = true
@@ -242,6 +263,8 @@ class Valkey
           end
 
           config_struct[:traces] = traces_struct.pointer
+          # Pin the wrapper (owns the endpoint ref) and the endpoint buffer.
+          keep_alive.push(traces_struct, endpoint_ptr)
         else
           config_struct[:traces] = FFI::Pointer::NULL
         end
@@ -251,8 +274,10 @@ class Valkey
           validate_endpoint!(metrics[:endpoint], "metrics")
 
           metrics_struct = Bindings::OpenTelemetryMetricsConfig.new
-          metrics_struct[:endpoint] = FFI::MemoryPointer.from_string(metrics[:endpoint])
+          endpoint_ptr = FFI::MemoryPointer.from_string(metrics[:endpoint])
+          metrics_struct[:endpoint] = endpoint_ptr
           config_struct[:metrics] = metrics_struct.pointer
+          keep_alive.push(metrics_struct, endpoint_ptr)
         else
           config_struct[:metrics] = FFI::Pointer::NULL
         end
@@ -266,7 +291,7 @@ class Valkey
           config_struct[:flush_interval_ms] = 5000 # Default
         end
 
-        config_struct
+        [config_struct, keep_alive]
       end
 
       def validate_endpoint!(endpoint, type)

--- a/lib/valkey/opentelemetry.rb
+++ b/lib/valkey/opentelemetry.rb
@@ -97,16 +97,13 @@ class Valkey
           raise ArgumentError, "flush_interval_ms must be a positive integer, got: #{flush_interval_ms}"
         end
 
-        # Build the configuration. keep_alive pins the nested FFI structs and
-        # endpoint buffers that the config struct references only by raw address;
-        # they must stay alive across the native call below (see build_config).
+        # Build the configuration
+        # keep_alive needs to be referenced so not to be GC'd before init_open_telemetry
+        # TODO: Refactor per https://github.com/valkey-io/valkey-glide-ruby/issues/179
         config, keep_alive = build_config(traces, metrics, flush_interval_ms)
 
-        # Call the FFI function. init_open_telemetry copies the endpoint strings
-        # synchronously and retains no pointers, so once it returns the pinned
-        # buffers are no longer read by the native layer and can be released.
         error_ptr = Bindings.init_open_telemetry(config)
-        keep_alive.clear
+        keep_alive.clear # Needed to avoid linter warning.
 
         unless error_ptr.null?
           error_msg = error_ptr.read_string
@@ -228,25 +225,21 @@ class Valkey
         raise ArgumentError, "tracestate must be a String or nil, got: #{tracestate.class}"
       end
 
-      # Builds the native OpenTelemetry config struct from the given options.
+      # Build the native OpenTelemetry configuration struct from the given options.
       #
-      # @return [Array(FFI::Struct, Array)] a two-element tuple:
-      #   1. the +OpenTelemetryConfig+ struct to pass to +Bindings.init_open_telemetry+, and
-      #   2. a +keep_alive+ array of the objects it references only by raw address —
-      #      the nested traces/metrics struct wrappers and their endpoint
-      #      +MemoryPointer+ buffers.
+      # @param traces [Hash, nil] Traces configuration (see {init})
+      # @param metrics [Hash, nil] Metrics configuration (see {init})
+      # @param flush_interval_ms [Integer, nil] Flush interval in milliseconds
       #
-      #   The config struct stores only the addresses of those nested objects, so
-      #   the caller MUST keep +keep_alive+ referenced until after the native init
-      #   call returns; otherwise GC could free the endpoint buffers and leave
-      #   +config->traces/metrics->endpoint+ dangling (use-after-free). This is the
-      #   same buffer-pinning contract as +build_command_args+.
+      # @return [Array(Bindings::OpenTelemetryConfig, Array)] a two-element array of:
+      #   - the `config` struct to pass to `Bindings.init_open_telemetry`
+      #   - a `keep_alive` array containing references to values in `config`.
+      #     This is so the caller can keep them alive in their own scope, otherwise
+      #     they may be garbage collected before use.
+      #     TODO: Refactor per https://github.com/valkey-io/valkey-glide-ruby/issues/179
       def build_config(traces, metrics, flush_interval_ms)
         config_struct = Bindings::OpenTelemetryConfig.new
 
-        # Objects referenced only by raw address from config_struct. They must
-        # outlive the Bindings.init_open_telemetry call, so we collect and return
-        # them for the caller to pin (config_struct only stores their addresses).
         keep_alive = [config_struct]
 
         # Configure traces if provided

--- a/lib/valkey/opentelemetry.rb
+++ b/lib/valkey/opentelemetry.rb
@@ -45,10 +45,6 @@ class Valkey
     @initialized = false
     @config = nil
     @parent_span_context_provider = nil
-    # Retains the FFI config struct wrappers and endpoint buffers passed to the
-    # native init so their memory isn't GC'd while the native layer holds their
-    # raw addresses. See build_config / init.
-    @config_refs = nil
 
     class << self
       # Initialize OpenTelemetry in the Valkey GLIDE core.
@@ -101,21 +97,16 @@ class Valkey
           raise ArgumentError, "flush_interval_ms must be a positive integer, got: #{flush_interval_ms}"
         end
 
-        # Build the configuration.
-        #
-        # build_config returns the config struct plus a "keep_alive" set of the
-        # nested FFI struct wrappers and endpoint buffers. The config struct only
-        # stores their raw addresses, so those objects must stay referenced until
-        # after the native call finishes reading them — otherwise GC could free
-        # the endpoint buffers and leave config->traces/metrics->endpoint
-        # dangling (use-after-free). Mirrors the buffer pinning in
-        # build_command_args. Stashing them in @config_refs keeps them alive for
-        # the process lifetime (init is one-time), which covers the native call.
+        # Build the configuration. keep_alive pins the nested FFI structs and
+        # endpoint buffers that the config struct references only by raw address;
+        # they must stay alive across the native call below (see build_config).
         config, keep_alive = build_config(traces, metrics, flush_interval_ms)
-        @config_refs = keep_alive
 
-        # Call the FFI function
+        # Call the FFI function. init_open_telemetry copies the endpoint strings
+        # synchronously and retains no pointers, so once it returns the pinned
+        # buffers are no longer read by the native layer and can be released.
         error_ptr = Bindings.init_open_telemetry(config)
+        keep_alive.clear
 
         unless error_ptr.null?
           error_msg = error_ptr.read_string
@@ -211,7 +202,6 @@ class Valkey
         @initialized = false
         @config = nil
         @parent_span_context_provider = nil
-        @config_refs = nil
       end
 
       private
@@ -238,6 +228,19 @@ class Valkey
         raise ArgumentError, "tracestate must be a String or nil, got: #{tracestate.class}"
       end
 
+      # Builds the native OpenTelemetry config struct from the given options.
+      #
+      # @return [Array(FFI::Struct, Array)] a two-element tuple:
+      #   1. the +OpenTelemetryConfig+ struct to pass to +Bindings.init_open_telemetry+, and
+      #   2. a +keep_alive+ array of the objects it references only by raw address —
+      #      the nested traces/metrics struct wrappers and their endpoint
+      #      +MemoryPointer+ buffers.
+      #
+      #   The config struct stores only the addresses of those nested objects, so
+      #   the caller MUST keep +keep_alive+ referenced until after the native init
+      #   call returns; otherwise GC could free the endpoint buffers and leave
+      #   +config->traces/metrics->endpoint+ dangling (use-after-free). This is the
+      #   same buffer-pinning contract as +build_command_args+.
       def build_config(traces, metrics, flush_interval_ms)
         config_struct = Bindings::OpenTelemetryConfig.new
 


### PR DESCRIPTION
### Summary

Fixes an use-after-free isssue `Valkey::OpenTelemetry` init. `build_config`.

### Issue link

Related to #179

### Features / Changes

- `build_config` returns `[config_struct, keep_alive]`; `keep_alive` pins the nested structs and endpoint buffers the config references only by address.
- `init` holds `keep_alive` across the `init_open_telemetry` call, then releases it — the native side copies the endpoints synchronously and retains no pointers.
- Documents the pinning contract on `build_config` and adds a `#179` TODO.

### Testing

- No automated test (a unit test can't deterministically force the use-after-free).
- Manual: stubbed-init smoke check confirms the endpoint is read correctly during the call and init completes.
- `bundle exec rubocop lib/valkey/opentelemetry.rb` → no offenses; `ruby -c` → OK.

### Checklist

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated. (Intentionally omitted — see Testing.)
-   [ ] Documentation is updated (if applicable).
-   [x] Linters have been run (`bundle exec rubocop`) and pass.
-   [x] Destination branch is correct — **release-1.0**.
