### PR TITLE
fix: raise `ConnectionError` instead of segfaulting on a closed client

### DIFF
--- a/lib/valkey.rb
+++ b/lib/valkey.rb
@@ -272,6 +272,12 @@ class Valkey
     end
 
     @connection = res[:conn_ptr]
+    # Serializes `close` so two threads cannot both capture the handle and
+    # double-decrement its Arc refcount (issue #212). We use `Mutex#try_lock`
+    # in `close`, not `#synchronize`, so trap-context callers still work:
+    # only `#lock`/`#synchronize` raise ThreadError from a trap, `#try_lock`
+    # returns false and moves on.
+    @close_lock = Mutex.new
     Bindings.free_connection_response(response_ptr)
 
     # Store cluster mode flag for response handling (MAP returns Hash in cluster, Array in standalone)
@@ -292,25 +298,35 @@ class Valkey
     @in_multi_block = false
   end
 
-  # Closes the client and frees the native connection. Idempotent: the handle is
-  # cleared before it is freed, so a second `close` sees nil and does nothing
-  # rather than freeing the same pointer twice.
+  # Closes the client and frees the native connection. Idempotent and
+  # thread-safe: `@close_lock.try_lock` lets exactly one caller free the
+  # handle, while every other concurrent `close` (and every subsequent one)
+  # is a no-op. Without this, two threads could both read `@connection`
+  # before either nulled it, both call `close_client`, and double-decrement
+  # the Arc refcount - which is UB per Rust (issue #212).
   #
-  # Deliberately not synchronized. A Mutex here would break the common
-  # `Signal.trap("TERM") { client.close }` shutdown idiom, because Ruby forbids
-  # locking from a trap context (ThreadError) - and it would leave the handle
-  # leaked when it raised.
+  # `try_lock` (not `synchronize`) is deliberate: `Mutex#synchronize` /
+  # `#lock` raise ThreadError from a trap context, but `#try_lock` does not.
+  # That keeps the standard `Signal.trap("TERM") { client.close }` shutdown
+  # idiom working - the trap either wins the lock and closes, or another
+  # thread has already closed and it silently returns.
   #
-  # In-flight commands are safe without a lock: every glide-ffi command entry
-  # point does `Arc::increment_strong_count` on the handle before using it, and
+  # In-flight commands are safe: every glide-ffi command entry point does
+  # `Arc::increment_strong_count` on the handle before using it, and
   # `close_client` only decrements, so the native ClientAdapter outlives any
-  # request still executing and is dropped once the last one finishes. Verified
-  # with 12 concurrent blocking calls held open across a `close`. See issue #212.
+  # request still executing and is dropped once the last one finishes.
+  # Verified with 12 concurrent blocking calls held open across a `close`.
   def close
-    conn = @connection
-    @connection = nil
+    return unless @close_lock&.try_lock
 
-    Bindings.close_client(conn) unless conn.nil? || conn.null?
+    begin
+      conn = @connection
+      @connection = nil
+
+      Bindings.close_client(conn) unless conn.nil? || conn.null?
+    ensure
+      @close_lock.unlock
+    end
   end
 
   alias disconnect! close
@@ -470,21 +486,7 @@ class Valkey
   private
 
   # Returns the live native client handle, raising if the client has been
-  # closed. Every call into the native layer that takes the client handle must
-  # go through this method: `close` frees the handle and sets `@connection` to
-  # nil, and passing that nil on to the FFI layer makes the core dereference a
-  # NULL pointer, which segfaults the whole VM instead of raising something
-  # Ruby code can rescue. See issue #212.
-  #
-  # The message matches the sibling GLIDE clients (Go ClosingError,
-  # Node/Java ClosingException).
-  #
-  # `nil?` is tested first because `@connection` is nil if `initialize` raised
-  # before connecting, and `nil.null?` would raise NoMethodError.
-  #
-  # The handle is returned rather than read from the ivar at the call site so
-  # callers pass a local, which keeps a concurrent `close` from nulling the
-  # reference between this check and the native call.
+  # closed.
   def connection!
     conn = @connection
     raise ConnectionError, "the client is closed" if conn.nil? || conn.null?

