### PR TITLE
Backport #164: multi atomic batch support to release-1.0

### DIFF
--- a/lib/valkey.rb
+++ b/lib/valkey.rb
@@ -427,7 +427,9 @@ class Valkey
         RequestType::MULTI, RequestType::EXEC, RequestType::DISCARD,
         RequestType::WATCH, RequestType::UNWATCH
       ]
-      @queued_commands << [command_type, command_args.dup] if !tx_commands.include?(command_type) && result == "QUEUED"
+      if !tx_commands.include?(command_type) && result == "QUEUED"
+        @queued_commands << [command_type, command_args.dup, block]
+      end
     end
 
     result
@@ -453,23 +455,29 @@ class Valkey
     end
   end
 
-  def send_batch_commands(commands, exception: true)
+  def send_batch_commands(commands, exception: true, is_atomic: false)
     # WORKAROUND: The underlying Glide FFI backend has stability issues when
-    # batching transactional commands like MULTI / EXEC / DISCARD. To avoid
-    # native crashes we fall back to issuing those commands sequentially
-    # instead of via `Bindings.batch`.
-    tx_types = [RequestType::MULTI, RequestType::EXEC, RequestType::DISCARD]
+    # batching LITERAL MULTI / EXEC / DISCARD commands (e.g. a `pipelined` block
+    # that manually calls `pipeline.multi`/`pipeline.exec`). To avoid native
+    # crashes we fall back to issuing those commands sequentially instead of via
+    # `Bindings.batch`. This never applies to a real `is_atomic: true` batch
+    # (see `multi`'s block form) - that path never contains literal MULTI/EXEC
+    # commands, since the server-side transaction wrapping is handled by GLIDE
+    # itself based on the `is_atomic` flag, not by commands in the list.
+    unless is_atomic
+      tx_types = [RequestType::MULTI, RequestType::EXEC, RequestType::DISCARD]
 
-    if commands.any? { |(command_type, _args, _block)| tx_types.include?(command_type) }
-      results = []
+      if commands.any? { |(command_type, _args, _block)| tx_types.include?(command_type) }
+        results = []
 
-      commands.each do |command_type, command_args, block|
-        res = send_command(command_type, command_args)
-        res = block.call(res) if block
-        results << res
+        commands.each do |command_type, command_args, block|
+          res = send_command(command_type, command_args)
+          res = block.call(res) if block
+          results << res
+        end
+
+        return results
       end
-
-      return results
     end
 
     cmds = []
@@ -499,7 +507,7 @@ class Valkey
     batch_info = Bindings::BatchInfo.new
     batch_info[:cmd_count] = cmds.size
     batch_info[:cmds] = cmd_ptrs
-    batch_info[:is_atomic] = false
+    batch_info[:is_atomic] = is_atomic
 
     batch_options = Bindings::BatchOptionsInfo.new
     batch_options[:retry_server_error] = true
@@ -705,7 +713,10 @@ class Valkey
 
     response = convert_response.call(result)
 
-    if block_given?
+    # Don't run the caller's converter (e.g. Utils::Boolify) over the MULTI-queued
+    # "QUEUED" sentinel - send_command's own `result == "QUEUED"` check (used to
+    # track queued commands) needs to see the literal string, not e.g. `true`.
+    if block_given? && response != "QUEUED"
       block.call(response)
     else
       response

--- a/lib/valkey/commands/string_commands.rb
+++ b/lib/valkey/commands/string_commands.rb
@@ -141,7 +141,7 @@ class Valkey
         # other GLIDE bindings' existing contracts expect to keep returning a
         # plain 0/1 integer. Doing the conversion here keeps it scoped to this
         # one Ruby-level method - see hexists/hsetnx for the same pattern.
-        send_command(RequestType::SET_NX, [key, value], &Utils::Boolify)
+        send_command(RequestType::SET_NX, [key, value.to_s], &Utils::Boolify)
       end
 
       # Set one or more values.

--- a/lib/valkey/commands/string_commands.rb
+++ b/lib/valkey/commands/string_commands.rb
@@ -141,7 +141,7 @@ class Valkey
         # other GLIDE bindings' existing contracts expect to keep returning a
         # plain 0/1 integer. Doing the conversion here keeps it scoped to this
         # one Ruby-level method - see hexists/hsetnx for the same pattern.
-        send_command(RequestType::SET_NX, [key, value.to_s], &Utils::Boolify)
+        send_command(RequestType::SET_NX, [key, value], &Utils::Boolify)
       end
 
       # Set one or more values.

