### PR TITLE
Backport #192: Valkey::Future placeholders for pipelined/multi to release-1.0

### DIFF
--- a/lib/valkey.rb
+++ b/lib/valkey.rb
@@ -13,6 +13,7 @@ require "valkey/bindings"
 require "valkey/utils"
 require "valkey/commands"
 require "valkey/errors"
+require "valkey/future"
 require "valkey/pubsub_callback"
 require "valkey/pipeline"
 require "valkey/opentelemetry"
@@ -26,11 +27,18 @@ class Valkey
   def pipelined(exception: true)
     pipeline = Pipeline.new
 
-    yield pipeline
+    begin
+      yield pipeline
 
-    return [] if pipeline.commands.empty?
+      return [] if pipeline.commands.empty?
 
-    send_batch_commands(pipeline.commands, exception: exception)
+      results = send_batch_commands(pipeline.commands, exception: exception)
+      pipeline.resolve_futures!(results)
+      results
+    rescue StandardError
+      pipeline.abort_futures!
+      raise
+    end
   end
 
   def initialize(options = {})
@@ -561,8 +569,12 @@ class Valkey
       end
     end
 
+    # An inline error slot (see the ResponseType::ERROR case in
+    # convert_response above) must be left alone here - e.g. Utils::Boolify
+    # would otherwise silently coerce a CommandError object to `true`
+    # (`value != 0` is true for any non-numeric object), hiding the error.
     blocks.each_with_index do |block, i|
-      results[i] = block.call(results[i]) if block
+      results[i] = block.call(results[i]) if block && !results[i].is_a?(CommandError)
     end
 
     results

--- a/lib/valkey/commands/string_commands.rb
+++ b/lib/valkey/commands/string_commands.rb
@@ -29,7 +29,7 @@ class Valkey
       # @param [Integer] decrement
       # @return [Integer] value after decrementing it
       def decrby(key, decrement)
-        send_command(RequestType::DECR_BY, [key, decrement])
+        send_command(RequestType::DECR_BY, [key, Integer(decrement)])
       end
 
       # Increment the integer value of a key by one.
@@ -54,7 +54,7 @@ class Valkey
       # @param [Integer] increment
       # @return [Integer] value after incrementing it
       def incrby(key, increment)
-        send_command(RequestType::INCR_BY, [key, increment])
+        send_command(RequestType::INCR_BY, [key, Integer(increment)])
       end
 
       # Increment the numeric value of a key by the given float number.
@@ -91,10 +91,10 @@ class Valkey
         # see build_command_args's flat_map fix for why this must happen
         # before command_args is built, not be left to that generic layer.
         args = [key, value.to_s]
-        args << "EX" << ex if ex
-        args << "PX" << px if px
-        args << "EXAT" << exat if exat
-        args << "PXAT" << pxat if pxat
+        args << "EX" << Integer(ex) if ex
+        args << "PX" << Integer(px) if px
+        args << "EXAT" << Integer(exat) if exat
+        args << "PXAT" << Integer(pxat) if pxat
         args << "NX" if nx
         args << "XX" if xx
         args << "KEEPTTL" if keepttl
@@ -115,7 +115,7 @@ class Valkey
       # @param [String] value
       # @return [String] `"OK"`
       def setex(key, ttl, value)
-        send_command(RequestType::SET_EX, [key, ttl, value.to_s])
+        send_command(RequestType::SET_EX, [key, Integer(ttl), value.to_s])
       end
 
       # Set the time to live in milliseconds of a key.
@@ -264,7 +264,7 @@ class Valkey
       # @param [String] value
       # @return [Integer] length of the string after it was modified
       def setrange(key, offset, value)
-        send_command(RequestType::SET_RANGE, [key, offset, value.to_s])
+        send_command(RequestType::SET_RANGE, [key, Integer(offset), value.to_s])
       end
 
       # Get a substring of the string stored at key.
@@ -306,10 +306,10 @@ class Valkey
       # @return [String, nil] the value of key, or nil when key does not exist
       def getex(key, ex: nil, px: nil, exat: nil, pxat: nil, persist: false)
         args = [key]
