### PR TITLE
Support Ruby 2.7: conditional ffi dependency for Ruby < 3.0

### DIFF
--- a/valkey.gemspec
+++ b/valkey.gemspec
@@ -29,5 +29,7 @@ Gem::Specification.new do |spec|
   end + Dir.glob("lib/valkey/native/**/*").reject { |f| File.directory?(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "ffi", "~> 1.17.0"
+  # ffi 1.17 dropped Ruby 2.7 (its required_ruby_version is >= 3.0), so 2.7
+  # installs resolve to ffi 1.16.x while 3.x installs pick up 1.17+ automatically.
+  spec.add_dependency "ffi", "~> 1.16"
 end


### PR DESCRIPTION
### Summary

Widen the `ffi` runtime dependency so the gem is installable on Ruby 2.7 — which
`valkey.gemspec` already declares support for via `required_ruby_version >= 2.6.0` —
without affecting resolution on Ruby 3.x.

Today `ffi` is pinned to `~> 1.17.0`, but `ffi` 1.17 dropped Ruby 2.7 (its
`required_ruby_version` is `>= 3.0`), so `bundle install` fails on 2.7 even though the
gem otherwise advertises 2.6+.

### Issue link

Closes #221

### Features / Changes

- `valkey.gemspec`: widen the `ffi` requirement from `~> 1.17.0` to `~> 1.16`.
  RubyGems then resolves `ffi 1.16.x` on Ruby 2.7 (it skips 1.17, whose
  `required_ruby_version` excludes 2.7) and `1.17+` on Ruby 3.x.

### Testing

- Built `libglide_ffi` from the pinned `valkey-glide` submodule and installed the gem
  on **Ruby 2.7.8** (Debian bullseye); confirmed `ffi 1.16.3` resolves and the native
  library loads.
- Exercised the client against a live server on 2.7.8: `PING`, and the string/set/expiry
  commands `get/set/getset/del/expire/exists/sadd/srem/smembers/sismember/expireat`,
  including through `valkey-namespace` and a downstream Rails app.
- Confirmed Ruby 3.x resolution is unchanged in practice (still resolves `ffi 1.17.x`).
- `bundle exec rubocop` passes (the earlier `Gemspec/RubyVersionGlobalsUsage` offense
  is resolved by using a plain version range).

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] Documentation is updated (if applicable).
-   [x] Linters have been run (`bundle exec rubocop`) and pass.
-   [x] Destination branch is correct - main

