### PR TITLE
rc3 blockers: fix blpop, fix xtrim, guard known FFI hangs and fork abort

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,38 @@ client = Valkey.new(
 )
 ```
 
+## Forking servers (Puma clustered, Unicorn, Sidekiq, Resque)
+
+A `Valkey` client must be created **after** `fork()`, not inherited from the
+parent. glide-core embeds an async runtime with background threads whose I/O
+resources do not survive fork. Using an inherited client raises
+`Valkey::InheritedError`; without the guard it would abort the child process
+(SIGTRAP) below the Ruby VM.
+
+### Puma (clustered mode)
+
+```ruby
+on_worker_boot { $valkey = Valkey.new(url: ENV['VALKEY_URL']) }
+```
+
+### Unicorn
+
+```ruby
+after_fork { |_, _| $valkey = Valkey.new(url: ENV['VALKEY_URL']) }
+```
+
+### Sidekiq
+
+```ruby
+Sidekiq.configure_server do |c|
+  c.on(:startup) { $valkey = Valkey.new(url: ENV['VALKEY_URL']) }
+end
+```
+
+Threads are safe — share one `Valkey` instance across threads.
+
+Tracking upstream fix: [valkey-io/valkey-glide#6672](https://github.com/valkey-io/valkey-glide/issues/6672)
+
 ## OpenTelemetry
 
 Valkey GLIDE Ruby configures OpenTelemetry in the **native Rust core** (not via the Ruby `opentelemetry-sdk` gem). Initialize once per process before creating clients:

--- a/lib/valkey.rb
+++ b/lib/valkey.rb
@@ -661,7 +661,7 @@ class Valkey
 
       case error[:command_error_type]
       when RequestErrorType::EXECABORT, RequestErrorType::UNSPECIFIED
-        raise CommandError, error[:command_error_message]
+        raise command_error_class_for(error[:command_error_message]), error[:command_error_message]
       when RequestErrorType::TIMEOUT
         raise TimeoutError, error[:command_error_message]
       when RequestErrorType::DISCONNECT
@@ -731,7 +731,7 @@ class Valkey
                     else
                       response_item[:string_value].read_string(response_item[:string_value_len])
                     end
-        CommandError.new(error_msg)
+        command_error_class_for(error_msg).new(error_msg)
       else
         raise "Unsupported response type: #{response_item[:response_type]}"
       end
@@ -746,6 +746,22 @@ class Valkey
       block.call(response)
     else
       response
+    end
+  end
+
+  # Maps a server-error message to the most specific Valkey::CommandError
+  # subclass based on the RESP error prefix (case-sensitive per RESP spec).
+  # Falls back to Valkey::CommandError for any unmapped prefix. All returned
+  # classes inherit from CommandError, so existing `rescue CommandError`
+  # blocks continue to catch every mapped error.
+  def command_error_class_for(message)
+    return CommandError if message.nil?
+
+    case message
+    when /\AWRONGTYPE\b/
+      WrongTypeError
+    else
+      CommandError
     end
   end
 end

--- a/lib/valkey.rb
+++ b/lib/valkey.rb
@@ -24,6 +24,25 @@ class Valkey
   include Commands
   include PubSubCallback
 
+  # Map a connection-time error message from glide-core to the appropriate
+  # Ruby error class.
+  #
+  # Wrong password / bad ACL credentials surface as a message containing
+  # "Password authentication failed- AuthenticationFailed" (see
+  # test/valkey/auth_commands_test.rb). Raising CannotConnectError for those
+  # masks auth failures as network errors — callers rescuing CommandError
+  # cannot catch them and retry loops on CannotConnectError will spin
+  # forever on bad credentials. Return PermissionError (a CommandError
+  # subclass) for auth failures so users can rescue via PermissionError,
+  # CommandError, or BaseError. All other messages remain CannotConnectError.
+  def self.classify_connection_error(message)
+    if message.is_a?(String) && message.match?(/authentication\s*failed/i)
+      PermissionError
+    else
+      CannotConnectError
+    end
+  end
+
   def pipelined(exception: true)
     pipeline = Pipeline.new
 
@@ -290,7 +309,7 @@ class Valkey
     if res[:conn_ptr].null?
       error_message = res[:connection_error_message]
       Bindings.free_connection_response(response_ptr)
-      raise CannotConnectError, error_message
+      raise Valkey.classify_connection_error(error_message), error_message
     end
 
     @connection = res[:conn_ptr]

--- a/lib/valkey.rb
+++ b/lib/valkey.rb
@@ -41,6 +41,9 @@ class Valkey
     end
   end
 
+  # @note Forking servers: create the client AFTER fork(), not before.
+  #   Inherited clients raise Valkey::InheritedError on first use. See README
+  #   "Forking servers" for Puma/Unicorn/Sidekiq examples. Threads are fine.
   def initialize(options = {})
     # Parse URL if provided
     if options[:url]
@@ -244,6 +247,15 @@ class Valkey
               "Reconnect attempts must be non-negative, got: #{number_of_retries}"
       end
 
+      # TODO: remove once https://github.com/valkey-io/valkey-glide/issues/6379 is fixed.
+      # Setting number_of_retries to 0 triggers an integer underflow in glide-core's
+      # retry_strategies.rs and hangs the process below the FFI boundary.
+      if number_of_retries.zero?
+        raise ArgumentError,
+              "reconnect_attempts: 0 is not supported due to an upstream bug that hangs the process " \
+              "(see https://github.com/valkey-io/valkey-glide/issues/6379). Use 1 or higher."
+      end
+
       raise ArgumentError, "Reconnect delay must be a number, got: #{base_delay.class}" unless base_delay.is_a?(Numeric)
       raise ArgumentError, "Reconnect delay must be positive, got: #{base_delay}" unless base_delay.positive?
 
@@ -294,6 +306,7 @@ class Valkey
     end
 
     @connection = res[:conn_ptr]
+    @created_pid = Process.pid
     Bindings.free_connection_response(response_ptr)
 
     # Store cluster mode flag for response handling (MAP returns Hash in cluster, Array in standalone)
@@ -370,6 +383,18 @@ class Valkey
   # explicit receiver to issue commands with no dedicated wrapper method yet
   # (e.g. `DEBUG SLEEP`, raw `HSET` in vector search fixtures).
   def send_command(command_type, command_args = [], route: nil, &block)
+    # TODO: remove once glide-core exposes glide_client_reset_after_fork() —
+    # see https://github.com/valkey-io/valkey-glide/issues/6672.
+    # Currently, using an inherited client would abort the child below the Ruby VM
+    # (SIGTRAP) because glide-core's tokio runtime is not fork-safe.
+    if @created_pid && Process.pid != @created_pid
+      raise InheritedError,
+            "Valkey client used across fork() — create a new client in the child. " \
+            "See README 'Forking servers'. Tracking: " \
+            "https://github.com/valkey-io/valkey-glide/issues/6672 and " \
+            "https://github.com/valkey-io/valkey-glide-ruby/issues/210"
+    end
+
     # Validate connection. A nil/null pointer means the client was closed (or
     # never established a usable connection); surface it as a typed error with
     # the same "the client is closed" wording the sibling GLIDE clients use

--- a/lib/valkey/commands/list_commands.rb
+++ b/lib/valkey/commands/list_commands.rb
@@ -59,7 +59,7 @@ class Valkey
       def blmove(source, destination, where_source, where_destination, timeout: 0)
         where_source, where_destination = _normalize_move_wheres(where_source, where_destination)
 
-        args = [:blmove, source, destination, where_source, where_destination, timeout]
+        args = [source, destination, where_source, where_destination, timeout]
         send_command(RequestType::BLMOVE, args)
       end
 
@@ -156,7 +156,7 @@ class Valkey
       #   - `nil` when the operation timed out
       #   - tuple of the list that was popped from and element was popped otherwise
       def blpop(*args)
-        _bpop(:blpop, args)
+        _bpop(RequestType::BLPOP, args)
       end
 
       # Remove and get the last element in a list, or block until one is available.
@@ -173,22 +173,6 @@ class Valkey
       # @see #blpop
       def brpop(*args)
         _bpop(RequestType::BRPOP, args.flatten)
-      end
-
-      # Pop a value from a list, push it to another list and return it; or block
-      # until one is available.
-      #
-      # @param [String] source source key
-      # @param [String] destination destination key
-      # @param [Hash] options
-      #   - `:timeout => [Float, Integer]`: timeout in seconds, defaults to no timeout
-      #
-      # @return [nil, String]
-      #   - `nil` when the operation timed out
-      #   - the element was popped and pushed otherwise
-      def brpoplpush(source, destination, timeout: 0)
-        args = [:brpoplpush, source, destination, timeout]
-        send_blocking_command(RequestType::BRPOPLPUSH, args, timeout)
       end
 
       # Pops one or more elements from the first non-empty list key from the list
@@ -326,7 +310,7 @@ class Valkey
 
         args.flatten!(1)
         args << timeout
-        send_blocking_command(cmd, args, &blk)
+        send_command(cmd, args, &blk)
       end
 
       def _normalize_move_wheres(where_source, where_destination)

--- a/lib/valkey/commands/stream_commands.rb
+++ b/lib/valkey/commands/stream_commands.rb
@@ -214,25 +214,31 @@ class Valkey
         end
       end
 
-      # Trim a stream to a maximum length.
+      # Trim a stream to a maximum length or minimum ID.
       #
       # @param [String] key stream key
-      # @param [Integer] maxlen maximum length of the stream
+      # @param [Integer, String] maxlen maximum length (for MAXLEN) or minimum ID (for MINID)
       # @param [Hash] options trimming options
-      #   - `:strategy => String`: trimming strategy (default: "MAXLEN")
-      #   - `:approximate => true`: use approximate trimming (default: true)
+      #   - `:strategy => String`: trimming strategy: "MAXLEN" (default) or "MINID"
+      #   - `:approximate => Boolean`: use approximate trimming (default: false)
+      #   - `:limit => Integer`: maximum number of entries to remove (requires approximate: true)
       # @return [Integer] number of entries removed
       #
-      # @example Trim to maximum length
+      # @example Trim to exactly 1000 entries
       #   valkey.xtrim("mystream", 1000)
-      # @example Trim with exact count
-      #   valkey.xtrim("mystream", 1000, approximate: false)
+      # @example Approximate trim with LIMIT
+      #   valkey.xtrim("mystream", 1000, approximate: true, limit: 100)
+      # @example Trim entries older than a given ID
+      #   valkey.xtrim("mystream", "1526919030474-0", strategy: "MINID")
       #
       # @see https://valkey.io/commands/xtrim/
-      def xtrim(key, maxlen, strategy: "MAXLEN", approximate: true)
+      def xtrim(key, maxlen, strategy: "MAXLEN", approximate: false, limit: nil)
+        raise ArgumentError, "LIMIT can only be used with approximate: true" if limit && !approximate
+
         args = [key, strategy]
         args << "~" if approximate
         args << maxlen.to_s
+        args << "LIMIT" << limit.to_s if limit
         send_command(RequestType::X_TRIM, args)
       end
 

--- a/lib/valkey/pipeline.rb
+++ b/lib/valkey/pipeline.rb
@@ -4,6 +4,29 @@ class Valkey
   class Pipeline
     include Commands
 
+    # SUBSCRIBE-shape commands drive a persistent connection state
+    # (the client stays subscribed and reads push messages asynchronously)
+    # which is fundamentally incompatible with pipelining/transactions.
+    # If we let them into the batch the server side transitions the shared
+    # connection into subscribe-state and every subsequent non-pubsub command
+    # fails with "only (P|S)SUBSCRIBE / ... allowed in this context".
+    # Reject them at enqueue time before any FFI dispatch so callers get a
+    # clear, actionable error and the client stays usable.
+    SUBSCRIBE_SHAPE_COMMANDS = [
+      RequestType::SUBSCRIBE,
+      RequestType::UNSUBSCRIBE,
+      RequestType::PSUBSCRIBE,
+      RequestType::PUNSUBSCRIBE,
+      RequestType::SSUBSCRIBE,
+      RequestType::SUNSUBSCRIBE
+    ].freeze
+
+    SUBSCRIBE_SHAPE_ERROR = <<~MSG.strip.tr("\n", " ")
+      SUBSCRIBE-shape commands cannot be used inside pipelined { ... } —
+      subscribe manages a persistent connection state that is incompatible
+      with pipelining. Call subscribe directly on the client instead.
+    MSG
+
     attr_reader :commands, :futures
 
     def initialize
@@ -15,6 +38,8 @@ class Valkey
     end
 
     def send_command(command_type, command_args = [], &block)
+      raise CommandError, SUBSCRIBE_SHAPE_ERROR if SUBSCRIBE_SHAPE_COMMANDS.include?(command_type)
+
       @commands << [command_type, command_args, block]
       future = Future.new(command_type, command_args)
       @futures << future

--- a/test/valkey/auth_commands_test.rb
+++ b/test/valkey/auth_commands_test.rb
@@ -33,7 +33,7 @@ module ValkeyTests
       skip(WRONG_CREDENTIALS_HANG_SKIP)
       with_default_user_password do |_user, _password|
         error = assert_raises(::Valkey::CannotConnectError) do
-          _new_client(password: "wrongpass", connect_timeout: 1.0, reconnect_attempts: 0)
+          _new_client(password: "wrongpass", connect_timeout: 1.0, reconnect_attempts: 1)
         end
         # glide-core surfaces a wrong password at connect-time as
         # "Password authentication failed- AuthenticationFailed" (not the raw
@@ -46,7 +46,7 @@ module ValkeyTests
     def test_connect_without_password_raises
       with_default_user_password do |_user, _password|
         error = assert_raises(::Valkey::CannotConnectError) do
-          _new_client(connect_timeout: 1.0, reconnect_attempts: 0)
+          _new_client(connect_timeout: 1.0, reconnect_attempts: 1)
         end
         assert_includes error.message, "NOAUTH"
       end
@@ -56,7 +56,7 @@ module ValkeyTests
     def test_connect_with_empty_password_against_auth_server_raises
       with_default_user_password do |_user, _password|
         error = assert_raises(::Valkey::CannotConnectError) do
-          _new_client(password: "", connect_timeout: 1.0, reconnect_attempts: 0)
+          _new_client(password: "", connect_timeout: 1.0, reconnect_attempts: 1)
         end
         # An empty password is currently treated as "no credentials", so the
         # server returns NOAUTH (same as the missing-password case). This
@@ -87,7 +87,7 @@ module ValkeyTests
       with_acl do |username, _password|
         error = assert_raises(::Valkey::CannotConnectError) do
           _new_client(username: username, password: "wrong",
-                      connect_timeout: 1.0, reconnect_attempts: 0)
+                      connect_timeout: 1.0, reconnect_attempts: 1)
         end
         assert_includes error.message, "AuthenticationFailed"
       end
@@ -100,7 +100,7 @@ module ValkeyTests
       with_acl do |_username, password|
         error = assert_raises(::Valkey::CannotConnectError) do
           _new_client(username: "nobody", password: password,
-                      connect_timeout: 1.0, reconnect_attempts: 0)
+                      connect_timeout: 1.0, reconnect_attempts: 1)
         end
         # An unknown username surfaces the same connect-time auth failure as a
         # wrong password (the server does not distinguish the two to clients).

--- a/test/valkey/regression/test_auth_error_class.rb
+++ b/test/valkey/regression/test_auth_error_class.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+# Regression test for the auth-error class round in PR #211.
+#
+# Before the fix, glide-core's "Password authentication failed-
+# AuthenticationFailed" connect-time error surfaced as
+# Valkey::CannotConnectError. That masked auth failures as network errors:
+# callers rescuing Valkey::CommandError could not catch them, and code that
+# retried on CannotConnectError would spin forever on bad credentials.
+#
+# The fix branches on the connection error message via
+# Valkey.classify_connection_error and raises Valkey::PermissionError
+# (already defined as a CommandError subclass) when the message mentions
+# authentication failure. Real network errors — e.g. a closed port — must
+# still raise CannotConnectError.
+#
+# Note on scope: this file exercises the classifier and the class
+# hierarchy contract only. A live wrong-password integration test is
+# already defined in test/valkey/auth_commands_test.rb but is currently
+# skipped because glide-core hangs on wrong credentials
+# (valkey-glide-ruby/issues/115). Once that upstream hang is resolved,
+# the auth_commands_test.rb `test_connect_with_wrong_password_raises`
+# case should be updated to assert PermissionError and re-enabled.
+
+require "test_helper"
+
+class TestAuthErrorClassRegression < Minitest::Test
+  # The exact message glide-core emits on wrong password at connect time.
+  # Kept verbatim so the regression check fails loudly if upstream ever
+  # changes the wording (see also test/valkey/auth_commands_test.rb which
+  # asserts the same "AuthenticationFailed" substring).
+  AUTH_FAILED_MESSAGE = "Received error for address 127.0.0.1:8000: " \
+                        "Password authentication failed- AuthenticationFailed"
+
+  # Classification: the exact glide-core wrong-password message maps to
+  # PermissionError. This is the regression: pre-fix behavior was
+  # CannotConnectError.
+  def test_classify_auth_failed_returns_permission_error
+    assert_equal ::Valkey::PermissionError,
+                 ::Valkey.classify_connection_error(AUTH_FAILED_MESSAGE)
+  end
+
+  # Match is case-insensitive and tolerates extra whitespace so mild
+  # wording drift still classifies correctly.
+  def test_classify_auth_failed_case_and_space_insensitive
+    ["authentication failed", "Authentication  Failed",
+     "some prefix - AUTHENTICATIONFAILED - some suffix"].each do |msg|
+      assert_equal ::Valkey::PermissionError,
+                   ::Valkey.classify_connection_error(msg),
+                   "expected PermissionError for: #{msg.inspect}"
+    end
+  end
+
+  # PermissionError is-a CommandError is-a BaseError: rescuing any of
+  # those must catch a connect-time auth failure. This is the whole point
+  # of the fix — legacy code that only rescued CannotConnectError will NOT
+  # catch these anymore (documented as intentional in the commit message).
+  def test_permission_error_class_hierarchy
+    assert_operator ::Valkey::PermissionError, :<, ::Valkey::CommandError
+    assert_operator ::Valkey::PermissionError, :<, ::Valkey::BaseError
+    # And crucially NOT a CannotConnectError / BaseConnectionError:
+    refute_operator ::Valkey::PermissionError, :<, ::Valkey::CannotConnectError
+    refute_operator ::Valkey::PermissionError, :<, ::Valkey::BaseConnectionError
+  end
+
+  # Classification: network / non-auth messages remain CannotConnectError.
+  # nil is included because res[:connection_error_message] may be nil in
+  # some code paths — the classifier must not raise on that.
+  def test_classify_non_auth_messages_return_cannot_connect_error
+    ["Connection refused (os error 61)",
+     "Received error for address 127.0.0.1:59999: TCP timeout",
+     "unknown transport failure",
+     "",
+     nil].each do |msg|
+      assert_equal ::Valkey::CannotConnectError,
+                   ::Valkey.classify_connection_error(msg),
+                   "expected CannotConnectError for: #{msg.inspect}"
+    end
+  end
+
+  # Contract with initialize: the raised class must equal the classifier
+  # result for the exact wrong-password message. The classifier is the
+  # single source of truth called from Valkey#initialize.
+  def test_initialize_uses_classifier_result
+    assert_equal ::Valkey::PermissionError,
+                 ::Valkey.classify_connection_error(AUTH_FAILED_MESSAGE)
+    # The error can be caught via any of these rescue clauses — this
+    # asserts the intended user-visible contract of the fix.
+    error = ::Valkey::PermissionError.new(AUTH_FAILED_MESSAGE)
+    assert_kind_of ::Valkey::PermissionError, error
+    assert_kind_of ::Valkey::CommandError, error
+    assert_kind_of ::Valkey::BaseError, error
+    refute_kind_of ::Valkey::CannotConnectError, error
+    assert_includes error.message, "AuthenticationFailed"
+  end
+end

--- a/test/valkey/regression/test_blocking_list_commands.rb
+++ b/test/valkey/regression/test_blocking_list_commands.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "securerandom"
+
+$LOAD_PATH.unshift File.expand_path("../../../lib", __dir__) unless ENV["TEST_INSTALLED_GEM"]
+require "valkey"
+
+# Regression tests for blpop/brpop.
+#
+# Bug: lib/valkey/commands/list_commands.rb called a non-existent
+# send_blocking_command method, causing NoMethodError for every blocking-list
+# command form. glide-core dispatches BLPOP/BRPOP with the timeout as the last
+# positional arg via the ordinary send_command, so no separate blocking
+# dispatch is needed.
+#
+# brpoplpush is intentionally NOT exposed by the wrapper: glide-core has no
+# get_command mapping for RequestType::BRPopLPush, so the command cannot
+# dispatch through the FFI stack. Every other GLIDE binding also omits it.
+# Users needing atomic blocking pop-and-move should use blmove.
+#
+# Requires a standalone Valkey/Redis server at 127.0.0.1:8100.
+class TestBlockingListCommandsRegression < Minitest::Test
+  PORT = Integer(ENV["REGRESSION_PORT"] || 8100)
+  HOST = ENV["REGRESSION_HOST"] || "127.0.0.1"
+
+  def setup
+    @client = Valkey.new(host: HOST, port: PORT)
+    @prefix = "regression:blpop:#{SecureRandom.hex(4)}:"
+  end
+
+  def teardown
+    @client&.close
+  end
+
+  def key(name)
+    "#{@prefix}#{name}"
+  end
+
+  # 1. blpop on missing key with timeout:1 returns nil after ~1s
+  def test_blpop_on_missing_key_returns_nil_after_timeout
+    started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    result = @client.blpop(key("missing"), timeout: 1)
+    elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+
+    assert_nil result
+    assert_operator elapsed, :>=, 0.8, "should block for ~1s (got #{elapsed}s)"
+    assert_operator elapsed, :<, 3.0, "should not block much longer than 1s (got #{elapsed}s)"
+  end
+
+  # 2. blpop on populated key returns [key, value] immediately (< 100ms)
+  def test_blpop_on_populated_key_returns_immediately
+    k = key("populated")
+    @client.rpush(k, "value1")
+
+    started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    result = @client.blpop(k, timeout: 1)
+    elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+
+    assert_equal [k, "value1"], result
+    assert_operator elapsed, :<, 0.5, "should return immediately (got #{elapsed}s)"
+  end
+
+  # 3. brpop on missing key with timeout:1 returns nil
+  def test_brpop_on_missing_key_returns_nil_after_timeout
+    started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    result = @client.brpop(key("missing-r"), timeout: 1)
+    elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+
+    assert_nil result
+    assert_operator elapsed, :>=, 0.8, "should block for ~1s (got #{elapsed}s)"
+    assert_operator elapsed, :<, 3.0, "should not block much longer than 1s (got #{elapsed}s)"
+  end
+
+  # 4. brpop on populated key returns [key, value]
+  def test_brpop_on_populated_key_returns_immediately
+    k = key("populated-r")
+    @client.rpush(k, "value1")
+    @client.rpush(k, "value2")
+
+    started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    result = @client.brpop(k, timeout: 1)
+    elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+
+    # brpop pops from the tail
+    assert_equal [k, "value2"], result
+    assert_operator elapsed, :<, 0.5, "should return immediately (got #{elapsed}s)"
+  end
+
+  # 5. brpoplpush is not exposed by the wrapper (see file header for rationale).
+  def test_brpoplpush_is_not_exposed
+    v = Valkey.new(host: '127.0.0.1', port: 8100)
+    refute v.respond_to?(:brpoplpush),
+           'brpoplpush should not be exposed until glide-core adds the ' \
+           'RequestType::BRPopLPush get_command mapping (parity with other clients)'
+  end
+
+  # 6. Positional-timeout parity form -- v.blpop('k', 1) -- is not supported
+  # by the current _bpop helper (only :timeout keyword is honoured), so a
+  # trailing Integer is dispatched as an extra key and the command blocks
+  # indefinitely. Dropped per task guidance: do NOT expand fix scope.
+  def test_blpop_positional_timeout_parity
+    skip "positional-timeout form (blpop('k', 1)) not supported by current _bpop helper; tracked separately"
+  end
+end

--- a/test/valkey/regression/test_fork_guard.rb
+++ b/test/valkey/regression/test_fork_guard.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "timeout"
+
+# Regression tests for the fork() guard.
+#
+# glide-core's tokio runtime is not fork-safe: any Valkey client created in
+# the parent process crashes the child with SIGTRAP on first use. The
+# Ruby-side guard raises Valkey::InheritedError instead, keeping the child's
+# Ruby VM alive. See https://github.com/valkey-io/valkey-glide/issues/6672
+# and https://github.com/valkey-io/valkey-glide-ruby/issues/210.
+if Process.respond_to?(:fork)
+  class TestForkGuard < Minitest::Test
+    PORT = Integer(ENV["VALKEY_PORT"] || 8102)
+
+    def test_inherited_client_raises_inherited_error_in_child
+      parent = Valkey.new(host: "127.0.0.1", port: PORT)
+      assert_equal "PONG", parent.ping
+
+      status = nil
+      Timeout.timeout(10) do
+        pid = fork do
+          # Rescue InheritedError → exit 0; any other exit path (crash, other
+          # exception) will be caught by the parent's status check below.
+          parent.ping
+          exit 42 # should never reach here
+        rescue Valkey::InheritedError
+          exit 0
+        rescue StandardError
+          exit 43
+        end
+        _, status = Process.waitpid2(pid)
+      end
+
+      refute_nil status, "child status was not captured"
+      # Child MUST NOT be killed by a signal — that's exactly the SIGTRAP
+      # abort the guard exists to prevent.
+      refute status.signaled?, "child was signaled (signal #{status.termsig}); guard failed to prevent abort"
+      assert_equal 0, status.exitstatus, "child did not raise Valkey::InheritedError as expected"
+    ensure
+      parent&.close
+    end
+
+    def test_parent_client_still_works_after_fork
+      parent = Valkey.new(host: "127.0.0.1", port: PORT)
+      assert_equal "PONG", parent.ping
+
+      Timeout.timeout(10) do
+        pid = fork do
+          # Child intentionally does nothing but exit cleanly. We just want
+          # to prove the parent's client remains usable after fork().
+          exit 0
+        end
+        Process.waitpid2(pid)
+      end
+
+      assert_equal "PONG", parent.ping
+    ensure
+      parent&.close
+    end
+
+    def test_child_can_create_its_own_client_after_fork
+      # This is the correct pattern documented in README "Forking servers":
+      # the parent process must never have created a client before fork(),
+      # otherwise glide-core's tokio runtime state contaminates the child.
+      # We spawn a fresh Ruby subprocess so no prior FFI usage bleeds in.
+      lib = File.expand_path("../../../lib", __dir__)
+      script = <<~RUBY
+        $LOAD_PATH.unshift(#{lib.inspect})
+        require "valkey"
+        pid = fork do
+          client = Valkey.new(host: "127.0.0.1", port: #{PORT})
+          exit(client.ping == "PONG" ? 0 : 45)
+        end
+        _, status = Process.waitpid2(pid)
+        exit(status.signaled? ? 46 : (status.exitstatus || 47))
+      RUBY
+
+      ok = nil
+      Timeout.timeout(10) do
+        ok = system(RbConfig.ruby, "-e", script)
+      end
+
+      assert ok, "post-fork Valkey.new pattern failed inside a fresh subprocess"
+    end
+
+    def test_inherited_error_message_references_upstream_issues
+      parent = Valkey.new(host: "127.0.0.1", port: PORT)
+
+      # Capture the error message from a forked child via a pipe. Doing the
+      # assertion in-process would require the guard to fire in the parent,
+      # which it can't — the parent IS @created_pid.
+      reader, writer = IO.pipe
+
+      Timeout.timeout(10) do
+        pid = fork do
+          reader.close
+          parent.ping
+        rescue Valkey::InheritedError => e
+          writer.write(e.message)
+          writer.close
+          exit 0
+        end
+        writer.close
+        message = reader.read
+        Process.waitpid2(pid)
+        # Message must reference at least one of the tracking issue numbers so
+        # operators can find the upstream tracker.
+        assert(message.include?("6672") || message.include?("210"),
+               "expected InheritedError message to reference issue #6672 or #210, got: #{message.inspect}")
+      end
+    ensure
+      reader&.close unless reader&.closed?
+      parent&.close
+    end
+  end
+end

--- a/test/valkey/regression/test_other_blocking_commands.rb
+++ b/test/valkey/regression/test_other_blocking_commands.rb
@@ -1,0 +1,173 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "securerandom"
+
+$LOAD_PATH.unshift File.expand_path("../../../lib", __dir__) unless ENV["TEST_INSTALLED_GEM"]
+require "valkey"
+
+# Regression tests for the remaining blocking commands surfaced by the
+# rc3 blocker sweep alongside blpop/brpop (see test_blocking_list_commands.rb).
+#
+# Covered: blmove, blmpop, bzpopmax, bzpopmin, bzmpop.
+#
+# Each command is exercised twice against a live server (127.0.0.1:8100):
+#   * happy path -- data is present, blocking call returns immediately
+#   * timeout path -- key is missing, call with timeout: 1 returns nil ~1s
+#
+# Bugs to catch (same failure modes that broke blpop):
+#   (a) NoMethodError from a stale send_blocking_command dispatch
+#   (b) TypeError from passing a Symbol as the RequestType command_type
+#   (c) Valkey::CommandError "Couldn't fetch command type" -- glide-core
+#       has no get_command mapping for this RequestType (e.g. BRPOPLPUSH)
+#   (d) Server-side wrong-number-of-arguments -- a Symbol accidentally
+#       shipped inside the args array becomes a bogus extra RESP token
+class TestOtherBlockingCommandsRegression < Minitest::Test
+  PORT = Integer(ENV["REGRESSION_PORT"] || 8100)
+  HOST = ENV["REGRESSION_HOST"] || "127.0.0.1"
+
+  def setup
+    @client = Valkey.new(host: HOST, port: PORT)
+    @prefix = "regression:other-blocking:#{SecureRandom.hex(4)}:"
+  end
+
+  def teardown
+    @client&.close
+  end
+
+  def key(name)
+    "#{@prefix}#{name}"
+  end
+
+  # -------------------- blmove --------------------
+
+  def test_blmove_happy_path_returns_immediately
+    src = key("blmove:src")
+    dst = key("blmove:dst")
+    @client.rpush(src, "elem")
+
+    started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    result = @client.blmove(src, dst, "LEFT", "RIGHT", timeout: 1)
+    elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+
+    assert_equal "elem", result
+    assert_equal ["elem"], @client.lrange(dst, 0, -1)
+    assert_operator elapsed, :<, 0.5, "should return immediately (got #{elapsed}s)"
+  end
+
+  def test_blmove_timeout_path_returns_nil
+    src = key("blmove:missing-src")
+    dst = key("blmove:missing-dst")
+
+    started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    result = @client.blmove(src, dst, "LEFT", "RIGHT", timeout: 1)
+    elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+
+    assert_nil result
+    assert_operator elapsed, :>=, 0.8, "should block for ~1s (got #{elapsed}s)"
+    assert_operator elapsed, :<, 3.0, "should not block much past 1s (got #{elapsed}s)"
+  end
+
+  # -------------------- blmpop --------------------
+
+  def test_blmpop_happy_path_returns_immediately
+    k = key("blmpop:list")
+    @client.rpush(k, "a")
+    @client.rpush(k, "b")
+
+    started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    result = @client.blmpop(1.0, k, count: 2)
+    elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+
+    # Expected: [key, [elems...]]
+    assert_kind_of Array, result
+    assert_equal k, result[0]
+    assert_equal %w[a b], result[1]
+    assert_operator elapsed, :<, 0.5, "should return immediately (got #{elapsed}s)"
+  end
+
+  def test_blmpop_timeout_path_returns_nil
+    started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    result = @client.blmpop(1.0, key("blmpop:missing"))
+    elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+
+    assert_nil result
+    assert_operator elapsed, :>=, 0.8, "should block for ~1s (got #{elapsed}s)"
+    assert_operator elapsed, :<, 3.0, "should not block much past 1s (got #{elapsed}s)"
+  end
+
+  # -------------------- bzpopmax --------------------
+
+  def test_bzpopmax_happy_path_returns_immediately
+    k = key("bzpopmax:zset")
+    @client.zadd(k, [[1.0, "low"], [3.0, "high"], [2.0, "mid"]])
+
+    started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    result = @client.bzpopmax(k, timeout: 1.0)
+    elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+
+    assert_equal [k, "high", 3.0], result
+    assert_operator elapsed, :<, 0.5, "should return immediately (got #{elapsed}s)"
+  end
+
+  def test_bzpopmax_timeout_path_returns_nil
+    started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    result = @client.bzpopmax(key("bzpopmax:missing"), timeout: 1.0)
+    elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+
+    assert_nil result
+    assert_operator elapsed, :>=, 0.8, "should block for ~1s (got #{elapsed}s)"
+    assert_operator elapsed, :<, 3.0, "should not block much past 1s (got #{elapsed}s)"
+  end
+
+  # -------------------- bzpopmin --------------------
+
+  def test_bzpopmin_happy_path_returns_immediately
+    k = key("bzpopmin:zset")
+    @client.zadd(k, [[1.0, "low"], [3.0, "high"], [2.0, "mid"]])
+
+    started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    result = @client.bzpopmin(k, timeout: 1.0)
+    elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+
+    assert_equal [k, "low", 1.0], result
+    assert_operator elapsed, :<, 0.5, "should return immediately (got #{elapsed}s)"
+  end
+
+  def test_bzpopmin_timeout_path_returns_nil
+    started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    result = @client.bzpopmin(key("bzpopmin:missing"), timeout: 1.0)
+    elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+
+    assert_nil result
+    assert_operator elapsed, :>=, 0.8, "should block for ~1s (got #{elapsed}s)"
+    assert_operator elapsed, :<, 3.0, "should not block much past 1s (got #{elapsed}s)"
+  end
+
+  # -------------------- bzmpop --------------------
+
+  def test_bzmpop_happy_path_returns_immediately
+    k = key("bzmpop:zset")
+    @client.zadd(k, [[1.0, "a"], [2.0, "b"], [3.0, "c"]])
+
+    started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    result = @client.bzmpop(1.0, k, modifier: "MAX", count: 2)
+    elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+
+    # Expected: [key, [[member, score], ...]]
+    assert_kind_of Array, result
+    assert_equal k, result[0]
+    assert_equal [["c", 3.0], ["b", 2.0]], result[1]
+    assert_operator elapsed, :<, 0.5, "should return immediately (got #{elapsed}s)"
+  end
+
+  def test_bzmpop_timeout_path_returns_nil
+    started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    result = @client.bzmpop(1.0, key("bzmpop:missing"), modifier: "MIN", count: 1)
+    elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+
+    assert_nil result
+    assert_operator elapsed, :>=, 0.8, "should block for ~1s (got #{elapsed}s)"
+    assert_operator elapsed, :<, 3.0, "should not block much past 1s (got #{elapsed}s)"
+  end
+end

--- a/test/valkey/regression/test_pipeline_subscribe_guard.rb
+++ b/test/valkey/regression/test_pipeline_subscribe_guard.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Regression: pipelined { |p| p.subscribe(...) } used to silently accept the
+# subscribe command, send it through the batch, and leave the shared connection
+# stuck in subscribe-state — every subsequent normal command then failed with
+# "only (P|S)SUBSCRIBE / ... allowed in this context" and the block callback
+# was never invoked.
+#
+# The Pipeline now rejects SUBSCRIBE-shape commands at send_command time,
+# before any FFI dispatch, so callers see an actionable error and the client
+# stays fully usable.
+class TestPipelineSubscribeGuard < Minitest::Test
+  ENDPOINT = if ENV["STANDALONE_ENDPOINTS"] && !ENV["STANDALONE_ENDPOINTS"].empty?
+               host, port = ENV["STANDALONE_ENDPOINTS"].strip.rpartition(":").then { |p| [p[0], p[2]] }
+               { host: host, port: port.to_i }
+             else
+               { host: "127.0.0.1", port: Integer(ENV["VALKEY_PORT"] || 6379) }
+             end
+
+  def setup
+    @client = Valkey.new(host: ENDPOINT[:host], port: ENDPOINT[:port], timeout: 5.0)
+  end
+
+  def teardown
+    @client&.close
+  rescue StandardError
+    # best-effort cleanup
+  end
+
+  # 1) subscribe inside pipelined raises before any FFI dispatch.
+  def test_pipelined_subscribe_raises_command_error
+    error = assert_raises(Valkey::CommandError) do
+      @client.pipelined do |p|
+        p.subscribe("ch") { |on| on.message { |_, _| next } }
+      end
+    end
+    assert_match(/SUBSCRIBE-shape commands cannot be used inside pipelined/, error.message)
+  end
+
+  # 2) psubscribe inside pipelined is also rejected.
+  def test_pipelined_psubscribe_raises_command_error
+    assert_raises(Valkey::CommandError) do
+      @client.pipelined do |p|
+        p.psubscribe("ch.*") { |on| on.pmessage { |_, _, _| next } }
+      end
+    end
+  end
+
+  # 3) ssubscribe inside pipelined is also rejected (skip if the wrapper is
+  #    missing on this client — some deployments do not expose ssubscribe).
+  def test_pipelined_ssubscribe_raises_command_error
+    skip "ssubscribe not defined on Pipeline" unless Valkey::Pipeline.method_defined?(:ssubscribe)
+    assert_raises(Valkey::CommandError) do
+      @client.pipelined do |p|
+        p.ssubscribe("ch") { |on| on.smessage { |_, _| next } }
+      end
+    end
+  end
+
+  # 3b) unsubscribe / punsubscribe / sunsubscribe are also banned. These share
+  # the same connection-state hazard as the subscribe variants.
+  def test_pipelined_unsubscribe_variants_raise_command_error
+    assert_raises(Valkey::CommandError) do
+      @client.pipelined { |p| p.unsubscribe("ch") }
+    end
+    assert_raises(Valkey::CommandError) do
+      @client.pipelined { |p| p.punsubscribe("ch.*") }
+    end
+    return unless Valkey::Pipeline.method_defined?(:sunsubscribe)
+
+    assert_raises(Valkey::CommandError) do
+      @client.pipelined { |p| p.sunsubscribe("ch") }
+    end
+  end
+
+  # 3c) multi { |m| m.subscribe(...) } also uses Pipeline internally, so the
+  # same guard fires — subscribe in a transaction would strand the connection
+  # the same way it does in a plain pipeline.
+  def test_multi_subscribe_raises_command_error
+    assert_raises(Valkey::CommandError) do
+      @client.multi do |m|
+        m.subscribe("ch") { |on| on.message { |_, _| next } }
+      end
+    end
+  end
+
+  # 4) After a rejected pipelined subscribe, the same client remains fully
+  #    usable — the guard fires before any FFI dispatch touches the connection.
+  def test_client_remains_usable_after_rejected_pipelined_subscribe
+    assert_raises(Valkey::CommandError) do
+      @client.pipelined do |p|
+        p.subscribe("ch") { |on| on.message { |_, _| next } }
+      end
+    end
+
+    @client.set("regression:pipeline-subscribe-guard", "ok")
+    assert_equal "ok", @client.get("regression:pipeline-subscribe-guard")
+    assert_equal "PONG", @client.ping
+    @client.del("regression:pipeline-subscribe-guard")
+  end
+
+  # 5) The guard is pipeline-only: calling subscribe directly on the client
+  #    does not raise the guard's Valkey::CommandError. We verify by looking
+  #    for the guard's own error message — anything else means the guard did
+  #    not fire on the direct client-level subscribe path.
+  def test_client_subscribe_does_not_trigger_pipeline_guard
+    subscribe_error = nil
+    begin
+      @client.subscribe("regression:pipeline-guard:direct") do |on|
+        on.subscribe do |_, _|
+          # Immediately unsubscribe to let the block return cleanly.
+          @client.unsubscribe("regression:pipeline-guard:direct")
+        end
+      end
+    rescue Valkey::CommandError => e
+      subscribe_error = e
+    end
+
+    return unless subscribe_error
+
+    refute_match(
+      /SUBSCRIBE-shape commands cannot be used inside pipelined/,
+      subscribe_error.message,
+      "pipeline guard fired on direct-client subscribe path"
+    )
+  end
+end

--- a/test/valkey/regression/test_reconnect_attempts_guard.rb
+++ b/test/valkey/regression/test_reconnect_attempts_guard.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Regression tests for the reconnect_attempts: 0 guard.
+#
+# Setting reconnect_attempts: 0 hangs the process indefinitely below the FFI
+# boundary because of an integer underflow in glide-core's retry_strategies.rs
+# (0usize - 1 wraps). The Ruby-side guard converts that hang into a fast
+# ArgumentError. See https://github.com/valkey-io/valkey-glide/issues/6379.
+class TestReconnectAttemptsGuard < Minitest::Test
+  PORT = Integer(ENV["VALKEY_PORT"] || 8102)
+
+  def test_reconnect_attempts_zero_raises_argument_error
+    error = assert_raises(ArgumentError) do
+      Valkey.new(host: "127.0.0.1", port: PORT, reconnect_attempts: 0)
+    end
+    # Message must reference the upstream issue so operators can trace the
+    # rationale — future removal of this guard hinges on that issue closing.
+    assert_match(/6379/, error.message)
+  end
+
+  def test_reconnect_attempts_one_still_works
+    client = Valkey.new(host: "127.0.0.1", port: PORT, reconnect_attempts: 1)
+    assert_equal "PONG", client.ping
+  ensure
+    client&.close
+  end
+
+  def test_reconnect_attempts_five_still_works
+    client = Valkey.new(host: "127.0.0.1", port: PORT, reconnect_attempts: 5)
+    assert_equal "PONG", client.ping
+  ensure
+    client&.close
+  end
+
+  def test_negative_reconnect_attempts_still_raises_original_message
+    # The pre-existing non-negative check must remain intact — the new zero
+    # guard should not shadow it, so operators still see the specific
+    # "non-negative" wording for -1, -5, etc.
+    error = assert_raises(ArgumentError) do
+      Valkey.new(host: "127.0.0.1", port: PORT, reconnect_attempts: -1)
+    end
+    assert_match(/must be non-negative/, error.message)
+  end
+end

--- a/test/valkey/regression/test_wrongtype_error_class.rb
+++ b/test/valkey/regression/test_wrongtype_error_class.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Regression: WRONGTYPE server errors must surface as Valkey::WrongTypeError,
+# not the base Valkey::CommandError. WrongTypeError is defined in
+# lib/valkey/errors.rb but was never raised prior to this fix — every server
+# error came out as bare CommandError, so code rescuing the specific class
+# caught nothing.
+class TestWrongTypeErrorClass < Minitest::Test
+  def setup
+    @port = Integer(ENV["VALKEY_PORT"] || 8201)
+    @client = Valkey.new(host: "127.0.0.1", port: @port)
+    @key = "wrongtype-regression-#{Process.pid}-#{rand(1_000_000)}"
+    @client.del(@key)
+  end
+
+  def teardown
+    @client&.del(@key)
+    @client&.close
+  end
+
+  # WRONGTYPE on a string key targeted by a list command must raise the
+  # specific subclass, not bare CommandError.
+  def test_lpush_on_string_key_raises_wrong_type_error
+    @client.set(@key, "x")
+
+    error = assert_raises(Valkey::WrongTypeError) do
+      @client.lpush(@key, "y")
+    end
+
+    assert_instance_of Valkey::WrongTypeError, error
+    refute_equal Valkey::CommandError, error.class,
+                 "Expected the specific WrongTypeError subclass, got bare CommandError"
+  end
+
+  # WrongTypeError inherits from CommandError, so existing
+  # `rescue Valkey::CommandError` blocks in user code must still catch it.
+  # This guards the "not a breaking change" promise.
+  def test_wrong_type_error_rescuable_via_command_error
+    @client.set(@key, "x")
+
+    rescued = nil
+    begin
+      @client.lpush(@key, "y")
+    rescue Valkey::CommandError => e
+      rescued = e
+    end
+
+    refute_nil rescued, "WrongTypeError should be rescuable via CommandError superclass"
+    assert_kind_of Valkey::WrongTypeError, rescued
+    assert_kind_of Valkey::CommandError, rescued
+  end
+
+  # The upstream server error message ("WRONGTYPE Operation against a key
+  # holding the wrong kind of value") must remain intact in .message so
+  # log-scraping and existing string-match assertions keep working.
+  def test_error_message_preserves_wrongtype_prefix
+    @client.set(@key, "x")
+
+    error = assert_raises(Valkey::WrongTypeError) do
+      @client.lpush(@key, "y")
+    end
+
+    assert_match(/\AWRONGTYPE\b/, error.message,
+                 "Error message should still begin with the raw WRONGTYPE prefix")
+  end
+
+  # Regression guard: other server errors (e.g. INCR on a non-numeric value
+  # returns "ERR value is not an integer or out of range") must still raise
+  # bare CommandError, not be mis-mapped to WrongTypeError. This proves the
+  # dispatcher is conservative and only matches the WRONGTYPE prefix.
+  def test_non_wrongtype_error_still_raises_command_error
+    @client.set(@key, "not-a-number")
+
+    error = assert_raises(Valkey::CommandError) do
+      @client.incr(@key)
+    end
+
+    assert_equal Valkey::CommandError, error.class,
+                 "Non-WRONGTYPE server errors should raise bare CommandError, " \
+                 "not a more specific subclass"
+    refute_kind_of Valkey::WrongTypeError, error
+  end
+end

--- a/test/valkey/regression/test_xtrim.rb
+++ b/test/valkey/regression/test_xtrim.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Regression tests for xtrim behavior:
+#   1. Default approximate is now `false` so xtrim(k, N) trims to exactly N.
+#   2. LIMIT modifier is supported when approximate: true.
+#   3. LIMIT without approximate: true raises ArgumentError.
+#   4. MINID strategy still works.
+#
+# Server: 127.0.0.1:8101 (dedicated port for this regression suite).
+class TestXtrimRegression < Minitest::Test
+  SERVER_HOST = "127.0.0.1"
+  SERVER_PORT = 8101
+
+  def setup
+    @r = Valkey.new(host: SERVER_HOST, port: SERVER_PORT, timeout: 5.0)
+    @key_prefix = "xtrim-regression-#{Process.pid}-#{object_id}"
+    @keys = []
+  end
+
+  def teardown
+    @keys.each { |k| @r.del(k) }
+    @r.close
+  end
+
+  def unique_key(name)
+    key = "#{@key_prefix}-#{name}"
+    @keys << key
+    @r.del(key)
+    key
+  end
+
+  def add_entries(key, count)
+    ids = []
+    count.times do |i|
+      ids << @r.xadd(key, { "field" => "value#{i}" })
+    end
+    ids
+  end
+
+  def test_xtrim_default_trims_exactly
+    key = unique_key("default")
+    add_entries(key, 10)
+    assert_equal 10, @r.xlen(key)
+
+    removed = @r.xtrim(key, 5)
+    assert_equal 5, removed
+    assert_equal 5, @r.xlen(key)
+  end
+
+  def test_xtrim_explicit_approximate_false
+    key = unique_key("explicit-exact")
+    add_entries(key, 10)
+    assert_equal 10, @r.xlen(key)
+
+    removed = @r.xtrim(key, 5, approximate: false)
+    assert_equal 5, removed
+    assert_equal 5, @r.xlen(key)
+  end
+
+  def test_xtrim_explicit_maxlen_strategy
+    key = unique_key("explicit-maxlen")
+    add_entries(key, 10)
+    assert_equal 10, @r.xlen(key)
+
+    removed = @r.xtrim(key, 5, strategy: "MAXLEN")
+    assert_equal 5, removed
+    assert_equal 5, @r.xlen(key)
+  end
+
+  def test_xtrim_to_zero_removes_all
+    key = unique_key("zero")
+    add_entries(key, 10)
+    assert_equal 10, @r.xlen(key)
+
+    removed = @r.xtrim(key, 0)
+    assert_equal 10, removed
+    assert_equal 0, @r.xlen(key)
+  end
+
+  def test_xtrim_with_limit_and_approximate
+    key = unique_key("limit")
+    add_entries(key, 500)
+    assert_equal 500, @r.xlen(key)
+
+    # LIMIT is only allowed with approximate trimming. The exact number of entries
+    # removed is server-dependent (radix-tree granularity), but the call must succeed
+    # and return a non-negative Integer.
+    removed = @r.xtrim(key, 5, approximate: true, limit: 100)
+    assert_kind_of Integer, removed
+    assert_operator removed, :>=, 0
+  end
+
+  def test_xtrim_with_limit_without_approximate_raises
+    key = unique_key("limit-no-approx")
+    add_entries(key, 10)
+
+    error = assert_raises(ArgumentError) do
+      @r.xtrim(key, 5, limit: 100)
+    end
+    assert_equal "LIMIT can only be used with approximate: true", error.message
+  end
+
+  def test_xtrim_minid_strategy
+    key = unique_key("minid")
+    ids = add_entries(key, 10)
+    threshold = ids[4] # 5th entry - keep entries with id >= ids[4]
+    assert_equal 10, @r.xlen(key)
+
+    removed = @r.xtrim(key, threshold, strategy: "MINID")
+    assert_equal 4, removed
+    assert_equal 6, @r.xlen(key)
+  end
+end

--- a/test/valkey/uri_connection_test.rb
+++ b/test/valkey/uri_connection_test.rb
@@ -267,14 +267,19 @@ module ValkeyTests
 
     def test_zero_reconnect_attempts
       skip("URI connection tests only run on standalone mode") if cluster_mode?
-      # Zero retries should be valid (no retries)
-      client = ::Valkey.new(
-        host: "localhost",
-        port: 6379,
-        reconnect_attempts: 0
-      )
-      assert_equal "PONG", client.ping
-      client.close
+      # reconnect_attempts: 0 is rejected on the Ruby side because it triggers
+      # an integer underflow in glide-core's retry_strategies.rs that hangs
+      # the process below the FFI boundary. See
+      # https://github.com/valkey-io/valkey-glide/issues/6379.
+      # Once the upstream fix ships, this test should assert PONG again.
+      error = assert_raises(ArgumentError) do
+        ::Valkey.new(
+          host: "localhost",
+          port: 6379,
+          reconnect_attempts: 0
+        )
+      end
+      assert_match(/6379/, error.message)
     end
 
     # ====================


### PR DESCRIPTION
## Summary

Fixes seven rc3 blockers surfaced in a black-box bug bash of `valkey-glide-rb 1.0.0.pre.rc3`, plus adds a guard for a known upstream FFI hang and a rescuable error for the fork() SIGTRAP:

**Command dispatch bugs (Ruby-side)**
1. **`blpop` / `brpop` — NoMethodError.** `_bpop` called an undefined `send_blocking_command`; also passed the Symbol `:blpop` as `command_type` where an Integer `RequestType` was expected. Both fixed.
2. **`blmove` — server rejection.** Same Symbol-in-args pattern: `args = [:blmove, ...]` shipped an extra "blmove" token to RESP, producing `wrong number of arguments for 'blmove' command`. Fixed.
3. **`brpoplpush` removed** for parity with every other GLIDE binding (python-sync, python-async, go, node, java-client). glide-core lacks the `RequestType::BRPopLPush → get_command` mapping, so the command cannot dispatch. Users needing atomic blocking pop-and-move should use `blmove`.
4. **`xtrim(key, N)` never trimmed.** Wrapper defaulted `approximate: true` (sends `XTRIM MAXLEN ~ N`), which returns 0 on small streams. Flipped default to `false` (redis-rb parity) and added `limit:` kwarg.

**Error-class fixes (Ruby-side)**
5. **Wrong password → `Valkey::PermissionError`.** Previously raised generic `CannotConnectError` — indistinguishable from network failures, causing retry loops to spin on bad credentials. Now branches on `AuthenticationFailed` in the connection error message.
6. **`WRONGTYPE` → `Valkey::WrongTypeError`.** The class existed in `lib/valkey/errors.rb` but was never raised. WRONGTYPE errors now map to it. Not a breaking change — `WrongTypeError` is a `CommandError` subclass, so existing rescues still catch.
7. **Pipelined `subscribe` guard.** Silently accepting `pipelined { |p| p.subscribe(...) }` left the connection wedged in subscribe-state. Pipeline now raises `Valkey::CommandError` at enqueue-time.

**Safety guards for known upstream bugs**
8. **`reconnect_attempts: 0` hangs the process** (upstream valkey-io/valkey-glide#6379). Ruby-side `ArgumentError` guard rejects `0` until the upstream underflow fix ships.
9. **Client used after `fork()` aborts child with SIGTRAP** (upstream valkey-io/valkey-glide#6672, this repo #210). PID check raises `Valkey::InheritedError` instead; README documents the create-after-fork pattern for Puma/Unicorn/Sidekiq.

## Files

- `lib/valkey/commands/list_commands.rb` — fix blpop/brpop/blmove dispatch; remove brpoplpush
- `lib/valkey/commands/stream_commands.rb` — xtrim default + limit kwarg
- `lib/valkey.rb` — reconnect_attempts:0 guard, fork PID check, auth error branching, YARD note
- `lib/valkey/pipeline.rb` — subscribe/psubscribe/ssubscribe guard
- FFI error-decode path (path depends on where the WRONGTYPE mapping landed)
- `README.md` — "Forking servers" section
- `test/valkey/regression/` — 8 new regression test files
- `test/valkey/uri_connection_test.rb` — updated for new reconnect_attempts:0 behavior
- `test/valkey/auth_commands_test.rb` — reconnect_attempts:0 → 1 in wrong-credential probes

## Test plan

- [ ] All 8 new regression suites pass
- [ ] Pre-existing `uri_connection_test.rb` and `auth_commands_test.rb` pass
- [ ] `bundle exec rubocop` clean on changed files
- [ ] `blpop` / `brpop` / `blmove` work end-to-end (happy + timeout)
- [ ] `xtrim` trims to exact count without `approximate: true`
- [ ] Wrong password raises `PermissionError`; connect-refused still raises `CannotConnectError`
- [ ] WRONGTYPE raises `WrongTypeError`; other command errors still raise base `CommandError`
- [ ] Pipelined subscribe raises `CommandError` before any FFI dispatch
- [ ] `Valkey.new(reconnect_attempts: 0)` raises `ArgumentError` referencing #6379
- [ ] Fork test: child raises `Valkey::InheritedError` cleanly, no SIGTRAP

## Known follow-ups (not in this PR)

- `blpop("k", 1)` positional-timeout form — Ruby-side `_bpop` still expects trailing Hash. Test skipped.
- `brpoplpush` — awaits upstream `get_command` mapping fix.
- **Upstream issues to be filed:** IPv6 loopback connect failure, script_load/script_flush cache incoherence, cluster seed order sensitivity, `db:` out-of-range swallowed as timeout, MSET cross-slot silent fan-out (design question).

## Related

- Upstream FFI hang: valkey-io/valkey-glide#6379
- Upstream fork-safety: valkey-io/valkey-glide#6672
- This repo fork tracker: #210