-        args << "EX" << ex if ex
-        args << "PX" << px if px
-        args << "EXAT" << exat if exat
-        args << "PXAT" << pxat if pxat
+        args << "EX" << Integer(ex) if ex
+        args << "PX" << Integer(px) if px
+        args << "EXAT" << Integer(exat) if exat
+        args << "PXAT" << Integer(pxat) if pxat
         args << "PERSIST" if persist
 
         send_command(RequestType::GET_EX, args)

--- a/lib/valkey/commands/transaction_commands.rb
+++ b/lib/valkey/commands/transaction_commands.rb
@@ -20,7 +20,17 @@ class Valkey
       #   single atomic batch once the block returns - GLIDE wraps them in a real
       #   MULTI/EXEC transaction internally. If the block raises, nothing has been
       #   sent to the server yet, so the exception simply propagates - there is no
-      #   transaction to discard.
+      #   transaction to discard. Each in-block command call returns a
+      #   {Valkey::Future} immediately; capture it and call `#value` on it once
+      #   the block has returned to read that command's own reply:
+      #
+      #   @example Capturing a per-command reply
+      #     future = nil
+      #     valkey.multi do |multi|
+      #       future = multi.incr("counter")
+      #       multi.expire("counter", 60)
+      #     end
+      #     future.value # => 6
       # @yieldparam [Valkey::Pipeline] multi collects the block's commands
       #
       # @return [Array<...>]
@@ -31,11 +41,19 @@ class Valkey
       def multi
         if block_given?
           pipeline = Pipeline.new
-          yield pipeline
 
-          return [] if pipeline.commands.empty?
+          begin
+            yield pipeline
 
-          send_batch_commands(pipeline.commands, exception: true, is_atomic: true)
+            return [] if pipeline.commands.empty?
+
+            results = send_batch_commands(pipeline.commands, exception: true, is_atomic: true)
+            pipeline.resolve_futures!(results)
+            results
+          rescue StandardError
+            pipeline.abort_futures!
+            raise
+          end
         else
           start_multi
           self

--- a/lib/valkey/future.rb
+++ b/lib/valkey/future.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+class Valkey
+  # Raised by Future#value when the pipeline/multi block has not finished
+  # executing yet (e.g. called from inside the block itself).
+  class FutureNotReady < BaseError
+    def initialize(msg = "Value will be available once the pipeline executes.")
+      super
+    end
+  end
+
+  # Raised by Future#value when the owning pipeline/multi block raised (or a
+  # sequential MULTI/EXEC/DISCARD fallback batch failed partway through)
+  # before this command's slot could ever be resolved. Distinct from
+  # FutureNotReady (still a subclass, so `rescue FutureNotReady` still catches
+  # it) to give a much clearer diagnostic than "not ready yet" for something
+  # that in fact will never become ready.
+  class FutureAborted < FutureNotReady
+    def initialize(msg = "This pipeline/multi block raised (or a sequential " \
+                         "fallback batch failed partway through) before this " \
+                         "command's result could be resolved.")
+      super
+    end
+  end
+
+  # A placeholder for the reply to a command queued inside Valkey#pipelined
+  # or the block form of Valkey::Commands::TransactionCommands#multi.
+  #
+  # Deliberately a plain Object, not BasicObject (unlike redis-rb's
+  # Redis::Future): #value is always called explicitly by callers, never as a
+  # transparent proxy, so BasicObject's stripped-down method surface buys
+  # nothing here.
+  #
+  # Coercion (Utils::Boolify, etc.) is intentionally not duplicated here: by
+  # the time Pipeline#resolve_futures! calls #_set, send_batch_commands has
+  # already applied it to the corresponding results[i].
+  class Future
+    NOT_READY = Object.new.freeze
+    private_constant :NOT_READY
+
+    def initialize(command_type, command_args)
+      @command_type = command_type
+      @command_args = command_args
+      @object = NOT_READY
+      @aborted = false
+    end
+
+    # @api private
+    def _set(object)
+      @object = object
+    end
+
+    # @api private
+    def _abort!
+      @aborted = true if @object.equal?(NOT_READY)
+    end
+
+    # @return [Boolean] whether #value can be called right now without
+    #   raising FutureNotReady/FutureAborted.
+    def ready?
+      !@aborted && !@object.equal?(NOT_READY)
+    end
+
+    # @return [Object] the resolved reply, already coerced the same way a
+    #   live (non-pipelined) call to the same command would be.
+    # @raise [FutureAborted] if the owning pipeline never got to resolve this
+    #   command (block raised, or the batch failed partway through)
+    # @raise [FutureNotReady] if called before the pipeline/multi block has
+    #   returned and its batch has been sent
+    # @raise [CommandError] if this slot's reply was itself an inline error
+    #   (e.g. WRONGTYPE inside a batch) - matches Valkey#convert_response's
+    #   "no rollback on runtime error" semantics.
+    def value
+      raise FutureAborted if @aborted
+      raise FutureNotReady if @object.equal?(NOT_READY)
+      raise @object if @object.is_a?(StandardError)
+
+      @object
+    end
+
+    def inspect
+      "#<Valkey::Future #{@command_type.inspect} #{@command_args.inspect}>"
+    end
+  end
+end

