### PR TITLE
Withhold server-module commands: JSON, FT, MODULE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,6 +277,8 @@ jobs:
     needs: [build-native-library]
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    # Disabled for now until Module support is added.
+    if: false
     steps:
       - name: Check out code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/lib/valkey/commands.rb
+++ b/lib/valkey/commands.rb
@@ -47,12 +47,9 @@ class Valkey
     include SetCommands
     include ScriptingCommands
     include FunctionCommands
-    include ModuleCommands
     include PubSubCommands
-    include JsonCommands
     include ClusterCommands
     include TransactionCommands
-    include VectorSearchCommands
     include StreamCommands
     include HashCommands
 

--- a/test/cluster/cluster_commands_test.rb
+++ b/test/cluster/cluster_commands_test.rb
@@ -55,26 +55,29 @@ class TestClusterGeoCommands < Minitest::Test
   include Lint::GeoCommands
 end
 
-class TestClusterJsonCommands < Minitest::Test
-  include Helper::Cluster
-  include Lint::JsonCommands
-end
-
-class TestClusterModuleCommands < Minitest::Test
-  include Helper::Cluster
-  include Lint::ModuleCommands
-end
-
-class TestClusterVectorSearchCommands < Minitest::Test
-  include Helper::Cluster
-  include Lint::VectorSearchCommands
-end
-
 # ValkeyTests modules with setup/teardown
 class TestClusterFunctionCommands < Minitest::Test
   include Helper::Cluster
   include ValkeyTests::FunctionCommands
 end
 
-# NOTE: Module tests (JsonCommands, ModuleCommands, VectorSearchCommands)
-# require modules loaded on all cluster nodes
+# Server-modules support is not yet added. Re-enable when implemented.
+#
+# The lint files are still required by test_helper, so they stay syntax-checked
+# and ready to re-enable alongside the lib includes. Note these also require the
+# modules to be loaded on all cluster nodes:
+#
+#   class TestClusterJsonCommands < Minitest::Test
+#     include Helper::Cluster
+#     include Lint::JsonCommands
+#   end
+#
+#   class TestClusterModuleCommands < Minitest::Test
+#     include Helper::Cluster
+#     include Lint::ModuleCommands
+#   end
+#
+#   class TestClusterVectorSearchCommands < Minitest::Test
+#     include Helper::Cluster
+#     include Lint::VectorSearchCommands
+#   end

--- a/test/cluster/cluster_commands_test.rb
+++ b/test/cluster/cluster_commands_test.rb
@@ -62,6 +62,8 @@ class TestClusterFunctionCommands < Minitest::Test
 end
 
 # Server-modules support is not yet added. Re-enable when implemented.
+# TODO: https://github.com/valkey-io/valkey-glide-ruby/issues/233
+#       https://github.com/valkey-io/valkey-glide-ruby/issues/234
 #
 # The lint files are still required by test_helper, so they stay syntax-checked
 # and ready to re-enable alongside the lib includes. Note these also require the

--- a/test/standalone/commands_test.rb
+++ b/test/standalone/commands_test.rb
@@ -36,17 +36,22 @@ class TestStandaloneGeoCommands < Minitest::Test
   include Lint::GeoCommands
 end
 
-class TestStandaloneJsonCommands < Minitest::Test
-  include Helper::Client
-  include Lint::JsonCommands
-end
-
-class TestStandaloneModuleCommands < Minitest::Test
-  include Helper::Client
-  include Lint::ModuleCommands
-end
-
-class TestStandaloneVectorSearchCommands < Minitest::Test
-  include Helper::Client
-  include Lint::VectorSearchCommands
-end
+# Server-modules support is not yet added. Re-enable when implemented.
+#
+# The lint files are still required by test_helper, so they stay syntax-checked
+# and ready to re-enable alongside the lib includes:
+#
+#   class TestStandaloneJsonCommands < Minitest::Test
+#     include Helper::Client
+#     include Lint::JsonCommands
+#   end
+#
+#   class TestStandaloneModuleCommands < Minitest::Test
+#     include Helper::Client
+#     include Lint::ModuleCommands
+#   end
+#
+#   class TestStandaloneVectorSearchCommands < Minitest::Test
+#     include Helper::Client
+#     include Lint::VectorSearchCommands
+#   end

--- a/test/standalone/commands_test.rb
+++ b/test/standalone/commands_test.rb
@@ -37,6 +37,8 @@ class TestStandaloneGeoCommands < Minitest::Test
 end
 
 # Server-modules support is not yet added. Re-enable when implemented.
+# TODO: https://github.com/valkey-io/valkey-glide-ruby/issues/233
+#       https://github.com/valkey-io/valkey-glide-ruby/issues/234
 #
 # The lint files are still required by test_helper, so they stay syntax-checked
 # and ready to re-enable alongside the lib includes:


### PR DESCRIPTION
## Summary

Current Modules API is withheld to avoid confusion as Module support is planned for post GA. 

## What changes

Removed from the `Commands` mixin in `lib/valkey/commands.rb`:

```ruby
include ModuleCommands       # 5 methods
include JsonCommands         # 22 methods
include VectorSearchCommands # 14 methods
```

json_get is not available in valkey-glide-rb 1.0.0: server-module commands are
withheld pending fixes. Use the generic command interface instead,
e.g. call("JSON.GET", ...).
```

**Module commands remain fully reachable** through the generic interface, which is unaffected:

```ruby
valkey.call("JSON.GET", "user:1", "$.name")
valkey.call("FT.SEARCH", "idx", "@title:ruby")
valkey.call("MODULE", "LIST")
```

## Also in this PR

Disables the `module-tests` CI job (`if: false`). With the test classes commented out, its `-n '/TestStandalone(Module|Json|VectorSearch)Commands/'` selector matches **zero tests and the job still exits 0** — green while asserting nothing.
