### PR TITLE
fix: dispatch `slowlog` subcommands to their RequestType constants

### DIFF
--- a/lib/valkey/commands/server_commands.rb
+++ b/lib/valkey/commands/server_commands.rb
@@ -216,13 +216,30 @@ class Valkey
 
       # Interact with the slowlog (get, len, reset)
       #
-      # @param [String] subcommand e.g. `get`, `len`, `reset`
-      # @param [Integer] length maximum number of entries to return
-      # @return [Array<String>, Integer, String] depends on subcommand
+      # @example Get the number of entries in the slowlog
+      #   valkey.slowlog(:len) # => 0
+      # @example Get the most recent entries
+      #   valkey.slowlog(:get, 2)
+      #
+      # @param [String, Symbol] subcommand one of `get`, `len`, `reset`
+      # @param [Integer] length maximum number of entries to return (`get` only)
+      # @return [Array<Array>, Integer, String] depends on subcommand
+      # @raise [ArgumentError] if the subcommand is not one of `get`, `len`, `reset`
+      #
+      # @see https://valkey.io/commands/slowlog/
       def slowlog(subcommand, length = nil)
-        args = [:slowlog, subcommand]
-        args << Integer(length) if length
-        send_command(args)
+        case subcommand.to_s.downcase
+        when "get"
+          args = []
+          args << Integer(length) if length
+          send_command(RequestType::SLOWLOG_GET, args)
+        when "len"
+          send_command(RequestType::SLOWLOG_LEN)
+        when "reset"
+          send_command(RequestType::SLOWLOG_RESET)
+        else
+          raise ArgumentError, "Unknown SLOWLOG subcommand: #{subcommand}"
+        end
       end
 
       # Internal command used for replication.

--- a/test/lint/server_commands.rb
+++ b/test/lint/server_commands.rb
@@ -64,6 +64,79 @@ module Lint
       assert_equal "OK", response
     end
 
+    def test_slowlog_len
+      skip("SLOWLOG is a per-node command and returns a multi-node response in cluster mode") if cluster_mode?
+
+      assert_kind_of Integer, r.slowlog(:len)
+    end
+
+    def test_slowlog_get
+      skip("SLOWLOG is a per-node command and returns a multi-node response in cluster mode") if cluster_mode?
+
+      assert_kind_of Array, r.slowlog(:get)
+    end
+
+    def test_slowlog_get_with_length
+      skip("SLOWLOG is a per-node command and returns a multi-node response in cluster mode") if cluster_mode?
+
+      assert_kind_of Array, r.slowlog(:get, 2)
+    end
+
+    def test_slowlog_reset
+      skip("SLOWLOG is a per-node command and returns a multi-node response in cluster mode") if cluster_mode?
+
+      assert_equal "OK", r.slowlog(:reset)
+    end
+
+    # Both spellings must dispatch. Asserted against invariant results rather than
+    # by comparing two LEN calls, whose values can legitimately differ if the
+    # slowlog threshold is low enough for the first call to log itself.
+    def test_slowlog_accepts_string_and_symbol_subcommands
+      skip("SLOWLOG is a per-node command and returns a multi-node response in cluster mode") if cluster_mode?
+
+      assert_equal "OK", r.slowlog(:reset)
+      assert_equal "OK", r.slowlog("RESET")
+      assert_kind_of Integer, r.slowlog(:len)
+      assert_kind_of Integer, r.slowlog("LEN")
+    end
+
+    # Exercises the full round trip: that GET actually returns logged entries and
+    # that `length` is passed through as a command argument rather than dropped.
+    def test_slowlog_get_returns_entries_and_honours_length
+      skip("SLOWLOG is a per-node command and returns a multi-node response in cluster mode") if cluster_mode?
+
+      # Fall back to the server default rather than skipping the restore, so a
+      # surprising CONFIG GET shape can never leave this shared server logging
+      # every command for the remainder of the run.
+      original = r.config_get("slowlog-log-slower-than")["slowlog-log-slower-than"] || "10000"
+      mutated = true
+      r.config_set("slowlog-log-slower-than", "0") # log every command
+      r.slowlog(:reset)
+      r.ping
+
+      entries = r.slowlog(:get)
+      refute_empty entries
+      assert_kind_of Array, entries.first
+      assert_equal 1, r.slowlog(:get, 1).length
+    ensure
+      if mutated
+        r.config_set("slowlog-log-slower-than", original)
+        r.slowlog(:reset)
+      end
+    end
+
+    def test_slowlog_unknown_subcommand_raises_argument_error
+      error = assert_raises(ArgumentError) { r.slowlog(:nope) }
+      assert_match(/Unknown SLOWLOG subcommand/, error.message)
+    end
+
+    # SLOWLOG HELP has no RequestType constant, so it is rejected explicitly
+    # rather than surfacing as a confusing TypeError. Use `call("SLOWLOG", "HELP")`
+    # if the raw help text is needed.
+    def test_slowlog_help_raises_argument_error
+      assert_raises(ArgumentError) { r.slowlog(:help) }
+    end
+
     def test_sync
       skip("SYNC command not implemented in backend yet")
 

