### PR TITLE
fix: raise on unparseable Valkey URLs; support valkey:// scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,13 +95,22 @@ client.close
 
 ### Standalone with URL (redis-rb compatible)
 
+Accepted URL schemes: `redis://`, `rediss://` (TLS), `valkey://`, `valkeys://` (TLS).
+
 ```ruby
 client = Valkey.new(url: "redis://localhost:6379/0")
-# TLS: rediss://user:password@localhost:6380/0
+# Valkey-native scheme (matches valkey-cli -u):
+#   valkey://localhost:6379/0
+# TLS variants:
+#   rediss://user:password@localhost:6380/0
+#   valkeys://user:password@localhost:6380/0
 
 client.ping
 # => "PONG"
 ```
+
+Unparseable URLs, unsupported schemes, and URLs without a host raise
+`ArgumentError` — they no longer fall back to `127.0.0.1:6379` silently.
 
 ### Cluster Mode
 
@@ -180,7 +189,7 @@ built dynamically. Both return the raw reply with no type-casting based on the c
 | Option | Description |
 |--------|-------------|
 | `host`, `port` | Server address (default `127.0.0.1:6379`) |
-| `url` | `redis://` or `rediss://` URI (merged with explicit options) |
+| `url` | `redis://`, `rediss://`, `valkey://`, or `valkeys://` URI (merged with explicit options) |
 | `db` | Database index (standalone only) |
 | `password`, `username` | Authentication |
 | `timeout` | Request timeout in seconds (default `5.0`) |

--- a/lib/valkey.rb
+++ b/lib/valkey.rb
@@ -85,7 +85,8 @@ class Valkey
       uri_parts << "@"
     end
 
-    uri_parts << uri_host
+    # Wrap IPv6 literals in brackets so the host/port separator is unambiguous.
+    uri_parts << (uri_host.include?(":") ? "[#{uri_host}]" : uri_host)
     uri_parts << ":"
     uri_parts << uri_port.to_s
 

--- a/lib/valkey/utils.rb
+++ b/lib/valkey/utils.rb
@@ -249,7 +249,11 @@ class Valkey
     def self.parse_redis_url(url)
       return {} unless url.is_a?(String) && !url.empty?
 