--- a/lib/valkey.rb
+++ b/lib/valkey.rb
@@ -292,11 +292,25 @@ class Valkey
     @in_multi_block = false
   end
 
+  # Closes the client and frees the native connection. Idempotent: the handle is
+  # cleared before it is freed, so a second `close` sees nil and does nothing
+  # rather than freeing the same pointer twice.
+  #
+  # Deliberately not synchronized. A Mutex here would break the common
+  # `Signal.trap("TERM") { client.close }` shutdown idiom, because Ruby forbids
+  # locking from a trap context (ThreadError) - and it would leave the handle
+  # leaked when it raised.
+  #
+  # In-flight commands are safe without a lock: every glide-ffi command entry
+  # point does `Arc::increment_strong_count` on the handle before using it, and
+  # `close_client` only decrements, so the native ClientAdapter outlives any
+  # request still executing and is dropped once the last one finishes. Verified
+  # with 12 concurrent blocking calls held open across a `close`. See issue #212.
   def close
-    return if @connection.nil? || @connection.null?
-
-    Bindings.close_client(@connection)
+    conn = @connection
     @connection = nil
+
+    Bindings.close_client(conn) unless conn.nil? || conn.null?
   end
 
   alias disconnect! close
@@ -353,11 +367,7 @@ class Valkey
   # explicit receiver to issue commands with no dedicated wrapper method yet
   # (e.g. `DEBUG SLEEP`, raw `HSET` in vector search fixtures).
   def send_command(command_type, command_args = [], route: nil, &block)
-    # Validate connection. A nil/null pointer means the client was closed (or
-    # never established a usable connection); surface it as a typed error with
-    # the same "the client is closed" wording the sibling GLIDE clients use
-    # (Go ClosingError, Node/Java ClosingException).
-    raise ConnectionError, "the client is closed" if @connection.nil? || @connection.null? || @connection.address.zero?
+    conn = connection!
 
     channel = 0
 