--- a/lib/valkey/pipeline.rb
+++ b/lib/valkey/pipeline.rb
@@ -4,10 +4,11 @@ class Valkey
   class Pipeline
     include Commands
 
-    attr_reader :commands
+    attr_reader :commands, :futures
 
     def initialize
       @commands = []
+      @futures = []
       # Keep transactional state consistent with the main client so that
       # helpers like `multi`/`exec` can safely consult `@in_multi`.
       @in_multi = false
@@ -15,6 +16,33 @@ class Valkey
 
     def send_command(command_type, command_args = [], &block)
       @commands << [command_type, command_args, block]
+      future = Future.new(command_type, command_args)
+      @futures << future
+      future
+    end
+
+    # @api private - called by Valkey#pipelined / the block form of #multi
+    # once send_batch_commands' final results are available. Purely
+    # positional, mirroring send_batch_commands' own per-command block
+    # re-application - safe for both the real-batch and the sequential
+    # MULTI/EXEC/DISCARD fallback branch, since both produce the same
+    # shape/order of results.
+    #
+    # `results` is `nil` when a watched key was modified, aborting the whole
+    # transaction server-side before any queued command actually ran - none
+    # of these futures were ever really resolved, so treat it the same as
+    # abort_futures! instead of raising NoMethodError on a nil index.
+    def resolve_futures!(results)
+      return abort_futures! if results.nil?
+
+      @futures.each_with_index { |future, i| future._set(results[i]) }
+    end
+
+    # @api private - called when an exception escapes pipelined/multi before
+    # resolve_futures! ran, so every still-unresolved future raises a clear
+    # FutureAborted instead of hanging on FutureNotReady forever.
+    def abort_futures!
+      @futures.each(&:_abort!)
     end
   end
 end

--- a/test/lint/string_commands.rb
+++ b/test/lint/string_commands.rb
@@ -286,6 +286,33 @@ module Lint
       assert_equal({ '{1}foo' => 's1', '{1}bar' => 's2' }, result[0])
     end
 
+    def test_pipelined_returns_futures_that_resolve_after_the_block
+      r.set('{1}foo', 's1')
+
+      future = nil
+      r.pipelined do |pipeline|
+        future = pipeline.get('{1}foo')
+        pipeline.del('{1}foo')
+      end
+
+      assert_equal 's1', future.value
+      assert_nil r.get('{1}foo')
+    end
+
+    def test_pipelined_future_raises_command_error_for_inline_error_slot
+      r.set('{1}foo', 'not_a_list')
+
+      future = nil
+      result = r.pipelined(exception: false) do |pipeline|
+        future = pipeline.lpush('{1}foo', 'bar')
+        pipeline.get('{1}foo')
+      end
+
+      assert_raises(Valkey::CommandError) { future.value }
+      assert_instance_of Valkey::CommandError, result[0]
+      assert_equal 'not_a_list', result[1]
+    end
+
     def test_mset
       r.mset('{1}foo', 's1', '{1}bar', 's2')
 

