### PR TITLE
Fix: incorrect list commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Pending
 
+### Fixes
+
+* Ruby: Fix `blpop`, `brpop`, `blmove`, `rpoplpush` and `brpoplpush`, all of which were non-functional. `blpop`/`brpop` called a non-existent `send_blocking_command` helper, `blmove` leaked the command name into argv, and `rpoplpush`/`brpoplpush` dispatched `RequestType::RPOPLPUSH`/`BRPOPLPUSH`, for which glide-core has no command mapping. Since Valkey defines `RPOPLPUSH src dst` as exactly `LMOVE src dst RIGHT LEFT` (and `BRPOPLPUSH src dst timeout` as `BLMOVE src dst RIGHT LEFT timeout`), `rpoplpush`/`brpoplpush` are now fixed-argument facades over `lmove`/`blmove`. Both remain deprecated as of Redis 6.2; prefer `lmove`/`blmove` in new code. The unusable `RequestType::RPOPLPUSH`/`BRPOPLPUSH` constants were removed.
+
 ### Changes
 
 * Ruby: Add Alpine Linux (musl libc) support for x86_64 and aarch64 — runtime detection of musl libc, CI/CD pipeline for native builds, and prebuilt `libglide_ffi.so` for musl targets ([#143](https://github.com/valkey-io/valkey-glide-ruby/pull/143))

--- a/lib/valkey/commands/list_commands.rb
+++ b/lib/valkey/commands/list_commands.rb
@@ -51,16 +51,63 @@ class Valkey
       #     e.g. 'LEFT' - from head, 'RIGHT' - from tail
       # @param [String, Symbol] where_destination where to push the element to the source list
       #     e.g. 'LEFT' - to head, 'RIGHT' - to tail
-      # @param [Hash] options
-      #   - `:timeout => [Float, Integer]`: timeout in seconds, defaults to no timeout
+      # @param [Float, Integer] timeout timeout in seconds; `0` blocks indefinitely
       #
       # @return [nil, String] the element, or nil when the source key does not exist or the timeout expired
       #
+      # @note This command comes in place of the now deprecated BRPOPLPUSH.
+      #     Doing BLMOVE RIGHT LEFT is equivalent.
       def blmove(source, destination, where_source, where_destination, timeout: 0)
         where_source, where_destination = _normalize_move_wheres(where_source, where_destination)
+        timeout = _validate_blocking_timeout(timeout)
 
-        args = [:blmove, source, destination, where_source, where_destination, timeout]
+        args = [source, destination, where_source, where_destination, timeout]
         send_command(RequestType::BLMOVE, args)
+      end
+
+      # Remove the last element in a list, prepend it to another list and return it.
+      #
+      # Deprecated in Redis 6.2 in favour of `LMOVE` so implemented as facade over {#lmove}
+      # as `LMOVE src dst RIGHT LEFT``. Note that glide-core has no command mapping for
+      # `RequestType::RPopLPush`, so dispatching it directly is not an option.
+      #
+      # @example
+      #   valkey.rpush("src", "a", "b")
+      #   valkey.rpoplpush("src", "dst") # => "b"
+      #
+      # @param [String] source source key
+      # @param [String] destination destination key
+      #
+      # @return [nil, String] the element, or nil when the source key does not exist
+      #
+      # @see #lmove
+      def rpoplpush(source, destination)
+        lmove(source, destination, "RIGHT", "LEFT")
+      end
+
+      # Remove the last element in a list, prepend it to another list and return it,
+      # or block until one is available.
+      #
+      # Deprecated in Redis 6.2 in favour of `BLMOVE` so implemented as facade over {#blmove}
+      # as `BLMOVE src dst RIGHT LEFT`. Note that glide-core has no command mapping for
+      # `RequestType::BRPopLPush`, so dispatching it directly is not an option.
+      #
+      # @example With timeout
+      #   valkey.brpoplpush("src", "dst", timeout: 5)
+      #     # => nil on timeout
+      #     # => "element" on success
+      #
+      # @param [String] source source key
+      # @param [String] destination destination key
+      # @param [Float, Integer] timeout timeout in seconds; `0` blocks indefinitely
+      #
+      # @return [nil, String]
+      #   - `nil` when the operation timed out
+      #   - the element that was popped and pushed otherwise
+      #
+      # @see #blmove
+      def brpoplpush(source, destination, timeout: 0)
+        blmove(source, destination, "RIGHT", "LEFT", timeout: timeout)
       end
 
       # Prepend one or more values to a list, creating the list if it doesn't exist.
@@ -125,70 +172,50 @@ class Valkey
         send_command(RequestType::RPOP, args)
       end
 
-      # Remove the last element in a list, append it to another list and return it.
-      #
-      # @param [String] source source key
-      # @param [String] destination destination key
-      # @return [nil, String] the element, or nil when the source key does not exist
-      def rpoplpush(source, destination)
-        send_command(RequestType::RPOPLPUSH, [source, destination])
-      end
-
       # Remove and get the first element in a list, or block until one is available.
       #
       # @example With timeout
-      #   list, element = valkey.blpop("list", :timeout => 5)
+      #   list, element = valkey.blpop("list", timeout: 5)
       #     # => nil on timeout
       #     # => ["list", "element"] on success
       # @example Without timeout
       #   list, element = valkey.blpop("list")
       #     # => ["list", "element"]
       # @example Blocking pop on multiple lists
-      #   list, element = valkey.blpop(["list", "another_list"])
-      #     # => ["list", "element"]
+      #   list, element = valkey.blpop("list", "another_list", timeout: 5)
+      #   list, element = valkey.blpop(["list", "another_list"], timeout: 5)
       #
-      # @param [String, Array<String>] keys one or more keys to perform the
-      #   blocking pop on
-      # @param [Hash] options
-      #   - `:timeout => [Float, Integer]`: timeout in seconds, defaults to no timeout
+      # @param [String, Array<String>] keys one or more keys, checked in the given
+      #   order; in cluster mode all keys must map to the same hash slot
+      # @param [Float, Integer] timeout timeout in seconds; `0` blocks indefinitely
       #
       # @return [nil, [String, String]]
       #   - `nil` when the operation timed out
       #   - tuple of the list that was popped from and element was popped otherwise
-      def blpop(*args)
-        _bpop(:blpop, args)
+      def blpop(*keys, timeout: 0)
+        _bpop(keys, is_left: true, timeout: timeout)
       end
 
       # Remove and get the last element in a list, or block until one is available.
       #
-      # @param [String, Array<String>] keys one or more keys to perform the
-      #   blocking pop on
-      # @param [Hash] options
-      #   - `:timeout => [Float, Integer]`: timeout in seconds, defaults to no timeout
+      # @param [String, Array<String>] keys one or more keys, checked in the given
+      #   order; in cluster mode all keys must map to the same hash slot
+      # @param [Float, Integer] timeout timeout in seconds; `0` blocks indefinitely
       #
       # @return [nil, [String, String]]
       #   - `nil` when the operation timed out
       #   - tuple of the list that was popped from and element was popped otherwise
       #
+      # @example With timeout
+      #   list, element = valkey.brpop("list", timeout: 5)
+      #     # => nil on timeout
+      #     # => ["list", "element"] on success
+      # @example Blocking pop on multiple lists
+      #   list, element = valkey.brpop("list", "another_list", timeout: 5)
+      #
       # @see #blpop
-      def brpop(*args)
-        _bpop(RequestType::BRPOP, args.flatten)
-      end
-
-      # Pop a value from a list, push it to another list and return it; or block
-      # until one is available.
-      #
-      # @param [String] source source key
-      # @param [String] destination destination key
-      # @param [Hash] options
-      #   - `:timeout => [Float, Integer]`: timeout in seconds, defaults to no timeout
-      #
-      # @return [nil, String]
-      #   - `nil` when the operation timed out
-      #   - the element was popped and pushed otherwise
-      def brpoplpush(source, destination, timeout: 0)
-        args = [:brpoplpush, source, destination, timeout]
-        send_blocking_command(RequestType::BRPOPLPUSH, args, timeout)
+      def brpop(*keys, timeout: 0)
+        _bpop(keys, is_left: false, timeout: timeout)
       end
 
       # Pops one or more elements from the first non-empty list key from the list
@@ -313,20 +340,23 @@ class Valkey
 
       private
 
-      def _bpop(cmd, args, &blk)
-        timeout = if args.last.is_a?(Hash)
-                    options = args.pop
-                    options[:timeout]
-                  end
+      # Shared implementation for BLPOP and BRPOP.
+      def _bpop(keys, is_left: false, timeout: 0)
+        request_type = is_left ? RequestType::BLPOP : RequestType::BRPOP
+        args = keys.flatten(1)
+        args << _validate_blocking_timeout(timeout)
 
+        send_command(request_type, args)
+      end
+
+      # @return [Integer, Float] a validated blocking timeout in seconds
+      def _validate_blocking_timeout(timeout)
         timeout ||= 0
         unless timeout.is_a?(Integer) || timeout.is_a?(Float)
           raise ArgumentError, "timeout must be an Integer or Float, got: #{timeout.class}"
         end
 
-        args.flatten!(1)
-        args << timeout
-        send_blocking_command(cmd, args, &blk)
+        timeout
       end
 
       def _normalize_move_wheres(where_source, where_destination)

--- a/lib/valkey/commands/list_commands.rb
+++ b/lib/valkey/commands/list_commands.rb
@@ -82,6 +82,7 @@ class Valkey
       #
       # @see #lmove
       def rpoplpush(source, destination)
+        # TODO: https://github.com/valkey-io/valkey-glide-ruby/issues/242
         lmove(source, destination, "RIGHT", "LEFT")
       end
 
@@ -107,6 +108,7 @@ class Valkey
       #
       # @see #blmove
       def brpoplpush(source, destination, timeout: 0)
+        # TODO: https://github.com/valkey-io/valkey-glide-ruby/issues/242
         blmove(source, destination, "RIGHT", "LEFT", timeout: timeout)
       end
 

--- a/lib/valkey/request_type.rb
+++ b/lib/valkey/request_type.rb
@@ -162,7 +162,6 @@ class Valkey
     BLMPOP = 802
     BLPOP = 803
     BRPOP = 804
-    BRPOPLPUSH = 805 # deprecated in 6.2.0
     LINDEX = 806
     LINSERT = 807
     LLEN = 808
@@ -177,7 +176,6 @@ class Valkey
     LSET = 817
     LTRIM = 818
     RPOP = 819
-    RPOPLPUSH = 820 # deprecated in 6.2.0
     RPUSH = 821
     RPUSHX = 822
 

--- a/test/lint/list_commands.rb
+++ b/test/lint/list_commands.rb
@@ -260,5 +260,329 @@ module Lint
         assert_equal({ '{1}foo' => ['a'] }, r.lmpop('{1}foo', '{1}foo2', modifier: "RIGHT"))
       end
     end
+
+    # --- Blocking list commands -------------------------------------------
+    #
+    # Every test below pushes a value first so the command returns immediately
+    # instead of actually blocking, except where the timeout path is the point.
+    # Timeouts are kept at 1s so the suite stays fast.
+
+    def test_blpop
+      r.rpush("{1}foo", "s1")
+
+      # Single key, no explicit timeout.
+      assert_equal ["{1}foo", "s1"], r.blpop("{1}foo")
+
+      # Single key with an explicit timeout.
+      r.rpush("{1}foo", "s2")
+      assert_equal ["{1}foo", "s2"], r.blpop("{1}foo", timeout: 1)
+
+      # BLPOP pops from the head.
+      r.rpush("{1}foo", "head", "tail")
+      assert_equal ["{1}foo", "head"], r.blpop("{1}foo", timeout: 1)
+      assert_equal ["tail"], r.lrange("{1}foo", 0, -1)
+    end
+
+    def test_blpop_multiple_keys
+      r.rpush("{1}foo2", "s2")
+
+      # Array form: keys are checked in the order given, so the first
+      # non-empty one wins even though it is not first in the list.
+      assert_equal ["{1}foo2", "s2"], r.blpop(["{1}foo", "{1}foo2"], timeout: 1)
+
+      # Splat form should behave identically to the array form.
+      r.rpush("{1}foo", "s1")
+      assert_equal ["{1}foo", "s1"], r.blpop("{1}foo", "{1}foo2", timeout: 1)
+    end
+
+    # Splat and Array forms may be mixed; `keys` is flattened one level. This
+    # covers the mixed shape end-to-end, but note it does not isolate _bpop's
+    # flatten: build_command_args in lib/valkey.rb flattens nested Arrays too,
+    # so the call still succeeds without it. The argv guards below are what
+    # observe _bpop's own output.
+    def test_blpop_mixed_key_forms
+      r.rpush("{1}foo3", "s3")
+
+      assert_equal ["{1}foo3", "s3"], r.blpop("{1}foo", ["{1}foo2", "{1}foo3"], timeout: 1)
+    end
+
+    # Float timeouts must survive to a live server, not just into argv.
+    def test_blpop_accepts_float_timeout
+      r.rpush("{1}foo", "s1")
+
+      assert_equal ["{1}foo", "s1"], r.blpop("{1}foo", timeout: 1.5)
+    end
+
+    def test_blpop_timeout_returns_nil
+      assert_nil r.blpop("{1}missing", timeout: 1)
+    end
+
+    def test_blpop_validates_timeout
+      error = assert_raises(ArgumentError) do
+        r.blpop("{1}foo", timeout: "1")
+      end
+      assert_equal "timeout must be an Integer or Float, got: String", error.message
+    end
+
+    def test_brpop
+      r.rpush("{1}foo", "s1")
+
+      # Single key, no explicit timeout.
+      assert_equal ["{1}foo", "s1"], r.brpop("{1}foo")
+
+      # Single key with an explicit timeout.
+      r.rpush("{1}foo", "s2")
+      assert_equal ["{1}foo", "s2"], r.brpop("{1}foo", timeout: 1)
+
+      # BRPOP pops from the tail.
+      r.rpush("{1}foo", "head", "tail")
+      assert_equal ["{1}foo", "tail"], r.brpop("{1}foo", timeout: 1)
+      assert_equal ["head"], r.lrange("{1}foo", 0, -1)
+    end
+
+    def test_brpop_multiple_keys
+      r.rpush("{1}foo2", "s2")
+
+      assert_equal ["{1}foo2", "s2"], r.brpop(["{1}foo", "{1}foo2"], timeout: 1)
+
+      r.rpush("{1}foo", "s1")
+      assert_equal ["{1}foo", "s1"], r.brpop("{1}foo", "{1}foo2", timeout: 1)
+    end
+
+    # @see #test_blpop_mixed_key_forms
+    def test_brpop_mixed_key_forms
+      r.rpush("{1}foo3", "s3")
+
+      assert_equal ["{1}foo3", "s3"], r.brpop("{1}foo", ["{1}foo2", "{1}foo3"], timeout: 1)
+    end
+
+    def test_brpop_accepts_float_timeout
+      r.rpush("{1}foo", "s1")
+
+      assert_equal ["{1}foo", "s1"], r.brpop("{1}foo", timeout: 1.5)
+    end
+
+    def test_brpop_timeout_returns_nil
+      assert_nil r.brpop("{1}missing", timeout: 1)
+    end
+
+    def test_brpop_builds_argv_with_timeout_as_last_token
+      with_timeout = capture_blocking_argv { r.brpop("{1}missing", timeout: 1) }
+      assert_equal ["{1}missing", 1], with_timeout
+
+      # No explicit timeout still appends the 0 sentinel.
+      without_timeout = capture_blocking_argv { r.brpop("{1}missing") }
+      assert_equal ["{1}missing", 0], without_timeout
+
+      # Floats survive as-is.
+      float_timeout = capture_blocking_argv { r.brpop("{1}missing", timeout: 1.5) }
+      assert_equal ["{1}missing", 1.5], float_timeout
+    end
+
+    # Same guard for blpop, including the array key form where the options Hash
+    # sits behind an Array argument, and the splat form.
+    def test_blpop_builds_argv_with_timeout_as_last_token
+      single_key = capture_blocking_argv { r.blpop("{1}missing", timeout: 1) }
+      assert_equal ["{1}missing", 1], single_key
+
+      array_form = capture_blocking_argv { r.blpop(["{1}missing", "{1}missing2"], timeout: 1) }
+      assert_equal ["{1}missing", "{1}missing2", 1], array_form
+
+      splat_form = capture_blocking_argv { r.blpop("{1}missing", "{1}missing2", timeout: 1) }
+      assert_equal ["{1}missing", "{1}missing2", 1], splat_form
+    end
+
+    # blmove's timeout must likewise land as the final argv token.
+    def test_blmove_builds_argv_with_timeout_as_last_token
+      with_timeout = capture_blocking_argv { r.blmove("{1}src", "{1}dst", "LEFT", "RIGHT", timeout: 1) }
+      assert_equal ["{1}src", "{1}dst", "LEFT", "RIGHT", 1], with_timeout
+
+      without_timeout = capture_blocking_argv { r.blmove("{1}src", "{1}dst", "RIGHT", "LEFT") }
+      assert_equal ["{1}src", "{1}dst", "RIGHT", "LEFT", 0], without_timeout
+    end
+
+    def test_brpop_honours_timeout_against_server
+      started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      assert_nil r.brpop("{1}missing", timeout: 1)
+      elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+
+      assert_operator elapsed, :>=, 0.5, "brpop returned too early to have waited for the timeout"
+    end
+
+    def test_blmove
+      # Uses foo/bar keys across different hash slots
+      skip("Cross-slot operation not supported in cluster mode") if cluster_mode?
+
+      r.rpush("foo", "a", "b") # foo = [a, b]
+
+      # LEFT -> RIGHT: pop the head of source, append to destination.
+      assert_equal "a", r.blmove("foo", "bar", "LEFT", "RIGHT", timeout: 1)
+      assert_equal ["b"], r.lrange("foo", 0, -1)
+      assert_equal ["a"], r.lrange("bar", 0, -1)
+
+      # RIGHT -> LEFT: pop the tail of source, prepend to destination.
+      assert_equal "b", r.blmove("foo", "bar", "RIGHT", "LEFT", timeout: 1)
+      assert_equal [], r.lrange("foo", 0, -1)
+      assert_equal %w[b a], r.lrange("bar", 0, -1)
+
+      # Source is now empty, so the call times out and returns nil.
+      assert_nil r.blmove("foo", "bar", "RIGHT", "LEFT", timeout: 1)
+    end
+
+    def test_blmove_without_explicit_timeout_returns_immediately_when_data_present
+      skip("Cross-slot operation not supported in cluster mode") if cluster_mode?
+
+      r.rpush("foo", "only")
+
+      assert_equal "only", r.blmove("foo", "bar", "LEFT", "LEFT")
+      assert_equal ["only"], r.lrange("bar", 0, -1)
+    end
+
+    def test_blmove_validates_wheres
+      error = assert_raises(ArgumentError) do
+        r.blmove("{1}foo", "{1}bar", "LEFT", "MIDDLE", timeout: 1)
+      end
+      assert_equal "where_destination must be 'LEFT' or 'RIGHT'", error.message
+    end
+
+    def test_blmove_validates_timeout
+      error = assert_raises(ArgumentError) do
+        r.blmove("{1}foo", "{1}bar", "LEFT", "RIGHT", timeout: "1")
+      end
+      assert_equal "timeout must be an Integer or Float, got: String", error.message
+    end
+
+    def test_rpoplpush
+      # Uses foo/bar keys across different hash slots
+      skip("Cross-slot operation not supported in cluster mode") if cluster_mode?
+
+      r.rpush("foo", "a", "b") # foo = [a, b]
+
+      # The tail of foo becomes the head of bar.
+      assert_equal "b", r.rpoplpush("foo", "bar") # foo = [a], bar = [b]
+      assert_equal ["a"], r.lrange("foo", 0, -1)
+      assert_equal ["b"], r.lrange("bar", 0, -1)
+
+      assert_equal "a", r.rpoplpush("foo", "bar") # foo = [], bar = [a, b]
+      assert_equal [], r.lrange("foo", 0, -1)
+      assert_equal %w[a b], r.lrange("bar", 0, -1)
+
+      # An empty list is deleted, so source no longer exists.
+      assert_nil r.rpoplpush("foo", "bar")
+      assert_nil r.rpoplpush("nonexistent", "bar")
+      assert_equal %w[a b], r.lrange("bar", 0, -1)
+    end
+
+    # Currying guard: rpoplpush must dispatch LMOVE with the exact argv the
+    # documented replacement builds -- nothing added, reordered or translated.
+    def test_rpoplpush_is_equivalent_to_lmove_right_left
+      facade_type, facade_argv = capture_blocking_call { r.rpoplpush("{1}src", "{1}dst") }
+      lmove_type, lmove_argv = capture_blocking_call { r.lmove("{1}src", "{1}dst", "RIGHT", "LEFT") }
+
+      assert_equal Valkey::RequestType::LMOVE, facade_type
+      assert_equal ["{1}src", "{1}dst", "RIGHT", "LEFT"], facade_argv
+
+      assert_equal lmove_type, facade_type
+      assert_equal lmove_argv, facade_argv
+    end
+
+    def test_brpoplpush
+      # Uses foo/bar keys across different hash slots
+      skip("Cross-slot operation not supported in cluster mode") if cluster_mode?
+
+      r.rpush("foo", "a", "b") # foo = [a, b]
+
+      assert_equal "b", r.brpoplpush("foo", "bar", timeout: 1) # foo = [a], bar = [b]
+      assert_equal ["a"], r.lrange("foo", 0, -1)
+      assert_equal ["b"], r.lrange("bar", 0, -1)
+
+      assert_equal "a", r.brpoplpush("foo", "bar", timeout: 1) # foo = [], bar = [a, b]
+      assert_equal [], r.lrange("foo", 0, -1)
+      assert_equal %w[a b], r.lrange("bar", 0, -1)
+
+      # Source is now empty, so the call times out and returns nil.
+      assert_nil r.brpoplpush("foo", "bar", timeout: 1)
+    end
+
+    def test_brpoplpush_without_explicit_timeout_returns_immediately_when_data_present
+      skip("Cross-slot operation not supported in cluster mode") if cluster_mode?
+
+      r.rpush("foo", "only")
+
+      assert_equal "only", r.brpoplpush("foo", "bar")
+      assert_equal ["only"], r.lrange("bar", 0, -1)
+    end
+
+    # Same guard as test_blmove_builds_argv_with_timeout_as_last_token, applied to
+    # the facade: the timeout must survive the extra hop and still land as the
+    # final argv token rather than being dropped (== block forever).
+    def test_brpoplpush_builds_argv_with_timeout_as_last_token
+      with_timeout = capture_blocking_argv { r.brpoplpush("{1}src", "{1}dst", timeout: 1) }
+      assert_equal ["{1}src", "{1}dst", "RIGHT", "LEFT", 1], with_timeout
+
+      # No explicit timeout still appends the 0 sentinel.
+      without_timeout = capture_blocking_argv { r.brpoplpush("{1}src", "{1}dst") }
+      assert_equal ["{1}src", "{1}dst", "RIGHT", "LEFT", 0], without_timeout
+
+      # Floats survive as-is.
+      float_timeout = capture_blocking_argv { r.brpoplpush("{1}src", "{1}dst", timeout: 1.5) }
+      assert_equal ["{1}src", "{1}dst", "RIGHT", "LEFT", 1.5], float_timeout
+    end
+
+    # Currying guard for the blocking facade, timeout included.
+    def test_brpoplpush_is_equivalent_to_blmove_right_left
+      facade_type, facade_argv = capture_blocking_call { r.brpoplpush("{1}src", "{1}dst", timeout: 1) }
+      blmove_type, blmove_argv = capture_blocking_call do
+        r.blmove("{1}src", "{1}dst", "RIGHT", "LEFT", timeout: 1)
+      end
+
+      assert_equal Valkey::RequestType::BLMOVE, facade_type
+      assert_equal ["{1}src", "{1}dst", "RIGHT", "LEFT", 1], facade_argv
+
+      assert_equal blmove_type, facade_type
+      assert_equal blmove_argv, facade_argv
+    end
+
+    # The facade adds no validation of its own; it inherits blmove's.
+    def test_brpoplpush_validates_timeout
+      error = assert_raises(ArgumentError) do
+        r.brpoplpush("{1}src", "{1}dst", timeout: "1")
+      end
+      assert_equal "timeout must be an Integer or Float, got: String", error.message
+    end
+
+    private
+
+    # Invokes a blocking list command while intercepting send_command, and
+    # returns the argv the client built -- without issuing a real blocking call.
+    # Mirrors capture_cluster_failover_args in test/lint/cluster_commands.rb and
+    # capture_call_args in test/valkey/call_test.rb.
+    def capture_blocking_argv(&invocation)
+      captured = nil
+      recorder = lambda do |_request_type, args = [], **_opts, &_block|
+        captured = args
+        nil
+      end
+      r.stub(:send_command, recorder, &invocation)
+      captured
+    end
+
+    # Same interception as capture_blocking_argv, but also returns the
+    # RequestType. Used by the rpoplpush/brpoplpush currying guards, where the
+    # request type is half the claim: a facade that built the right argv under
+    # the wrong request type would still be a different command.
+    #
+    # @return [[Integer, Array]] the request type and argv the client built
+    def capture_blocking_call(&invocation)
+      captured_type = nil
+      captured_args = nil
+      recorder = lambda do |request_type, args = [], **_opts, &_block|
+        captured_type = request_type
+        captured_args = args
+        nil
+      end
+      r.stub(:send_command, recorder, &invocation)
+      [captured_type, captured_args]
+    end
   end
 end


### PR DESCRIPTION
### Summary

`blpop`, `brpop`, `blmove`, `rpoplpush` and `brpoplpush` were all non-functional. This PR fixes all five. No breaking changes.

### Issue link

Related #216

### What was broken

| Command | Failure |
|---|---|
| `blpop` / `brpop` | `_bpop` called `send_blocking_command`, a helper that does not exist anywhere in the repo → `NoMethodError` on every call. `blpop` also passed the Symbol `:blpop` where an Integer `RequestType` is required. |
| `blmove` | Prepended a stray `:blmove` token to argv → server rejected every call with `wrong number of arguments`. |
| `rpoplpush` / `brpoplpush` | Dispatched `RequestType::RPOPLPUSH`/`BRPOPLPUSH`, for which glide-core has no `get_command` mapping arm → `Couldn't fetch command type- ClientError`. |

### Changes

**Blocking dispatch.** `blpop`/`brpop` now go through the ordinary `send_command` — glide-core handles the blocking wait natively, so no separate dispatch path is needed.

**`rpoplpush`/`brpoplpush` as facades over `lmove`/`blmove`.** Valkey defines `RPOPLPUSH` as *precisely* `LMOVE ... RIGHT LEFT`, so the missing dispatch path is recoverable by fixed-argument currying rather than by dropping the API:

```
RPOPLPUSH  src dst          ≡  LMOVE  src dst RIGHT LEFT
BRPOPLPUSH src dst timeout  ≡  BLMOVE src dst RIGHT LEFT timeout
```

```ruby
def rpoplpush(source, destination)
  lmove(source, destination, "RIGHT", "LEFT")
end

def brpoplpush(source, destination, timeout: 0)
  blmove(source, destination, "RIGHT", "LEFT", timeout: timeout)
end
```

As one-line facades they inherit `lmove`/`blmove`'s where-normalization, timeout validation and argv construction, so they cannot drift. Both remain documented as deprecated (Redis 6.2) in favour of `lmove`/`blmove`. The unusable `RequestType::RPOPLPUSH`/`BRPOPLPUSH` constants are removed — nothing referenced them.

**Explicit `timeout` keyword on `blpop`/`brpop`.** Both took `*args` and inferred the timeout by sniffing for a trailing options Hash. That indirection is where the bugs came from: an undeclared parameter cannot be validated at the boundary, and a Hash that survives the sniff becomes a key while the timeout silently falls back to `0` — block forever. The positional timeout that `*args` existed to support was deprecated in redis-rb 4.8.0 and **removed in 5.0.0**, so the splat's only remaining job is variadic keys:

```ruby
def blpop(*keys, timeout: 0)
def brpop(*keys, timeout: 0)
```

Every documented redis-rb 5.x call shape still works — single key, Array, splat, mixed, implicit timeout — and the contract now matches the Python client (keys checked in order, `[key, value]` return, `0` blocks indefinitely). Also dropped the unreachable `&blk` from `_bpop`: neither method declared or forwarded a block, so it was always `nil`.

**Refactor.** Extracted `_validate_blocking_timeout` so `blmove` validates its timeout the same way `blpop`/`brpop` do — new validation for `blmove`, which previously had none.

**Docs.** Corrected YARD on `blpop`/`brpop`/`blmove`/`brpoplpush`, all of which documented a `@param [Hash] options` that no longer exists. The `@example` lines mattered most: they showed `:timeout => 5`, which is the one form this PR changes, so copy-pasting them would have produced a block-forever call.

### Compatibility

One behavioral change: an **explicit positional Hash**, `blpop("k", { timeout: 1 })`, previously worked via the Hash sniff and now treats the Hash as a key. This is the form redis-rb removed in 5.0.0; it is used nowhere in this repo, and `blpop("k", timeout: 1)` (keywords) is unaffected. All other forms are byte-identical — verified by diffing built argv across 13 call shapes before and after.

### Checklist

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] Documentation is updated (if applicable).
-   [x] Linters have been run (`bundle exec rubocop`) and pass.
-   [x] Destination branch is correct - `release-1.0`