--- a/lib/valkey/commands/transaction_commands.rb
+++ b/lib/valkey/commands/transaction_commands.rb
@@ -16,8 +16,12 @@ class Valkey
       #   end # => ["OK", 6]
       #
       # @yield [multi] the commands that are called inside this block are cached
-      #   and written to the server upon returning from it
-      # @yieldparam [Valkey] multi `self`
+      #   locally (no server round-trip per command) and sent to the server as a
+      #   single atomic batch once the block returns - GLIDE wraps them in a real
+      #   MULTI/EXEC transaction internally. If the block raises, nothing has been
+      #   sent to the server yet, so the exception simply propagates - there is no
+      #   transaction to discard.
+      # @yieldparam [Valkey::Pipeline] multi collects the block's commands
       #
       # @return [Array<...>]
       #   - an array with replies
@@ -26,17 +30,12 @@ class Valkey
       # @see #unwatch
       def multi
         if block_given?
-          begin
-            @in_multi_block = true
-            start_multi
-            yield(self)
-            exec
-          rescue StandardError
-            discard
-            raise
-          ensure
-            @in_multi_block = false
-          end
+          pipeline = Pipeline.new
+          yield pipeline
+
+          return [] if pipeline.commands.empty?
+
+          send_batch_commands(pipeline.commands, exception: true, is_atomic: true)
         else
           start_multi
           self
@@ -114,11 +113,12 @@ class Valkey
       # @see #discard
       def exec
         if @in_multi
+          queued_commands = @queued_commands
           begin
             begin
               result = send_command(RequestType::EXEC)
               # If EXEC returns an error object (from array), it's already handled
-              result
+              result.is_a?(Array) ? reconvert_queued_replies(result, queued_commands) : result
             rescue CommandError => e
               # If EXEC itself raises an error (like when transaction is aborted),
               # return an array with the error to match expected behavior in tests
@@ -157,7 +157,58 @@ class Valkey
         @queued_commands = []
       end
 
+      # Commands whose reply is boolean when run standalone (via native return-type
+      # coercion server-side), but arrives as a raw 0/1 integer inside an EXEC array,
+      # since that coercion is keyed by the single command actually being run - which,
+      # for a queued command, is EXEC itself, not the original command.
+      #
+      # This list mirrors glide-core's own Boolean-coercion table in
+      # `value_conversion.rs::expected_type_for_cmd` (HEXISTS, HSETNX, EXPIRE, EXPIREAT,
+      # PEXPIRE, PEXPIREAT, SISMEMBER, PERSIST, SMOVE, PFADD, RENAMENX, MOVE, COPY,
+      # MSETNX, XGROUP DESTROY, XGROUP CREATECONSUMER) MINUS the commands whose Ruby
+      # method already passes its own explicit conversion block (`hexists`/`hsetnx`
+      # use `&Utils::Boolify`; `xgroup_destroy`/`xgroup_createconsumer` use a custom
+      # bool->int block). Those are already handled correctly by the `if block`
+      # branch below, before this list is even consulted - listing them here too
+      # would be redundant, not wrong. Every RequestType below calls `send_command`
+      # with NO block at all, so this static list is the only place their boolean-ness
+      # is recorded.
+      #
+      # NOTE: SETNX is deliberately NOT in glide-core's coercion table (and so isn't
+      # here as a "no block" entry either) - it's `redis-rb`-style boolean-ness only,
+      # not something the server/`glide-core` treats as boolean, since coercion there
+      # is keyed by command name alone and can't distinguish this dedicated RequestType
+      # from a raw `customCommand(["SETNX", ...])` call, which other bindings' existing
+      # contracts expect to keep returning a plain integer. `setnx`'s own Ruby method
+      # passes `&Utils::Boolify` directly instead - see string_commands.rb - so it's
+      # already covered by the `if block` branch, same as hexists/hsetnx.
+      BOOLEAN_REQUEST_TYPES = [
+        RequestType::EXPIRE, RequestType::EXPIRE_AT, RequestType::PEXPIRE, RequestType::PEXPIRE_AT,
+        RequestType::PERSIST, RequestType::SISMEMBER, RequestType::S_MOVE, RequestType::PFADD,
+        RequestType::RENAME_NX, RequestType::MOVE, RequestType::COPY, RequestType::MSET_NX
+      ].freeze
+
       private