--- a/test/lint/transaction_commands.rb
+++ b/test/lint/transaction_commands.rb
@@ -551,5 +551,96 @@ module Lint
 
       assert_equal [false, true], result
     end
+
+    def test_multi_with_block_returns_futures_that_resolve_after_the_block
+      skip("MULTI/EXEC not supported in cluster mode") if cluster_mode?
+
+      future = nil
+      result = r.multi do |multi|
+        future = multi.set("foo", "s1")
+        multi.get("foo")
+      end
+
+      assert_instance_of Valkey::Future, future
+      assert_equal "OK", future.value
+      assert_equal %w[OK s1], result
+    end
+
+    def test_multi_future_value_raises_before_block_completes
+      skip("MULTI/EXEC not supported in cluster mode") if cluster_mode?
+
+      captured = nil
+      r.multi do |multi|
+        captured = multi.set("foo", "s1")
+        assert_raises(Valkey::FutureNotReady) { captured.value }
+      end
+
+      assert_equal "OK", captured.value
+    end
+
+    def test_multi_future_is_aborted_when_block_raises
+      skip("MULTI/EXEC not supported in cluster mode") if cluster_mode?
+
+      future = nil
+      assert_raises(RuntimeError) do
+        r.multi do |multi|
+          future = multi.set("bar", "s2")
+          raise "boom"
+        end
+      end
+
+      assert_raises(Valkey::FutureAborted) { future.value }
+    end
+
+    def test_multi_future_is_aborted_when_batch_raises_a_command_error
+      skip("MULTI/EXEC not supported in cluster mode") if cluster_mode?
+
+      # multi's block form hardcodes exception: true, so a real per-command
+      # error (as opposed to the user's block raising Ruby-level) makes the
+      # whole batch call raise before resolve_futures! ever runs - same
+      # abort path as test_multi_future_is_aborted_when_block_raises, just
+      # triggered from send_batch_commands itself instead of user code.
+      r.set("foo", "not_a_list")
+
+      future = nil
+      assert_raises(Valkey::CommandError) do
+        r.multi do |multi|
+          future = multi.lpush("foo", "bar")
+          multi.get("foo")
+        end
+      end
+
+      assert_raises(Valkey::FutureAborted) { future.value }
+    end
+
+    def test_multi_future_reflects_boolean_coercion
+      skip("MULTI/EXEC not supported in cluster mode") if cluster_mode?
+
+      r.set("foo", "bar")
+      r.del("someset")
+      r.set("existing", "value")
+      r.del("newkey")
+
+      persist_future = nil
+      pexpire_future = nil
+      sismember_future = nil
+      setnx_future = nil
+      hexists_future = nil
+
+      result = r.multi do |multi|
+        persist_future = multi.persist("foo")
+        pexpire_future = multi.pexpire("foo", 900_000)
+        sismember_future = multi.sismember("someset", "member")
+        setnx_future = multi.setnx("existing", "ignored")
+        hexists_future = multi.hexists("newkey", "field")
+      end
+
+      assert_equal [false, true, false, false, false], result
+      assert_equal false, persist_future.value
+      assert_equal true, pexpire_future.value
+      assert_equal false, sismember_future.value
+      assert_equal false, setnx_future.value
+      assert_equal false, hexists_future.value
+    end
   end
 end