-      redacted = url.sub(%r{://[^/@]*@}, '://[REDACTED]@').inspect
+      # Redact userinfo before it ends up in error messages, logs, or trackers.
+      # The regex greedily consumes up to the LAST `@` after `://`, so passwords
+      # containing `/` or `@` are still fully redacted (RFC 3986 allows both in
+      # percent-decoded form; either can appear raw in a user-supplied URL).
+      redacted = url.sub(%r{(\A[^:]+://).*@}, '\1[REDACTED]@').inspect
 
       uri = begin
         URI.parse(url)

--- a/lib/valkey/utils.rb
+++ b/lib/valkey/utils.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "uri"
+
 class Valkey
   # Valkey Utils module
   #
@@ -223,48 +225,64 @@ class Valkey
 
     Noop = ->(reply) { reply }
 
-    # Parse Redis URL format: redis://[:password@]host[:port][/db]
-    # Also supports: rediss:// (SSL)
+    # Parse a Valkey/Redis connection URL.
     #
-    # @param [String] url Redis URL to parse
-    # @return [Hash] Parsed connection options with keys: :host, :port, :password, :username, :db, :ssl
+    # Accepted schemes: redis, rediss, valkey, valkeys. TLS is enabled for the
+    # `rediss` and `valkeys` variants. Matches the URI format documented for
+    # valkey-cli (`valkey://user:password@host:port/dbnum`).
+    #
+    # @param [String] url Connection URL to parse
+    # @return [Hash] Parsed options with keys :host, :port, :ssl,
+    #   and optionally :username, :password, :db. Returns {} for nil / "".
+    # @raise [ArgumentError] if the URL is malformed, has an unsupported
+    #   scheme, is missing a host, or has a non-integer db path.
     # @example
     #   parse_redis_url('redis://:secret@localhost:6379/15')
     #   # => { host: 'localhost', port: 6379, password: 'secret', db: 15, ssl: false }
     #
-    #   parse_redis_url('rediss://user:secret@localhost:6380/0')
+    #   parse_redis_url('valkeys://user:secret@localhost:6380/0')
     #   # => { host: 'localhost', port: 6380, username: 'user', password: 'secret', db: 0, ssl: true }
+    ALLOWED_URL_SCHEMES = %w[redis rediss valkey valkeys].freeze
+    TLS_URL_SCHEMES = %w[rediss valkeys].freeze
+    private_constant :ALLOWED_URL_SCHEMES, :TLS_URL_SCHEMES
+
     def self.parse_redis_url(url)
       return {} unless url.is_a?(String) && !url.empty?
 
-      # Match redis:// or rediss:// URLs
-      # Format: redis[s]://[username:password@]host[:port][/db][?param=value]
-      # Supports: redis://host, redis://user:pass@host, redis://:pass@host
-      # The regex handles:
-      # - No auth: redis://host...
-      # - Username and password: redis://user:pass@host...
-      # - Password only: redis://:pass@host...
-      match = url.match(%r{\A(redis|rediss)://(?:([^:@]*):([^@]+)@)?([^:/]+)(?::(\d+))?(?:/(\d+))?(?:\?.*)?\z})
+      redacted = url.sub(%r{://[^/@]*@}, '://[REDACTED]@').inspect
 
-      return {} unless match
+      uri = begin
+        URI.parse(url)
+      rescue URI::InvalidURIError
+        raise ArgumentError, "Invalid Valkey URL #{redacted}: URI could not be parsed"
+      end
 
-      scheme = match[1]
-      username = match[2]
-      password = match[3]
-      host = match[4]
-      port = match[5]&.to_i
-      db = match[6]&.to_i
-      ssl = scheme == "rediss"
+      unless ALLOWED_URL_SCHEMES.include?(uri.scheme)
+        raise ArgumentError,
+              "Invalid Valkey URL #{redacted}: scheme must be one of " \
+              "#{ALLOWED_URL_SCHEMES.join(', ')}, got #{uri.scheme.inspect}"
+      end
+
+      host = uri.hostname
+      raise ArgumentError, "Invalid Valkey URL #{redacted}: missing host" if host.to_s.empty?
 
       result = {
         host: host,
-        port: port || 6379,
-        ssl: ssl
+        port: uri.port || 6379,
+        ssl: TLS_URL_SCHEMES.include?(uri.scheme)
       }
 
-      result[:username] = username if username && !username.empty?
-      result[:password] = password if password && !password.empty?
-      result[:db] = db if db
+      db_segment = uri.path.to_s.delete_prefix('/')
+      unless db_segment.empty?
+        unless db_segment.match?(/\A\d+\z/)
+          raise ArgumentError, "Invalid Valkey URL #{redacted}: database must be a non-negative integer"
+        end
+
+        result[:db] = db_segment.to_i
+      end
+
+      result[:username] = uri.user if uri.user && !uri.user.empty?
+      result[:password] = uri.password if uri.password && !uri.password.empty?
 
       result
     end

--- a/test/valkey/uri_connection_test.rb
+++ b/test/valkey/uri_connection_test.rb
@@ -878,12 +878,12 @@ module ValkeyTests
 
     def test_url_with_invalid_scheme
       skip("URI connection tests only run on standalone mode") if cluster_mode?
-      # redis-rb's parse_redis_url should handle this
-      # but we should not crash
 
-      ::Valkey.new(url: "http://localhost:6379", connect_timeout: 1.0)
-    rescue ArgumentError, ::Valkey::CannotConnectError
-      # Expected - invalid scheme
+      # The specific error wording lives in Utils.parse_redis_url; at this
+      # layer we only care that Valkey.new no longer silently connects.
+      assert_raises(ArgumentError) do
+        ::Valkey.new(url: "http://localhost:6379", connect_timeout: 1.0)
+      end
     end
 
     def test_url_overridden_by_explicit_invalid_values
@@ -895,6 +895,32 @@ module ValkeyTests
         )
       end
       assert_match(/Database ID must be non-negative/, error.message)
+    end
+
+    # Regression test for GH #185: unparseable URLs used to silently connect
+    # to 127.0.0.1:6379. They must now raise ArgumentError instead.
+    def test_unparseable_url_raises_instead_of_falling_back
+      skip("URI connection tests only run on standalone mode") if cluster_mode?
+
+      assert_raises(ArgumentError) do
+        ::Valkey.new(url: "not-a-url", connect_timeout: 1.0)
+      end
+    end
+
+    def test_url_with_trailing_slash_parses
+      skip("URI connection tests only run on standalone mode") if cluster_mode?
+
+      client = ::Valkey.new(url: "redis://localhost:6379/")
+      assert_equal "PONG", client.ping
+      client.close
+    end
+
+    def test_valkey_scheme_url_parses
+      skip("URI connection tests only run on standalone mode") if cluster_mode?
+
+      client = ::Valkey.new(url: "valkey://localhost:6379/0")
+      assert_equal "PONG", client.ping
+      client.close
     end
   end
 end

--- a/test/valkey/utils_test.rb
+++ b/test/valkey/utils_test.rb
@@ -160,6 +160,20 @@ module ValkeyTests
       end
       refute_match(/supersecret/, error.message)
       assert_match(/REDACTED/, error.message)
+
+      # Password containing `/` — must still redact, not slip through userinfo
+      error = assert_raises(ArgumentError) do
+        ::Valkey::Utils.parse_redis_url("redis://user:sup/er/secret@bad-host:notaport/x")
+      end
+      refute_match(%r{sup/er/secret}, error.message)
+      assert_match(/REDACTED/, error.message)
+
+      # Password containing raw `@`
+      error = assert_raises(ArgumentError) do
+        ::Valkey::Utils.parse_redis_url("redis://user:p@ss@bad-host:notaport/x")
+      end
+      refute_match(/p@ss/, error.message)
+      assert_match(/REDACTED/, error.message)
     end
   end
 end

--- a/test/valkey/utils_test.rb
+++ b/test/valkey/utils_test.rb
@@ -92,11 +92,74 @@ module ValkeyTests
     end
 
     def test_parse_redis_url_invalid_format
-      # Should handle gracefully or return nil
-      result = ::Valkey::Utils.parse_redis_url("not-a-url")
-      # The method should either return nil or raise an error
-      # Based on implementation, it might return nil or raise
-      assert(result.nil? || result.is_a?(Hash))
+      error = assert_raises(ArgumentError) { ::Valkey::Utils.parse_redis_url("not-a-url") }
+      assert_match(/not-a-url/, error.message)
+    end
+
+    def test_parse_redis_url_trailing_slash
+      result = ::Valkey::Utils.parse_redis_url("redis://myhost.example.com:6380/")
+      assert_equal "myhost.example.com", result[:host]
+      assert_equal 6380, result[:port]
+      assert_nil result[:db]
+      assert_equal false, result[:ssl]
+    end
+
+    def test_parse_redis_url_ipv6_host
+      result = ::Valkey::Utils.parse_redis_url("redis://[::1]:6379/0")
+      assert_equal "::1", result[:host]
+      assert_equal 6379, result[:port]
+      assert_equal 0, result[:db]
+    end
+
+    def test_parse_redis_url_valkey_scheme
+      result = ::Valkey::Utils.parse_redis_url("valkey://myhost.example.com:6380/0")
+      assert_equal "myhost.example.com", result[:host]
+      assert_equal 6380, result[:port]
+      assert_equal 0, result[:db]
+      assert_equal false, result[:ssl]
+    end
+
+    def test_parse_redis_url_valkeys_scheme_enables_tls
+      result = ::Valkey::Utils.parse_redis_url("valkeys://user:pass@myhost.example.com:6380/2")
+      assert_equal "myhost.example.com", result[:host]
+      assert_equal 6380, result[:port]
+      assert_equal "user", result[:username]
+      assert_equal "pass", result[:password]
+      assert_equal 2, result[:db]
+      assert_equal true, result[:ssl]
+    end
+
+    def test_parse_redis_url_unknown_scheme_raises
+      error = assert_raises(ArgumentError) { ::Valkey::Utils.parse_redis_url("http://localhost:6379") }
+      assert_match(/scheme must be one of/, error.message)
+    end
+
+    def test_parse_redis_url_missing_host_raises
+      error = assert_raises(ArgumentError) { ::Valkey::Utils.parse_redis_url("redis://") }
+      assert_match(/missing host/, error.message)
+    end
+
+    def test_parse_redis_url_non_integer_db_raises
+      error = assert_raises(ArgumentError) do
+        ::Valkey::Utils.parse_redis_url("redis://localhost:6379/not-a-number")
+      end
+      assert_match(/database must be a non-negative integer/, error.message)
+    end
+
+    def test_parse_redis_url_error_message_redacts_credentials
+      # Non-integer db (validated after URI parse)
+      error = assert_raises(ArgumentError) do
+        ::Valkey::Utils.parse_redis_url("redis://user:supersecret@localhost:6379/not-a-number")
+      end
+      refute_match(/supersecret/, error.message)
+      assert_match(/REDACTED/, error.message)
+
+      # URI.parse itself failing — must not leak the password from the underlying error
+      error = assert_raises(ArgumentError) do
+        ::Valkey::Utils.parse_redis_url("redis://user:supersecret@bad-host:notaport/x")
+      end
+      refute_match(/supersecret/, error.message)
+      assert_match(/REDACTED/, error.message)
     end
   end
 end


### PR DESCRIPTION
### Summary

`Valkey.new(url: ...)` silently connected to `127.0.0.1:6379` whenever the URL didn't match a narrow hand-rolled regex in `Utils.parse_redis_url` — trailing slashes, IPv6 literals, the Valkey-native `valkey://` scheme, and any unparseable string all fell through to the localhost defaults with no warning or exception. This PR replaces the regex parser with `URI.parse`, raises `ArgumentError` on unparseable URLs / unknown schemes / missing hosts, and accepts the four schemes documented by valkey-cli (`redis`, `rediss`, `valkey`, `valkeys`).

### Issue link

- Closes #185

### Features / Changes

- `lib/valkey/utils.rb` — Rewrote `parse_redis_url` to use `URI.parse`. Accepts `redis`, `rediss`, `valkey`, `valkeys` (matching `valkey-cli -u` semantics — `valkeys` maps to TLS). Raises `ArgumentError` on unparseable URLs, unknown schemes, missing hosts, or non-integer database paths. Error messages redact userinfo (`redis://[REDACTED]@…`) so passwords don't leak into logs, stack traces, or error trackers.
- `lib/valkey.rb` — Wraps host in `[..]` at outgoing URI assembly when it contains a `:`, so IPv6 literals produce an unambiguous URI to the FFI.
- `README.md` — Documented all four accepted schemes and the new raise-on-invalid behavior.
- Note: URL-decoding of userinfo (percent-encoded `@`, `:`, etc. in passwords) is intentionally deferred to #184, which owns that credential-handling fix.

### Testing

**Unit tests (`test/valkey/utils_test.rb`):** replaced the permissive `test_parse_redis_url_invalid_format` with an `assert_raises`, added 9 new tests covering trailing slash, IPv6, `valkey://`, `valkeys://`, unknown scheme, missing host, non-integer db, and credential redaction (both URI-parse failure and post-parse validation paths).

**Integration tests (`test/valkey/uri_connection_test.rb`):** tightened `test_url_with_invalid_scheme` to `assert_raises(ArgumentError)`, added `test_unparseable_url_raises_instead_of_falling_back` (the specific GH #185 regression), `test_url_with_trailing_slash_parses`, and `test_valkey_scheme_url_parses`.

**Local test runs on this branch (base `release-1.0` @ `bf4a67f`):**

- `bundle exec rubocop lib/valkey/utils.rb lib/valkey.rb test/valkey/utils_test.rb test/valkey/uri_connection_test.rb` — 4 files, 0 offenses.
- `bundle exec rake test:standalone` — 787 tests, 4035 assertions, **0 failures**, 4 errors, 102 skips. All 4 errors are `TLS_CERT_DIR is not set` — pre-existing infra requirement, present on the untouched base, unrelated to this diff.
- `bundle exec rake test:cluster` — 787 tests, 2763 assertions, **0 failures**, 4 errors, 277 skips. Same 4 pre-existing TLS_CERT_DIR errors.
- All 24 URL/URI-related tests pass, including every new/tightened test above.

### Checklist

Before submitting the PR make sure the following are checked:

- [x] This Pull Request is related to one issue.
- [x] Commit message has a detailed description of what changed and why.
- [x] Tests are added or updated.
- [x] Documentation is updated (if applicable).
- [x] Linters have been run (`bundle exec rubocop`) and pass.
- [x] Destination branch is correct - `release-1.0`