### PR TITLE
fix: pipeline route pass through

### DIFF
--- a/lib/valkey/pipeline.rb
+++ b/lib/valkey/pipeline.rb
@@ -15,13 +15,14 @@ class Valkey
     end
 
     # `route:` is accepted and ignored. Routing is not supported for Pipeline yet.
+    # rubocop:disable Lint/UnusedMethodArgument
     def send_command(command_type, command_args = [], route: nil, &block)
-      # rubocop:enable Lint/UnusedMethodArgument
       @commands << [command_type, command_args, block]
       future = Future.new(command_type, command_args)
       @futures << future
       future
     end
+    # rubocop:enable Lint/UnusedMethodArgument
 
     # @api private - called by Valkey#pipelined / the block form of #multi
     # once send_batch_commands' final results are available. Purely

--- a/lib/valkey/pipeline.rb
+++ b/lib/valkey/pipeline.rb
@@ -14,7 +14,9 @@ class Valkey
       @in_multi = false
     end
 
-    def send_command(command_type, command_args = [], &block)
+    # `route:` is accepted and ignored. Routing is not supported for Pipeline yet.
+    def send_command(command_type, command_args = [], route: nil, &block)
+      # rubocop:enable Lint/UnusedMethodArgument
       @commands << [command_type, command_args, block]
       future = Future.new(command_type, command_args)
       @futures << future


### PR DESCRIPTION
### Summary

Commands that accept a `route:` kwarg raised `ArgumentError: unknown keyword: :route` when queued inside `pipelined`/`multi`. They now queue without error and the `route` is ignored. Routing support for Batch is not yet implemented.

### Issue link

Related to #216 but a separate issues found. 

### Testing

- `bundle exec rubocop` — 99 files, no offenses.
- Verified against a live standalone server: `pipelined { set("rk","1"); ping(route: Valkey::Route.all_nodes); get("rk") }` returns `["OK", "PONG", "1"]` instead of raising, and a direct `send_command(RequestType::PING, [], route: ...)` inside `pipelined` queues cleanly.

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [x] Documentation is updated (if applicable).
-   [x] Linters have been run (`bundle exec rubocop`) and pass.
-   [x] Destination branch is correct - release-1.0