--- a/test/lint/server_commands.rb
+++ b/test/lint/server_commands.rb
@@ -98,6 +98,8 @@ module Lint
       assert_equal "OK", r.slowlog("RESET")
       assert_kind_of Integer, r.slowlog(:len)
       assert_kind_of Integer, r.slowlog("LEN")
+      assert_kind_of Array, r.slowlog(:get)
+      assert_kind_of Array, r.slowlog("GET")
     end
 
     # Exercises the full round trip: that GET actually returns logged entries and


### PR DESCRIPTION
### Summary

`Valkey#slowlog` has never worked. It built a redis-rb-style argument array (`[:slowlog, subcommand]`) and passed it as the **first** argument to `send_command`, whose first parameter is the numeric `command_type` slot — the FFI `attach_function :command` declares it `:int`. Every call raised `TypeError: no implicit conversion of Array into Integer`. This PR dispatches each subcommand to its own `RequestType` constant (`SLOWLOG_GET` / `SLOWLOG_LEN` / `SLOWLOG_RESET`) and rejects unknown subcommands with a clear `ArgumentError`.

### Issue link

Closes #215

### Features / Changes

**`lib/valkey/commands/server_commands.rb`** — rewrote `slowlog` to normalize the subcommand with `to_s.downcase` and `case`-dispatch to the right `RequestType`; `length` is forwarded as a command argument for `get`. Unknown subcommands raise `ArgumentError`. YARD docs on the method were expanded (params, `@raise`, `@example`, `@see`).

**`test/lint/server_commands.rb`** — 8 new tests covering all three subcommands, string/symbol/mixed-case spellings, `length` pass-through, and the `ArgumentError` paths.

#### Provenance

Broken **since the initial import `b222363`** ("add all files") — `send_command`'s first parameter was already the numeric `command_type` slot at that commit, so this method never worked at any point in history. It was then **missed by #38 (`6d9751f`, "server commands - time")**, which converted this file to numeric dispatch: that commit rewrote `slaveof` immediately above and converted `sync`/`save`/`lastsave`/`bgsave`/`bgrewriteaof`/`time` below, leaving only the `slowlog` hunk in between untouched. #38 should have fixed it and didn't. `git log -L` on the method body shows `b222363` and nothing else.

> **Retraction:** the issue originally attributed this to #23 (`4dcd95d`). That is incorrect — `4dcd95d` is a pure rename (`server.rb` → `server_commands.rb`, `module Server` → `module ServerCommands`) at 97% similarity with no logic change.

#### ⚠️ This reverses a written reviewer preference — please confirm

Issue #216 Group 5, row R3-3a records verbatim: *"Reviewer preference: **remove from GA** (no other GLIDE binding exposes it)."* That text is live in #216 today. This PR **fixes the dispatch instead of removing the command**, for these reasons:

- **Fixing is non-breaking; removal deletes a documented public API.** `slowlog` is a shipped, documented method.
- **redis-rb exposes `slowlog`.** Removing it widens the very parity gap the README advertises at line 3 ("an interface similar to redis-rb") and line 12 ("**Drop-in Replacement**: Familiar redis-rb-style API"). `CLAUDE.md` also mandates matching redis-rb conventions.
- **The premise argues the wrong axis.** "No other GLIDE binding exposes it" is an argument for parity with other *bindings*; this gem's stated contract is parity with *redis-rb*.