--- a/test/valkey/future_test.rb
+++ b/test/valkey/future_test.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Unit tests for Valkey::Future.
+# These do not require a running server — they test the Ruby layer only.
+class TestFutureUnit < Minitest::Test
+  def test_value_raises_future_not_ready_before_resolution
+    future = Valkey::Future.new(Valkey::RequestType::GET, ["foo"])
+
+    assert_raises(Valkey::FutureNotReady) { future.value }
+  end
+
+  def test_ready_predicate_before_resolution
+    future = Valkey::Future.new(Valkey::RequestType::GET, ["foo"])
+
+    refute future.ready?
+  end
+
+  def test_value_returns_resolved_object_after_set
+    future = Valkey::Future.new(Valkey::RequestType::GET, ["foo"])
+    future._set("s1")
+
+    assert future.ready?
+    assert_equal "s1", future.value
+  end
+
+  def test_value_raises_the_resolved_command_error
+    future = Valkey::Future.new(Valkey::RequestType::INCR, ["foo"])
+    future._set(Valkey::CommandError.new("boom"))
+
+    assert_raises(Valkey::CommandError) { future.value }
+  end
+
+  def test_value_raises_future_aborted_after_abort
+    future = Valkey::Future.new(Valkey::RequestType::SET, %w[foo bar])
+    future._abort!
+
+    assert_raises(Valkey::FutureAborted) { future.value }
+  end
+
+  def test_future_aborted_is_a_future_not_ready
+    assert Valkey::FutureAborted < Valkey::FutureNotReady
+  end
+
+  def test_abort_after_set_is_a_no_op
+    future = Valkey::Future.new(Valkey::RequestType::GET, ["foo"])
+    future._set("s1")
+    future._abort!
+
+    assert_equal "s1", future.value
+  end
+
+  def test_inspect_includes_command_type_and_args
+    future = Valkey::Future.new(Valkey::RequestType::GET, ["foo"])
+
+    assert_match(/Valkey::Future/, future.inspect)
+    assert_match(/"foo"/, future.inspect)
+  end
+end

--- a/test/valkey/pipeline_test.rb
+++ b/test/valkey/pipeline_test.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Unit tests for Valkey::Pipeline's Future bookkeeping.
+# These do not require a running server — they test the Ruby layer only.
+class TestPipelineUnit < Minitest::Test
+  def test_send_command_returns_a_future_and_queues_the_command
+    pipeline = Valkey::Pipeline.new
+
+    future = pipeline.send_command(Valkey::RequestType::GET, ["foo"])
+
+    assert_instance_of Valkey::Future, future
+    assert_equal [[Valkey::RequestType::GET, ["foo"], nil]], pipeline.commands
+    assert_equal [future], pipeline.futures
+  end
+
+  def test_resolve_futures_sets_each_future_by_position
+    pipeline = Valkey::Pipeline.new
+
+    future_a = pipeline.send_command(Valkey::RequestType::SET, %w[foo bar])
+    future_b = pipeline.send_command(Valkey::RequestType::GET, ["foo"])
+    future_c = pipeline.send_command(Valkey::RequestType::INCR, ["counter"])
+
+    pipeline.resolve_futures!(["OK", "bar", 5])
+
+    assert_equal "OK", future_a.value
+    assert_equal "bar", future_b.value
+    assert_equal 5, future_c.value
+  end
+
+  def test_abort_futures_marks_only_unresolved_futures
+    pipeline = Valkey::Pipeline.new
+
+    future_a = pipeline.send_command(Valkey::RequestType::SET, %w[foo bar])
+    future_b = pipeline.send_command(Valkey::RequestType::GET, ["foo"])
+
+    future_a._set("OK")
+    pipeline.abort_futures!
+
+    assert_equal "OK", future_a.value
+    assert_raises(Valkey::FutureAborted) { future_b.value }
+  end
+end


### PR DESCRIPTION
## Summary
- Backports #192 (`f1199aef`) to `release-1.0`.
- Adds `Valkey::Future` placeholders returned by commands queued inside `pipelined` / `multi`, so callers can reference each queued reply after the batch resolves.
- Also carries the collateral changes from that PR: nested-array arg flattening, stricter `build_command_args` argument-type checks, `Integer()` coercion for `setex`/`set`/`getex`/`setrange`/`incrby`/`decrby` numeric args, and the scripting use-after-free fix.

Cherry-picked cleanly with `git cherry-pick -x` — no conflicts.
