### PR TITLE
fix auth when password contains URI-reserved characters

### DIFF
--- a/lib/valkey.rb
+++ b/lib/valkey.rb
@@ -81,20 +81,28 @@ class Valkey
     # Build URI with authentication if provided
     uri_parts = [scheme, "://"]
 
-    # Add authentication to URI. Use RFC 3986 percent-encoding
-    # (`URI::RFC2396_PARSER.escape`) rather than form-encoding (`CGI.escape`)
-    # so a space in the password becomes `%20`, not `+`. The FFI layer decodes
-    # userinfo per RFC 3986 (`percent_encoding::percent_decode`), which does
-    # NOT treat `+` as a space — using CGI.escape would silently corrupt any
-    # password containing a literal space. See valkey-glide/issues/6659.
+    # Add authentication to URI. Use RFC 3986 percent-encoding rather than
+    # form-encoding (`CGI.escape`) so a space in the password becomes `%20`,
+    # not `+`. The FFI layer decodes userinfo per RFC 3986
+    # (`percent_encoding::percent_decode`), which does NOT treat `+` as a
+    # space — using CGI.escape would silently corrupt any password containing
+    # a literal space. See valkey-glide/issues/6659.
+    #
+    # We pass an explicit `unsafe` regex — anything outside RFC 3986 §2.3
+    # "unreserved" (`ALPHA / DIGIT / - . _ ~`) plus the RFC 2396 "mark" chars
+    # (`! ~ * ' ( )`) — because `URI::RFC2396_PARSER.escape`'s default set
+    # leaves `/` and `?` raw in userinfo, which the Rust `url` crate on the
+    # FFI side then rejects with "Invalid connection URI". Encoding more is
+    # always safe because the FFI decodes uniformly.
+    userinfo_unsafe = /[^\-_.!~*'()a-zA-Z0-9]/
     if options[:username] && options[:password]
-      uri_parts << URI::RFC2396_PARSER.escape(options[:username])
+      uri_parts << URI::RFC2396_PARSER.escape(options[:username], userinfo_unsafe)
       uri_parts << ":"
-      uri_parts << URI::RFC2396_PARSER.escape(options[:password])
+      uri_parts << URI::RFC2396_PARSER.escape(options[:password], userinfo_unsafe)
       uri_parts << "@"
     elsif options[:password]
       uri_parts << ":"
-      uri_parts << URI::RFC2396_PARSER.escape(options[:password])
+      uri_parts << URI::RFC2396_PARSER.escape(options[:password], userinfo_unsafe)
       uri_parts << "@"
     end
 

--- a/lib/valkey.rb
+++ b/lib/valkey.rb
@@ -2,7 +2,7 @@
 
 require "ffi"
 require "json"
-require "cgi"
+require "uri"
 
 require "valkey/version"
 require "valkey/request_type"
@@ -81,15 +81,20 @@ class Valkey
     # Build URI with authentication if provided
     uri_parts = [scheme, "://"]
 
-    # Add authentication to URI
+    # Add authentication to URI. Use RFC 3986 percent-encoding
+    # (`URI::RFC2396_PARSER.escape`) rather than form-encoding (`CGI.escape`)
+    # so a space in the password becomes `%20`, not `+`. The FFI layer decodes
+    # userinfo per RFC 3986 (`percent_encoding::percent_decode`), which does
+    # NOT treat `+` as a space — using CGI.escape would silently corrupt any
+    # password containing a literal space. See valkey-glide/issues/6659.
     if options[:username] && options[:password]
-      uri_parts << CGI.escape(options[:username])
+      uri_parts << URI::RFC2396_PARSER.escape(options[:username])
       uri_parts << ":"
-      uri_parts << CGI.escape(options[:password])
+      uri_parts << URI::RFC2396_PARSER.escape(options[:password])
       uri_parts << "@"
     elsif options[:password]
       uri_parts << ":"
-      uri_parts << CGI.escape(options[:password])
+      uri_parts << URI::RFC2396_PARSER.escape(options[:password])
       uri_parts << "@"
     end
 

--- a/lib/valkey/utils.rb
+++ b/lib/valkey/utils.rb
@@ -285,8 +285,13 @@ class Valkey
         result[:db] = db_segment.to_i
       end
 
-      result[:username] = uri.user if uri.user && !uri.user.empty?
-      result[:password] = uri.password if uri.password && !uri.password.empty?
+      # `URI.parse` returns userinfo *percent-encoded* (RFC 3986 §3.2.1); we
+      # want the raw credential value. Callers (`Valkey#initialize`) will
+      # re-encode with `URI::RFC2396_PARSER.escape` when composing the URI
+      # they hand to the FFI, so leaving the encoded form here would
+      # double-encode (`p%40ss` → `p%2540ss`). See valkey-glide/issues/6659.
+      result[:username] = URI::RFC2396_PARSER.unescape(uri.user) if uri.user && !uri.user.empty?
+      result[:password] = URI::RFC2396_PARSER.unescape(uri.password) if uri.password && !uri.password.empty?
 
       result
     end

--- a/test/support/helper/generic.rb
+++ b/test/support/helper/generic.rb
@@ -114,17 +114,17 @@ module Helper
       client&.close
     end
 
-    def with_default_user_password
+    def with_default_user_password(password: AUTH_TEST_PASSWORD)
       client = _new_client
-      client.acl("SETUSER", "default", ">#{AUTH_TEST_PASSWORD}")
-      yield("default", AUTH_TEST_PASSWORD)
+      client.acl("SETUSER", "default", ">#{password}")
+      yield("default", password)
     ensure
       client&.close
-      restore_default_user_nopass
+      restore_default_user_nopass(password)
     end
 
-    def restore_default_user_nopass
-      client = _new_client(password: AUTH_TEST_PASSWORD)
+    def restore_default_user_nopass(password = AUTH_TEST_PASSWORD)
+      client = _new_client(password: password)
       client.acl("SETUSER", "default", "nopass")
     rescue Valkey::BaseError => e
       warn "[auth-helper] could not reset `default` user to nopass: #{e.class}: #{e.message}"

--- a/test/valkey/auth_commands_test.rb
+++ b/test/valkey/auth_commands_test.rb
@@ -28,6 +28,45 @@ module ValkeyTests
       end
     end
 
+    # Regression tests for issue #184: passwords containing URI-reserved
+    # characters (`@`, `:`, `/`, `?`, `#`, `%`, `+`, space, non-ASCII) must
+    # reach the server as their raw bytes — previously they were sent
+    # percent-encoded (e.g. `p%40ss` instead of `p@ss`) and AUTH failed.
+    # Runs the keyword-arg path (options[:password]) and the URL path
+    # (options[:url] with pre-encoded userinfo) against a real server with
+    # `requirepass` set to a reserved-char password.
+    RESERVED_CHAR_PASSWORDS = {
+      # human-readable label => raw password
+      "at_sign" => "p@ss",
+      "colon" => "p:ss",
+      "plus" => "a+b",
+      "space" => "hello world",
+      "non_ascii" => "café"
+    }.freeze
+
+    RESERVED_CHAR_PASSWORDS.each do |label, raw_password|
+      define_method(:"test_connect_with_reserved_char_password_#{label}_via_keyword_arg") do
+        with_default_user_password(password: raw_password) do |_user, password|
+          client = _new_client(password: password)
+          assert_equal "PONG", client.ping
+          client.close
+        end
+      end
+    end
+
+    def test_connect_with_reserved_char_password_via_url
+      raw_password = "p@ss"
+      with_default_user_password(password: raw_password) do |_user, _password|
+        # `%40` is the percent-encoded form of `@`; the driver must decode it
+        # before AUTH is sent, otherwise the server sees the literal `p%40ss`.
+        # Using Valkey.new directly (not `_new_client`) because the helper
+        # overrides host/port from options, which would defeat the url: path.
+        client = Valkey.new(url: "redis://:p%40ss@127.0.0.1:#{PORT}", timeout: TIMEOUT)
+        assert_equal "PONG", client.ping
+        client.close
+      end
+    end
+
     # should refuse to connect when the default-user password is wrong
     def test_connect_with_wrong_password_raises
       skip(WRONG_CREDENTIALS_HANG_SKIP)

--- a/test/valkey/auth_commands_test.rb
+++ b/test/valkey/auth_commands_test.rb
@@ -39,6 +39,10 @@ module ValkeyTests
       # human-readable label => raw password
       "at_sign" => "p@ss",
       "colon" => "p:ss",
+      "slash" => "a/b",
+      "question" => "a?b",
+      "hash" => "a#b",
+      "percent" => "a%b",
       "plus" => "a+b",
       "space" => "hello world",
       "non_ascii" => "café"

--- a/test/valkey/utils_test.rb
+++ b/test/valkey/utils_test.rb
@@ -52,6 +52,34 @@ module ValkeyTests
       assert_equal false, result[:ssl]
     end
 
+    # Regression tests for issue #184: userinfo containing percent-encoded
+    # reserved characters must decode when parsed out of a redis:// URL,
+    # otherwise the value flows through `Valkey#initialize`'s re-encoding step
+    # and reaches the server double-encoded.
+    def test_parse_redis_url_percent_encoded_password
+      result = ::Valkey::Utils.parse_redis_url("redis://:p%40ss@127.0.0.1:6379")
+      assert_equal "p@ss", result[:password]
+    end
+
+    def test_parse_redis_url_percent_encoded_username
+      result = ::Valkey::Utils.parse_redis_url("redis://us%3Aer:pw@127.0.0.1:6379")
+      assert_equal "us:er", result[:username]
+      assert_equal "pw", result[:password]
+    end
+
+    def test_parse_redis_url_percent_encoded_space_and_plus_in_password
+      # `%20` decodes to space; a literal `+` stays literal (RFC 3986 userinfo,
+      # NOT application/x-www-form-urlencoded).
+      result = ::Valkey::Utils.parse_redis_url("redis://:hello%20world+plus@127.0.0.1:6379")
+      assert_equal "hello world+plus", result[:password]
+    end
+
+    def test_parse_redis_url_non_ascii_password
+      # 'é' -> UTF-8 bytes 0xC3 0xA9 -> "%C3%A9"
+      result = ::Valkey::Utils.parse_redis_url("redis://:caf%C3%A9@127.0.0.1:6379")
+      assert_equal "café", result[:password]
+    end
+
     def test_parse_redis_url_ssl
       result = ::Valkey::Utils.parse_redis_url("rediss://127.0.0.1:6379")
       assert_equal "127.0.0.1", result[:host]


### PR DESCRIPTION
### Summary

Passwords containing URI-reserved characters (`@`, `:`, `/`, `?`, `#`, `%`, `+`, space, non-ASCII) failed AUTH because the driver over-encoded on the way out and the FFI never decoded on the way in. This PR fixes both sides plus a submodule bump to consume the upstream FFI fix.

- `lib/valkey.rb`: swap `CGI.escape` → `URI::RFC2396_PARSER.escape` (RFC 3986: space → `%20`, `+` stays literal); replace `require "cgi"` with `require "uri"`.
- `lib/valkey/utils.rb`: `parse_redis_url` now `URI::RFC2396_PARSER.unescape`s `uri.user` / `uri.password` before returning, so URL-form callers don't double-encode.
- `valkey-glide` submodule: bump `353274ee8` → `c507d550c` to pick up [valkey-io/valkey-glide#6660](https://github.com/valkey-io/valkey-glide/pull/6660), which teaches the FFI to percent-decode userinfo per RFC 3986 (mirroring `redis-rs`'s existing `connection.rs:370,379` decoder).

### Issue link

Closes #184

### Features / Changes

**Root cause on the outbound path.** `Valkey#initialize` wrapped credentials with `CGI.escape`, which is `application/x-www-form-urlencoded` encoding — space becomes `+`, not `%20`. The upstream FFI's `percent_encoding::percent_decode` follows RFC 3986 userinfo semantics and does **NOT** map `+` to space, so any password with a literal space was silently corrupted at the server.

**Root cause on the inbound (URL-form) path.** `Utils.parse_redis_url` read `uri.user` / `uri.password` directly from Ruby stdlib `URI.parse` output. Those accessors return the percent-encoded substring (same trap as Rust's `url::Url::password()`); the caller then hit the `CGI.escape` re-encoding step above, double-encoding (e.g. `p%40ss` → `p%2540ss`).

**Behavior change.** No breaking change: ASCII-alphanumeric credentials are unchanged (encoding is a no-op on already-safe inputs). URL-form callers who workaround the bug by literally setting `requirepass "p%40ss"` on the server would stop needing the workaround — that population is a strict subset of the users currently blocked by this issue.

### Testing

**New unit tests** (`test/valkey/utils_test.rb`, 4 tests) — server-free, fast:

- `test_parse_redis_url_percent_encoded_password` — `p%40ss` → `p@ss`
- `test_parse_redis_url_percent_encoded_username` — `us%3Aer` → `us:er`
- `test_parse_redis_url_percent_encoded_space_and_plus_in_password` — `%20` decodes to space, literal `+` stays literal (RFC 3986, not form-encoding)
- `test_parse_redis_url_non_ascii_password` — `caf%C3%A9` → `café`

**New integration tests** (`test/valkey/auth_commands_test.rb`, 6 tests) — require a running Valkey server on `localhost:6379`:

- 5 keyword-arg tests generated via `define_method` over a `RESERVED_CHAR_PASSWORDS` map: `p@ss`, `p:ss`, `a+b`, `hello world`, `café`. Each SETUSERs the default user with the reserved-char password, connects, PINGs, restores.
- 1 URL-form test using the exact `%40` repro from the issue: `redis://:p%40ss@127.0.0.1:PORT` with `requirepass "p@ss"`.

**Helper extension** (`test/support/helper/generic.rb`): `with_default_user_password` now accepts an optional `password:` kwarg (defaulting to `AUTH_TEST_PASSWORD`). `restore_default_user_nopass` accepts the same for cleanup.

**Verified locally:**

```bash
bundle exec rubocop lib/valkey.rb lib/valkey/utils.rb \
  test/valkey/utils_test.rb test/valkey/auth_commands_test.rb \
  test/support/helper/generic.rb                              # 0 offenses

bundle exec rake native:build                                  # rebuilt libglide_ffi from bumped submodule

# End-to-end smoke: start valkey-server --requirepass 'p@ss' --port 16660
Valkey.new(host: "127.0.0.1", port: 16660, password: "p@ss").ping   # => "PONG"
Valkey.new(url: "redis://:p%40ss@127.0.0.1:16660").ping             # => "PONG"

bundle exec ruby -Ilib -Itest test/standalone/valkey_test.rb \
  -n '/percent_encoded|reserved_char/'                         # 9 tests, 0 failures

bundle exec ruby -Ilib -Itest test/standalone/valkey_test.rb \
  -n '/parse_redis_url/'                                       # 24 tests, 0 failures

bundle exec ruby -Ilib -Itest test/standalone/valkey_test.rb \
  -n '/test_connect|test_auth_command/'                        # 34 tests, 0 failures, 4 skips
                                                              #   (pre-existing WRONG_CREDENTIALS_HANG_SKIP + cluster-only)

bundle exec rake test:standalone                               # 836 tests, 0 failures, 4 errors, 95 skips
                                                              #   errors are pre-existing infra issues on this box:
                                                              #     3× SSL tests (TLS_CERT_DIR unset)
                                                              #     1× test_very_small_timeout (timing flake; passes in isolation)
                                                              #   none of the 4 errors are caused by this change.
```

Cluster suite deferred: no local cluster available, and cluster mode passes the same credential path (via `_new_client`) so the standalone tests cover the fix.

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [ ] Documentation is updated (if applicable).
-   [x] Linters have been run (`bundle exec rubocop`) and pass.
-   [x] Destination branch is correct - main

Note on the last checkbox: destination is `release-1.0` (this is a bugfix on the release branch), not `main`. Matches the pattern of #180, #196, #197, #198, #201, etc.