If maintainers still prefer removal for 1.0.0 GA, say so and I'll close this in favour of a removal PR.

#### ⚠️ Deliberate narrowing: `slowlog(:help)` now raises `ArgumentError`

There is no `SLOWLOG_HELP` `RequestType`, so `:help` surfaces a clear `ArgumentError` instead of today's misleading `TypeError`. `call("SLOWLOG", "HELP")` remains available and is verified working. This diverges from redis-rb's verbatim passthrough, so it is an explicit reviewer decision point rather than an oversight.

#### Design notes (for reviewers comparing against the issue's suggested code)

- **Inline `case`, not a frozen `Hash` + `private_constant`.** The issue suggested the latter. I used an inline `case` to match `xinfo` (`lib/valkey/commands/stream_commands.rb:541`) and `xgroup` (`:261`) — the repo's only comparable subcommand dispatchers — including identical error-message wording, making it 3-of-3. `private_constant` appears nowhere in `lib/valkey/commands/`.
- **No `route:` kwarg, deliberately.** SLOWLOG is per-node and 14 neighbouring admin commands do take `route:`, but `Valkey::Pipeline#send_command` accepts no `route:` — so all 14 (`bgrewriteaof`, `bgsave`, `config_get`/`config_set`/`config_resetstat`/`config_rewrite`, `dbsize`, `flushall`, `flushdb`, `info`, `lastsave`, `save`, `time`, `lolwut`) **already** raise `ArgumentError: wrong number of arguments` inside `pipelined` on the unmodified baseline — verified. Route-free `slowlog` works in `pipelined` today (`pipelined { |p| p.slowlog(:len); p.slowlog(:get) }` → `[0, []]`). Adding `route:` would inherit that latent breakage. **A separate issue is warranted for the pipeline/`route:` defect** (not filed as part of this PR).
- **Cluster-mode skips are intentional.** SLOWLOG is per-node and may return a per-node Hash in cluster mode (unverified — no local cluster available). The 6 wire-touching tests carry `skip(...) if cluster_mode?`. The 2 `ArgumentError` tests deliberately run in **both** modes, since they raise before any `send_command` — giving real cluster coverage of the validation path.
- **Two known warts left as-is for consistency with `xinfo`/`xgroup`:** `length` is silently dropped for `:len`, and `slowlog(nil)` produces an empty-subcommand message.

### Testing

**Lint** — `bundle exec rubocop lib/valkey/commands/server_commands.rb test/lint/server_commands.rb` → **2 files inspected, 0 offenses**.

**Standalone suite** — `CI=1 SKIP_TLS_TESTS=true VALKEY_PORT=6415 bundle exec rake test:standalone` against a dedicated Valkey 8.1.3 on port 6415:

| | tests | assertions | failures | errors | skips |
|---|---|---|---|---|---|
| Baseline (pristine `fb2fa46`) | 840 | 4167 | 0 | 0 | 100 |
| With this fix | 848 | 4189 | 0 | 0 | 100 |

Exactly +8 tests, no regressions.

**Bisect proof the tests actually pin the fix** — reverting only `lib/valkey/commands/server_commands.rb` while keeping the new tests gives `8 tests, 2 assertions, 2 failures, 6 errors`; the errors are `TypeError: no implicit conversion of Array into Integer` at `server_commands.rb:225` — the exact symptom reported in #215. With the fix applied: `8 tests, 16 assertions, 0 failures, 0 errors`.

**Behavioural coverage verified** — `:len`, `"len"`, `"LEN"`, `:get`, `"GET"`, `:get, 2`, `:reset`, `"RESET"`, and mixed-case `:Get` all dispatch correctly; `:nope`, `:help`, and `nil` all raise `ArgumentError`.

**Deferred** — cluster-mode run, no local cluster available: `bundle exec rake test:cluster`.

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] Documentation is updated (if applicable). <sub>(YARD docs on `slowlog` expanded — params, `@raise`, `@example`, `@see`. No prose docs needed.)</sub>
-   [x] Linters have been run (`bundle exec rubocop`) and pass.
-   [x] Destination branch is correct - main <sub>(destination is `release-1.0` per the 1.0.0 GA release-blocker track, matching #207, #205, #203, #202, #201, #198, #197, #196, #195.)</sub>