+
+      # Re-applies each queued command's own reply conversion (e.g. `&Utils::Boolify`)
+      # to EXEC's raw array, since redis-rb's Future-based design does the equivalent
+      # (a Future remembers its conversion and re-applies it once EXEC resolves), but
+      # queued commands here go through the plain single-command path with no such
+      # memory - see BOOLEAN_REQUEST_TYPES above for the case with no explicit block.
+      def reconvert_queued_replies(result, queued_commands)
+        return result unless result.size == queued_commands.size
+
+        result.each_with_index.map do |value, i|
+          command_type, _args, block = queued_commands[i]
+          if block
+            block.call(value)
+          elsif BOOLEAN_REQUEST_TYPES.include?(command_type)
+            Utils::Boolify.call(value)
+          else
+            value
+          end
+        end
+      end
 
       # Start a MULTI block if one isn't already active.
       #

--- a/test/lint/string_commands.rb
+++ b/test/lint/string_commands.rb
@@ -97,14 +97,12 @@ module Lint
     end
 
     def test_setex
-      skip "setex is deprecated in Redis 2.6.12"
       assert r.setex("foo", 1, "bar")
       assert_equal "bar", r.get("foo")
       assert [0, 1].include? r.ttl("foo")
     end
 
     def test_setex_with_non_string_value
-      skip "setex is deprecated in Redis 2.6.12"
       value = %w[b a r]
 
       assert r.setex("foo", 1, value)
@@ -113,14 +111,12 @@ module Lint
     end
 
     def test_psetex
-      skip "psetex is deprecated in Redis 2.6.12"
       assert r.psetex("foo", 1000, "bar")
       assert_equal "bar", r.get("foo")
       assert [0, 1].include? r.ttl("foo")
     end
 
     def test_psetex_with_non_string_value
-      skip "psetex is deprecated in Redis 2.6.12"
       value = %w[b a r]
 
       assert r.psetex("foo", 1000, value)
@@ -161,8 +157,6 @@ module Lint
     end
 
     def test_setnx
-      skip "setnx is deprecated in Redis 2.6.12"
-
       r.set("foo", "qux")
       assert !r.setnx("foo", "bar")
       assert_equal "qux", r.get("foo")
@@ -173,8 +167,6 @@ module Lint
     end
 
     def test_setnx_with_non_string_value
-      skip "setnx is deprecated in Redis 2.6.12"
-
       value = %w[b a r]
 
       r.set("foo", "qux")

--- a/test/lint/transaction_commands.rb
+++ b/test/lint/transaction_commands.rb
@@ -520,5 +520,36 @@ module Lint
       res = r.watch("foo")
       assert_equal "OK", res
     end
+
+    def test_multi_with_boolean_reply_commands
+      # In cluster mode, MULTI/EXEC transactions require all keys in same slot
+      # and behave differently with connection routing
+      skip("MULTI/EXEC not supported in cluster mode") if cluster_mode?
+
+      r.set("foo", "bar")
+      r.del("someset")
+
+      result = r.multi do |multi|
+        multi.persist("foo")
+        multi.pexpire("foo", 900_000)
+        multi.sismember("someset", "member")
+      end
+
+      assert_equal [false, true, false], result
+    end
+
+    def test_multi_with_setnx
+      skip("MULTI/EXEC not supported in cluster mode") if cluster_mode?
+
+      r.set("foo", "existing")
+      r.del("bar")
+
+      result = r.multi do |multi|
+        multi.setnx("foo", "ignored")
+        multi.setnx("bar", "new")
+      end
+
+      assert_equal [false, true], result
+    end
   end
 end


### PR DESCRIPTION
## Summary

Backport of #164 (commit c932ad2) to `release-1.0`.

Adopts core's BATCH support for atomic MULTI transactions, restores `setex`/`psetex`/`setnx` (fixed in the bumped `valkey-glide` submodule), and adds transaction lint coverage.

## Conflicts resolved

Cherry-pick surfaced conflicts against release-1.0's newer code:

- `lib/valkey.rb` — kept release-1.0's `read_ssl_value` helper alongside the new `send_batch_commands(..., is_atomic:)` signature from #164.
- `lib/valkey/commands/string_commands.rb` (`setnx`) — dropped the `value.to_s` coercion in favor of #164's raw `value`. Release-1.0's `build_command_args` already handles String/Symbol/Integer/Float coercion (and rejects other types), so the explicit `.to_s` is redundant and #164's form is preferred.