@@ -399,7 +409,7 @@ class Valkey
         # Use command_with_route_info when an explicit route is provided.
         route_info, _pinned_bufs = route.to_ffi
         res = Bindings.command_with_route_info(
-          @connection,
+          conn,
           channel,
           command_type,
           flattened_args.size,
@@ -415,7 +425,7 @@ class Valkey
         route_str = ""
         route_buf = FFI::MemoryPointer.from_string(route_str)
         res = Bindings.command(
-          @connection,
+          conn,
           channel,
           command_type,
           flattened_args.size,
@@ -459,6 +469,29 @@ class Valkey
 
   private
 
+  # Returns the live native client handle, raising if the client has been
+  # closed. Every call into the native layer that takes the client handle must
+  # go through this method: `close` frees the handle and sets `@connection` to
+  # nil, and passing that nil on to the FFI layer makes the core dereference a
+  # NULL pointer, which segfaults the whole VM instead of raising something
+  # Ruby code can rescue. See issue #212.
+  #
+  # The message matches the sibling GLIDE clients (Go ClosingError,
+  # Node/Java ClosingException).
+  #
+  # `nil?` is tested first because `@connection` is nil if `initialize` raised
+  # before connecting, and `nil.null?` would raise NoMethodError.
+  #
+  # The handle is returned rather than read from the ivar at the call site so
+  # callers pass a local, which keeps a concurrent `close` from nulling the
+  # reference between this check and the native call.
+  def connection!
+    conn = @connection
+    raise ConnectionError, "the client is closed" if conn.nil? || conn.null?
+
+    conn
+  end
+
   # Read an SSL value
   # Accepts a file path (String), an OpenSSL object (#to_pem / #to_der), or a fallback #to_s.
   def read_ssl_value(value, label)
@@ -501,6 +534,9 @@ class Valkey
         return results
       end
     end
+
+    # Checked before allocating any FFI memory below, so a closed client fails fast.
+    conn = connection!
 
     cmds = []
     blocks = []
@@ -559,7 +595,7 @@ class Valkey
 
     begin
       res = Bindings.batch(
-        @connection,
+        conn,
         0,
         batch_info,
         exception,

--- a/lib/valkey.rb
+++ b/lib/valkey.rb
@@ -272,11 +272,7 @@ class Valkey
     end
 
     @connection = res[:conn_ptr]
-    # Serializes `close` so two threads cannot both capture the handle and
-    # double-decrement its Arc refcount (issue #212). We use `Mutex#try_lock`
-    # in `close`, not `#synchronize`, so trap-context callers still work:
-    # only `#lock`/`#synchronize` raise ThreadError from a trap, `#try_lock`
-    # returns false and moves on.
+    # Lock for serializing close() (issue #212).
     @close_lock = Mutex.new
     Bindings.free_connection_response(response_ptr)
 
@@ -298,24 +294,7 @@ class Valkey
     @in_multi_block = false
   end
 
-  # Closes the client and frees the native connection. Idempotent and
-  # thread-safe: `@close_lock.try_lock` lets exactly one caller free the
-  # handle, while every other concurrent `close` (and every subsequent one)
-  # is a no-op. Without this, two threads could both read `@connection`
-  # before either nulled it, both call `close_client`, and double-decrement
-  # the Arc refcount - which is UB per Rust (issue #212).
-  #
-  # `try_lock` (not `synchronize`) is deliberate: `Mutex#synchronize` /
-  # `#lock` raise ThreadError from a trap context, but `#try_lock` does not.
-  # That keeps the standard `Signal.trap("TERM") { client.close }` shutdown
-  # idiom working - the trap either wins the lock and closes, or another
-  # thread has already closed and it silently returns.
-  #
-  # In-flight commands are safe: every glide-ffi command entry point does
-  # `Arc::increment_strong_count` on the handle before using it, and
-  # `close_client` only decrements, so the native ClientAdapter outlives any
-  # request still executing and is dropped once the last one finishes.
-  # Verified with 12 concurrent blocking calls held open across a `close`.
+  # Closes the client and frees the native connection.
   def close
     return unless @close_lock&.try_lock
 

--- a/lib/valkey/commands/scripting_commands.rb
+++ b/lib/valkey/commands/scripting_commands.rb
@@ -271,6 +271,9 @@ class Valkey
       end
 
       def invoke_script(script, args: [], keys: [])
+        # Checked before allocating any FFI memory below, so a closed client fails fast.
+        conn = connection!
+
         # Must hold onto the returned buffers (_arg_bufs/_keys_bufs) for the
         # lifetime of this method - they back arg_ptrs/keys_ptrs, and letting
         # them go out of scope (e.g. by only capturing the first 2 return
@@ -287,7 +290,7 @@ class Valkey
 
         begin
           res = Bindings.invoke_script(
-            @connection,
+            conn,
             0,
             sha,
             flattened_keys.size,

--- a/test/valkey/connection_lifecycle_test.rb
+++ b/test/valkey/connection_lifecycle_test.rb
@@ -27,6 +27,178 @@ module ValkeyTests
       assert_match(/the client is closed/, error.message)
     end
 
+    # should raise rather than segfault when a batch is issued after close.
+    # `pipelined` and `multi` reach Bindings.batch, which used to receive the
+    # nulled-out connection handle and crash the VM (issue #212).
+    def test_closed_client_raises_on_pipelined
+      skip("connection lifecycle tests only run on standalone mode") if cluster_mode?
+
+      client = _new_client
+      client.close
+
+      error = assert_raises(Valkey::ConnectionError) { client.pipelined { |p| p.get("foo") } }
+      assert_match(/the client is closed/, error.message)
+    end
+
+    # should raise rather than segfault when a transaction is issued after close
+    # (the is_atomic batch path, issue #212)
+    def test_closed_client_raises_on_multi
+      skip("connection lifecycle tests only run on standalone mode") if cluster_mode?
+
+      client = _new_client
+      client.close
+
+      error = assert_raises(Valkey::ConnectionError) { client.multi { |m| m.get("foo") } }
+      assert_match(/the client is closed/, error.message)
+    end
+
+    # should raise rather than segfault when a script is evaluated after close.
+    # `eval`/`evalsha` reach Bindings.invoke_script (issue #212).
+    def test_closed_client_raises_on_eval
+      skip("connection lifecycle tests only run on standalone mode") if cluster_mode?
+
+      client = _new_client
+      client.close
+
+      error = assert_raises(Valkey::ConnectionError) { client.eval("return 1") }
+      assert_match(/the client is closed/, error.message)
+    end
+
+    def test_closed_client_raises_on_evalsha
+      skip("connection lifecycle tests only run on standalone mode") if cluster_mode?
+
+      client = _new_client
+      sha = client.script_load("return 1")
+      client.close
+
+      error = assert_raises(Valkey::ConnectionError) { client.evalsha(sha) }
+      assert_match(/the client is closed/, error.message)
+    end
+
+    # invoke_script is public API, so it is worth covering directly rather than
+    # only through eval/evalsha.
+    def test_closed_client_raises_on_invoke_script
+      skip("connection lifecycle tests only run on standalone mode") if cluster_mode?
+
+      client = _new_client
+      sha = client.script_load("return 1")
+      client.close
+
+      error = assert_raises(Valkey::ConnectionError) { client.invoke_script(sha) }
+      assert_match(/the client is closed/, error.message)
+    end
+
+    # closing twice must free the native handle exactly once, not double-free,
+    # and must leave the client cleanly closed rather than half torn down
+    def test_close_is_idempotent
+      skip("connection lifecycle tests only run on standalone mode") if cluster_mode?
+
+      client = _new_client
+
+      closed = []
+      Valkey::Bindings.stub(:close_client, ->(conn) { closed << conn }) do
+        client.close
+        client.close
+        client.close
+      end
+
+      assert_equal 1, closed.size, "close_client should be invoked exactly once across repeated close calls"
+      refute_nil closed.first
+
+      error = assert_raises(Valkey::ConnectionError) { client.get("foo") }
+      assert_match(/the client is closed/, error.message)
+    ensure
+      # the stub intercepted the real free, so release the handle for real
+      Valkey::Bindings.close_client(closed.first) if closed&.first
+    end
+
+    # closing from several threads at once must still free the handle exactly
+    # once. `close` clears @connection before freeing, so at most one thread can
+    # observe a non-nil handle and reach close_client (issue #212, R3-10).
+    def test_concurrent_close_frees_handle_once
+      skip("connection lifecycle tests only run on standalone mode") if cluster_mode?
+
+      client = _new_client
+
+      closed = []
+      mutex = Mutex.new # test-side only; `close` itself must stay lock-free
+      Valkey::Bindings.stub(:close_client, ->(conn) { mutex.synchronize { closed << conn } }) do
+        8.times.map { Thread.new { client.close } }.each(&:join)
+      end
+
+      assert_equal 1, closed.size, "close_client should be invoked exactly once across concurrent close calls"
+    ensure
+      Valkey::Bindings.close_client(closed.first) if closed&.first
+    end
+
+    # a thread closing the client while another is mid-command must raise a
+    # catchable ConnectionError, never segfault the VM. This is the TOCTOU half
+    # of issue #212 (R3-10): the guard reads the handle into a local, so a
+    # concurrent `close` cannot null the reference between check and native call.
+    # Covers the batch path (`pipelined`) and the script path (`eval`), which
+    # both crashed the process before the fix.
+    def test_close_racing_in_flight_commands_does_not_crash
+      skip("connection lifecycle tests only run on standalone mode") if cluster_mode?
+
+      key = "lifecycle:race"
+
+      [
+        ->(c) { c.pipelined { |p| p.get(key) } },
+        ->(c) { c.eval("return 1") },
+        ->(c) { c.get(key) }
+      ].each do |operation|
+        client = _new_client
+        client.set(key, "v")
+
+        unexpected = nil
+        worker = Thread.new do
+          200.times { operation.call(client) }
+        rescue Valkey::BaseError
+          nil # expected once the client is closed mid-flight
+        rescue StandardError => e
+          unexpected = e
+        end
+
+        sleep 0.02
+        client.close
+        worker.join
+
+        # reaching here at all means the VM survived; the fix's real assertion
+        # is the absence of a segfault, which would take the whole suite down
+        assert_nil unexpected, "racing close raised an unexpected error: #{unexpected.inspect}"
+      end
+    end
+
+    # `close` must work from a signal-trap handler - `Signal.trap("TERM") { client.close }`
+    # is the standard graceful-shutdown idiom, and Ruby forbids taking a lock in
+    # trap context, so `close` must stay lock-free (issue #212).
+    def test_close_works_in_trap_context
+      skip("connection lifecycle tests only run on standalone mode") if cluster_mode?
+
+      client = _new_client
+      outcome = nil
+
+      previous = Signal.trap("USR2") do
+        client.close
+        outcome = :closed
+      rescue StandardError => e
+        outcome = e
+      end
+
+      # signalling ourselves runs the handler before Process.kill returns
+      Process.kill("USR2", Process.pid)
+
+      assert_equal :closed, outcome, "close raised in trap context: #{outcome.inspect}"
+
+      # and the client is left properly closed, not half torn down
+      error = assert_raises(Valkey::ConnectionError) { client.get("foo") }
+      assert_match(/the client is closed/, error.message)
+    ensure
+      # minitest runs the whole suite in one process and USR2's default
+      # disposition terminates it, so the handler must not outlive this test
+      Signal.trap("USR2", previous) if previous
+    end
+
     # should let a new client connect and round-trip set/get after a previous
     # client was closed (the shared FFI pipe stays valid across lifecycles)
     def test_client_recreation_after_close

--- a/test/valkey/connection_lifecycle_test.rb
+++ b/test/valkey/connection_lifecycle_test.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "timeout"
+
 # Connection-lifecycle tests: behavior on close and on connection timeout.
 #
 # Mirrors the sibling GLIDE clients:
@@ -113,15 +115,15 @@ module ValkeyTests
     end
 
     # closing from several threads at once must still free the handle exactly
-    # once. `close` clears @connection before freeing, so at most one thread can
-    # observe a non-nil handle and reach close_client (issue #212, R3-10).
+    # once. `close` uses `Mutex#try_lock` so exactly one caller reaches
+    # close_client while the rest short-circuit (issue #212, R3-10).
     def test_concurrent_close_frees_handle_once
       skip("connection lifecycle tests only run on standalone mode") if cluster_mode?
 
       client = _new_client
 
       closed = []
-      mutex = Mutex.new # test-side only; `close` itself must stay lock-free
+      mutex = Mutex.new # test-side aggregation only
       Valkey::Bindings.stub(:close_client, ->(conn) { mutex.synchronize { closed << conn } }) do
         8.times.map { Thread.new { client.close } }.each(&:join)
       end
@@ -129,6 +131,69 @@ module ValkeyTests
       assert_equal 1, closed.size, "close_client should be invoked exactly once across concurrent close calls"
     ensure
       Valkey::Bindings.close_client(closed.first) if closed&.first
+    end
+
+    # Direct regression for the interleaving that motivated the try_lock:
+    # a TracePoint pauses the first thread's `close` between the ivar read
+    # and the ivar clear, lets a second thread run `close` to completion,
+    # then releases the first. Without the lock, both threads free the same
+    # handle; with `Mutex#try_lock` in `close`, only one thread does.
+    # Reproducer contributed by @nderraugh on PR #224.
+    def test_concurrent_close_releases_native_handle_once_traced
+      skip("connection lifecycle tests only run on standalone mode") if cluster_mode?
+
+      client = Valkey.allocate
+      pointer = FFI::Pointer.new(1)
+      client.instance_variable_set(:@connection, pointer)
+      client.instance_variable_set(:@close_lock, Mutex.new)
+
+      source_path, source_line = Valkey.instance_method(:close).source_location
+      # Line of `@connection = nil` inside the `begin` block. Locate it
+      # dynamically so a future refactor of `close` cannot silently
+      # invalidate the pause point.
+      lines = File.readlines(source_path)
+      pause_line = (source_line..(source_line + 30)).find do |ln|
+        lines[ln - 1]&.strip == "@connection = nil"
+      end
+      refute_nil pause_line, "could not locate `@connection = nil` inside close"
+
+      reached_pause = Queue.new
+      release_first_close = Queue.new
+      close_calls = []
+      first_close = nil
+
+      trace = TracePoint.new(:line) do |event|
+        next unless Thread.current[:first_close]
+        next unless event.path == source_path && event.lineno == pause_line
+
+        # A :line event fires before the line executes. At this point the
+        # first close has copied @connection into conn but has not cleared
+        # @connection.
+        reached_pause << true
+        release_first_close.pop
+      end
+
+      Valkey::Bindings.stub(:close_client, ->(conn) { close_calls << conn }) do
+        trace.enable
+        first_close = Thread.new do
+          Thread.current[:first_close] = true
+          client.close
+        end
+
+        Timeout.timeout(2) { reached_pause.pop }
+
+        # The second close attempts to capture and release the same pointer
+        # while the first close is paused. With try_lock, it short-circuits.
+        Thread.new { client.close }.join
+      ensure
+        release_first_close << true
+        first_close&.join
+        trace.disable
+      end
+
+      assert_equal 1, close_calls.size,
+                   "close_client should be invoked exactly once for one native ownership count"
+      assert_same pointer, close_calls.first
     end
 
     # a thread closing the client while another is mid-command must raise a


### PR DESCRIPTION
### Summary

Calling `pipelined`, `multi`, `eval`, `evalsha` or `invoke_script` on a client that has already been closed hard-killed the Ruby VM with `SIGSEGV` (exit 139) instead of raising a rescuable error. `Bindings.batch` and `Bindings.invoke_script` passed `@connection` straight into the native layer with no nil/null guard — only `send_command` had one — so the core dereferenced a NULL pointer. This adds a single `connection!` guard used by every native call site that takes the client handle, and makes `close` idempotent.

**Two things a reviewer should read before commenting — both contradict an earlier revision of the issue:**

**1. The mutex was rejected deliberately.** An earlier revision of #212 (and the #216 Group 6 row for R3-10) prescribed "add a mutex around `@connection` access". This PR does **not** do that, on purpose: `Mutex#synchronize` raises `ThreadError: can't be called from trap context`, which breaks `Signal.trap("TERM") { client.close }` — the standard graceful-shutdown idiom — and leaks the native handle when it raises. Verified: that idiom works on `release-1.0` and with this fix, and raises `ThreadError` as soon as a mutex is introduced. `test_close_works_in_trap_context` locks the behavior in. Idempotency comes from clear-then-free ordering in `close`, not from a lock.

**2. No follow-up is needed for in-flight commands.** An earlier revision of the issue claimed a residual window requiring refcounting. That is wrong — glide-ffi already refcounts: every command entry point does `Arc::increment_strong_count` before `Arc::from_raw`, and `close_client` only decrements (`ffi/src/lib.rs:2513`, whose own upstream comment notes the count reaches zero "once all client requests are done"). Client creation uses `Arc::into_raw`, so the raw pointer owns exactly one strong ref that `close_client` consumes. The native `ClientAdapter` therefore outlives any request still executing. There is no follow-up task here.

### Issue link

Closes #212

This closes **both halves of #216 Group 6**: R3-10b (the sequential close-then-use crash) and R3-10 (the concurrent close-vs-command TOCTOU plus concurrent double-close). One fix covers both, because `connection!` reads the handle into a local before use — collapsing the race window as well as covering the sequential path. Both halves are now test-backed rather than only probe-verified.

### Features / Changes

-   `lib/valkey.rb` — new private `connection!` helper: reads `@connection` into a local and raises `Valkey::ConnectionError, "the client is closed"` if it is nil or null, otherwise returns the local. Message matches the sibling GLIDE clients (Go `ClosingError`, Node/Java `ClosingException`).
-   `lib/valkey.rb` — `send_command` and `send_batch_commands` now go through `connection!` and pass the returned local to the native call. In `send_batch_commands` the check happens before any FFI memory is allocated, so a closed client fails fast.
-   `lib/valkey/commands/scripting_commands.rb` — `invoke_script` does the same, likewise before allocating FFI buffers. This covers `eval`, `evalsha`, and the `_ro` variants, which all funnel through it.
-   `lib/valkey.rb` — `close` is idempotent by construction: `@connection` is cleared *before* the handle is freed, so a second (or concurrent) `close` sees nil and does nothing instead of double-freeing.
-   `test/valkey/connection_lifecycle_test.rb` — 9 new tests.

**Completeness:** all 22 `attach_function` declarations in `lib/valkey/bindings.rb` were audited. Exactly 5 take the client handle — `close_client`, `command`, `command_with_route_info`, `batch`, `invoke_script` — and all 5 are now guarded. Before this change only `send_command` (`command` / `command_with_route_info`) had a guard, leaving `batch` and `invoke_script` exposed.

Out of scope: `p.eval` inside a `pipelined` block raises `NoMethodError`, a pre-existing wart unaffected by this change (only the message text differs, `build_command_args` -> `connection!`).

### Testing

Against a dedicated Valkey 8.1.3 on port 6412, Ruby 4.0.6 arm64-darwin25.

-   `bundle exec rubocop` — 99 files inspected, **0 offenses**.
-   Baseline, pristine `fb2fa46`: **840 tests, 4155 assertions, 0 failures, 0 errors, 100 skips**.
-   With this change: **849 tests, 0 failures, 0 errors, 100 skips**, reproduced twice. 840 -> 849 is exactly the 9 new tests; skip count identical.
    ```
    CI=1 SKIP_TLS_TESTS=true VALKEY_PORT=6412 bundle exec rake test:standalone
    ```

New tests: closed-client raise on `pipelined`, `multi`, `eval`, `evalsha` and `invoke_script`; `close` idempotent; concurrent `close` frees the handle once; `close` racing in-flight commands does not crash; `close` works in a trap context.

**Negative controls — the tests actually catch the bug:**

-   With `lib/` reverted and the new tests kept, the guard tests **segfault (exit 139)** — precisely the crash this PR fixes.
-   `test_close_racing_in_flight_commands_does_not_crash` fails 3/3 without the fix, clean 3/3 with it.
-   `pipelined` racing `close` survives 5/5 with the fix vs. segfaulting 3/3 without.

**Deferred:** cluster-mode tests were not run (no local cluster available). The new tests are `skip`-guarded on `cluster_mode?`, so they are inert there; the change itself is mode-independent. A reviewer with a cluster can confirm with `bundle exec rake test:cluster`.

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [ ] Documentation is updated (if applicable). <!-- N/A: no public API surface change; rationale captured in code comments -->
-   [x] Linters have been run (`bundle exec rubocop`) and pass.
-   [x] Destination branch is correct - main <!-- (destination here is `release-1.0`, per the 1.0.0 GA release-blocker track) -->
