### PR TITLE
fix: send real SCRIPT LOAD/EVAL/EVALSHA instead of the local cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,5 +9,9 @@
 ### Changes
 
 * Ruby: fixed cd workflow to correctly build the ffi with **glibc 2.17** ([#223](https://github.com/valkey-io/valkey-glide-ruby/issues/223))
+* Ruby: **Breaking** — scripting commands now dispatch real `EVAL` / `EVALSHA` / `SCRIPT LOAD` to the server instead of a client-side script container ([#213](https://github.com/valkey-io/valkey-glide-ruby/issues/213)). Three consequences:
+  * `eval` / `evalsha` (and the `_ro` variants) now accept the standard integer key-count form used by `valkey-cli` and the Valkey docs — `eval(script, 1, "mykey", "myarg")`. It previously made the count `KEYS[1]`, shifted the real key into `ARGV[1]`, and dropped the remaining arguments without raising.
+  * `script_load` now really sends `SCRIPT LOAD`, so the returned SHA1 is known to the server and usable by `evalsha` from any other client or process. `script_exists` previously reported `false` for a just-loaded script.
+  * `evalsha` on a flushed or never-loaded SHA now raises `Valkey::CommandError` (NOSCRIPT) instead of silently re-uploading the script and succeeding, so `script_flush` is no longer quietly undone. Callers relying on the old auto-reload must load the script again after a flush, or use `eval`.
 * Ruby: Add Alpine Linux (musl libc) support for x86_64 and aarch64 — runtime detection of musl libc, CI/CD pipeline for native builds, and prebuilt `libglide_ffi.so` for musl targets ([#143](https://github.com/valkey-io/valkey-glide-ruby/pull/143))
 * Ruby: Add distributed tracing support — `Valkey::OpenTelemetry.set_parent_span_context_provider` (and `init(parent_span_context_provider:)`) let an app propagate its current W3C trace context into command/pipeline spans, so they become children of the app's trace instead of independent root spans, matching the Node.js client's `parentSpanContextProvider` behavior.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Changes
 
 * Ruby: fixed cd workflow to correctly build the ffi with **glibc 2.17** ([#223](https://github.com/valkey-io/valkey-glide-ruby/issues/223))
-* Ruby: **Breaking** — scripting commands now dispatch real `EVAL` / `EVALSHA` / `SCRIPT LOAD` to the server instead of a client-side script container ([#213](https://github.com/valkey-io/valkey-glide-ruby/issues/213)). Three consequences:
+* Ruby: scripting commands now dispatch real `EVAL` / `EVALSHA` / `SCRIPT LOAD` to the server instead of a client-side script container ([#213](https://github.com/valkey-io/valkey-glide-ruby/issues/213)). Three behavior changes:
   * `eval` / `evalsha` (and the `_ro` variants) now accept the standard integer key-count form used by `valkey-cli` and the Valkey docs — `eval(script, 1, "mykey", "myarg")`. It previously made the count `KEYS[1]`, shifted the real key into `ARGV[1]`, and dropped the remaining arguments without raising.
   * `script_load` now really sends `SCRIPT LOAD`, so the returned SHA1 is known to the server and usable by `evalsha` from any other client or process. `script_exists` previously reported `false` for a just-loaded script.
   * `evalsha` on a flushed or never-loaded SHA now raises `Valkey::CommandError` (NOSCRIPT) instead of silently re-uploading the script and succeeding, so `script_flush` is no longer quietly undone. Callers relying on the old auto-reload must load the script again after a flush, or use `eval`.

--- a/lib/valkey/commands/scripting_commands.rb
+++ b/lib/valkey/commands/scripting_commands.rb
@@ -4,6 +4,18 @@ class Valkey
   module Commands
     # this module contains commands related to list data type.
     #
+    # EVAL / EVALSHA / SCRIPT LOAD are dispatched as custom commands via #call
+    # rather than through typed `send_command(RequestType::EVAL, ...)`. This is
+    # not a style choice: glide-core defines those enum values but has no
+    # `get_command()` arm for them, so typed dispatch fails outright with
+    # "Couldn't fetch command type - ClientError". Cluster routing is unaffected
+    # (redis-rs derives it from the wire command name, so EVAL still routes by
+    # ThirdArgAfterKeyCount and SCRIPT LOAD still broadcasts to all nodes), but
+    # OpenTelemetry spans are named "CustomCommand" instead of the command.
+    # Once glide-core gains those arms, these can revert to typed dispatch -
+    # EVAL_RO / EVALSHA_RO already have arms and could use it today; they go
+    # through #call only to keep the family's behavior uniform.
+    #
     # @see https://valkey.io/commands/#scripting
     #
     module ScriptingCommands
@@ -100,20 +112,31 @@ class Valkey
         send_command(RequestType::SCRIPT_DEBUG, [mode.to_s.upcase])
       end
 
+      # Load a Lua script into the server's script cache without executing it.
+      #
+      # Sends a real `SCRIPT LOAD` to the server, so the returned SHA1 is
+      # immediately usable by `evalsha` - including from a different client,
+      # process, or worker. In cluster mode `SCRIPT LOAD` is routed to all
+      # nodes, so the script is available whichever node a later `EVALSHA`
+      # lands on.
+      #
+      # @param [String] script the Lua script to load
+      # @return [String] the SHA1 hash of the script, as computed by the server
+      #
+      # @example
+      #   sha = valkey.script_load("return 1")
+      #   valkey.script_exists(sha)   # => true
+      #
+      # @see https://valkey.io/commands/script-load/
       def script_load(script)
         script = script.first if script.is_a?(Array)
 
-        buf = FFI::MemoryPointer.new(:char, script.bytesize)
-        buf.put_bytes(0, script)
+        # Validate here rather than letting a non-String flatten into extra
+        # SCRIPT LOAD wire arguments and fail as a server-side arity error.
+        raise ArgumentError, "script must be a string" unless script.is_a?(String)
+        raise ArgumentError, "script cannot be empty" if script.empty?
 
-        result = Bindings.store_script(buf, script.bytesize)
-
-        begin
-          hash_buffer = Bindings::ScriptHashBuffer.new(result)
-          hash_buffer[:ptr].read_string(hash_buffer[:len])
-        ensure
-          Bindings.free_script_hash_buffer(result) if result && !result.null?
-        end
+        call("SCRIPT", "LOAD", script)
       end
 
       # Execute a Lua script on the server.
@@ -140,30 +163,17 @@ class Valkey
       # @example Positional form, matching redis-rb's eval(script, keys, argv)
       #   valkey.eval("return KEYS[1] .. ARGV[1]", ["mykey"], ["myarg"])
       #     # => "mykeynyarg"
-      # Since the eval is not available in the rust backend
-      # using the load and invoke script
+      # @example Integer key-count form, matching valkey-cli and the Valkey docs
+      #   valkey.eval("return {KEYS[1], ARGV[1]}", 1, "mykey", "myarg")
+      #     # => ["mykey", "myarg"]
       def eval(script, *rest, keys: nil, args: nil)
         # Validate script parameter
         raise ArgumentError, "script must be a string" unless script.is_a?(String)
         raise ArgumentError, "script cannot be empty" if script.empty?
 
-        # Accept redis-rb's flexible positional form - eval(script, keys, argv)
-        # - in addition to the keyword form, mirroring the same treatment
-        # applied to evalsha (see that method for the full rationale).
-        keys ||= rest[0] || []
-        args ||= rest[1] || []
+        keys, args = split_keys_and_args(rest, keys, args)
 
-        # Validate and convert keys and args to strings
-        begin
-          keys = Array(keys).map(&:to_s)
-          args = Array(args).map(&:to_s)
-        rescue StandardError => e
-          raise ArgumentError, "failed to convert keys or args to strings: #{e.message}"
-        end
-
-        # Load script to get SHA1 hash, then execute via invoke_script
-        sha = script_load(script)
-        invoke_script(sha, keys: keys, args: args)
+        call("EVAL", script, keys.size, *keys, *args)
       end
 
       # Execute a cached Lua script by its SHA1 hash.
@@ -193,29 +203,17 @@ class Valkey
       # @example Positional form, matching redis-rb's evalsha(sha, keys, argv)
       #   valkey.evalsha(sha, ["user"], ["123"])
       #     # => "user:123"
-      # Since evalsha is not available in rust backend
-      # using invoke script
+      # @example Integer key-count form, matching valkey-cli and the Valkey docs
+      #   valkey.evalsha(sha, 1, "user", "123")
+      #     # => "user:123"
       def evalsha(sha, *rest, keys: nil, args: nil)
         # Validate SHA1 hash parameter
         raise ArgumentError, "sha1 hash must be a string" unless sha.is_a?(String)
         raise ArgumentError, "sha1 hash must be a 40-character hexadecimal string" unless valid_sha1?(sha)
 
-        # Accept redis-rb's flexible positional form - evalsha(sha, keys, argv)
-        # - in addition to the keyword form, so code written against redis-rb's
-        # API (e.g. redis_display_id) doesn't need to special-case this client.
-        keys ||= rest[0] || []
-        args ||= rest[1] || []
+        keys, args = split_keys_and_args(rest, keys, args)
 
-        # Validate and convert keys and args to strings
-        begin
-          keys = Array(keys).map(&:to_s)
-          args = Array(args).map(&:to_s)
-        rescue StandardError => e
-          raise ArgumentError, "failed to convert keys or args to strings: #{e.message}"
-        end
-
-        # Execute cached script via invoke_script
-        invoke_script(sha, keys: keys, args: args)
+        call("EVALSHA", sha, keys.size, *keys, *args)
       end
 
       # Execute a read-only Lua script on the server.
@@ -231,17 +229,18 @@ class Valkey
       # @example Execute a read-only script
       #   valkey.eval_ro("return redis.call('get', KEYS[1])", keys: ["mykey"])
       #     # => "myvalue"
+      # @example Integer key-count form
+      #   valkey.eval_ro("return redis.call('get', KEYS[1])", 1, "mykey")
+      #     # => "myvalue"
       #
       # @see https://valkey.io/commands/eval_ro/
-      def eval_ro(script, keys: [], args: [])
+      def eval_ro(script, *rest, keys: nil, args: nil)
         raise ArgumentError, "script must be a string" unless script.is_a?(String)
         raise ArgumentError, "script cannot be empty" if script.empty?
 
-        keys = Array(keys).map(&:to_s)
-        args = Array(args).map(&:to_s)
+        keys, args = split_keys_and_args(rest, keys, args)
 
-        sha = script_load(script)
-        invoke_script(sha, keys: keys, args: args)
+        call("EVAL_RO", script, keys.size, *keys, *args)
       end
 
       # Execute a cached read-only Lua script by its SHA1 hash.
@@ -258,18 +257,29 @@ class Valkey
       #   sha = valkey.script_load("return redis.call('get', KEYS[1])")
       #   valkey.evalsha_ro(sha, keys: ["mykey"])
       #     # => "myvalue"
+      # @example Integer key-count form
+      #   valkey.evalsha_ro(sha, 1, "mykey")
+      #     # => "myvalue"
       #
       # @see https://valkey.io/commands/evalsha_ro/
-      def evalsha_ro(sha, keys: [], args: [])
+      def evalsha_ro(sha, *rest, keys: nil, args: nil)
         raise ArgumentError, "sha1 hash must be a string" unless sha.is_a?(String)
         raise ArgumentError, "sha1 hash must be a 40-character hexadecimal string" unless valid_sha1?(sha)
 
-        keys = Array(keys).map(&:to_s)
-        args = Array(args).map(&:to_s)
+        keys, args = split_keys_and_args(rest, keys, args)
 
-        invoke_script(sha, keys: keys, args: args)
+        call("EVALSHA_RO", sha, keys.size, *keys, *args)
       end
 
+      # Execute a cached script via the glide-ffi `invoke_script` entry point.
+      #
+      # No longer used by eval/evalsha - they dispatch real wire commands now.
+      # Retained as the FFI seam for the `Script` object proposed in #206, and
+      # still exercised by the scripting tests. Note that its glide-core
+      # NOSCRIPT self-heal relies on the client-side script container that
+      # `script_load` no longer populates, so a SHA this client never stored
+      # will surface a NOSCRIPT CommandError rather than being re-uploaded.
+      # Emits no OpenTelemetry span (span_ptr is hardcoded to 0 below).
       def invoke_script(script, args: [], keys: [])
         # Must hold onto the returned buffers (_arg_bufs/_keys_bufs) for the
         # lifetime of this method - they back arg_ptrs/keys_ptrs, and letting
@@ -308,6 +318,69 @@ class Valkey
       end
 
       private
+
+      # Resolve the KEYS/ARGV split from the three call shapes the scripting
+      # commands accept, and normalize both to Arrays of Strings.
+      #
+      # 1. Integer key-count form, as used by the Valkey docs and valkey-cli:
+      #      eval(script, 1, "mykey", "myarg")
+      # 2. redis-rb's two-array positional form:
+      #      eval(script, ["mykey"], ["myarg"])
+      # 3. Keyword form:
+      #      eval(script, keys: ["mykey"], args: ["myarg"])
+      #
+      # Integer and Array are disjoint in the first positional slot, so
+      # recognizing the integer form is a strict superset - it cannot change
+      # the meaning of any call that already worked. Anything the caller
+      # plainly meant as a key count but that isn't an Integer, and any extra
+      # positional beyond (keys, argv), raises instead of being reinterpreted:
+      # silently proceeding with a different meaning is the defect this fixes.
+      #
+      # @return [Array(Array<String>, Array<String>)] the keys and args
+      def split_keys_and_args(rest, keys, args)
+        if rest.first.is_a?(Integer)
+          if keys || args
+            raise ArgumentError,
+                  "cannot mix the integer key-count form with the keys:/args: keywords"
+          end
+
+          numkeys, *positional = rest
+
+          raise ArgumentError, "numkeys must be non-negative" if numkeys.negative?
+
+          if numkeys > positional.size
+            raise ArgumentError,
+                  "numkeys (#{numkeys}) exceeds the number of arguments given (#{positional.size})"
+          end
+
+          # shift consumes the keys; whatever remains is ARGV
+          keys = positional.shift(numkeys)
+          args = positional
+        else
+          if rest.first.is_a?(Numeric)
+            raise ArgumentError,
+                  "numkeys must be an Integer, got #{rest.first.class} (#{rest.first.inspect})"
+          end
+
+          if rest.size > 2
+            raise ArgumentError,
+                  "wrong number of positional arguments (given #{rest.size}, expected at most 2: keys, argv). " \
+                  "To pass a key count, make it an Integer: eval(script, #{rest.size - 1}, ...)"
+          end
+
+          keys ||= rest[0] || []
+          args ||= rest[1] || []
+        end
+
+        # Stringify before handing off to #call, whose flattening raises
+        # TypeError on non-String/Symbol/Integer/Float leaves. Converting here
+        # preserves the lenient #to_s coercion these commands have always had.
+        begin
+          [Array(keys).map(&:to_s), Array(args).map(&:to_s)]
+        rescue StandardError => e
+          raise ArgumentError, "failed to convert keys or args to strings: #{e.message}"
+        end
+      end
 
       # Validate SHA1 hash format (40-character hexadecimal string)
       def valid_sha1?(sha)

--- a/lib/valkey/commands/scripting_commands.rb
+++ b/lib/valkey/commands/scripting_commands.rb
@@ -4,18 +4,6 @@ class Valkey
   module Commands
     # this module contains commands related to list data type.
     #
-    # EVAL / EVALSHA / SCRIPT LOAD are dispatched as custom commands via #call
-    # rather than through typed `send_command(RequestType::EVAL, ...)`. This is
-    # not a style choice: glide-core defines those enum values but has no
-    # `get_command()` arm for them, so typed dispatch fails outright with
-    # "Couldn't fetch command type - ClientError". Cluster routing is unaffected
-    # (redis-rs derives it from the wire command name, so EVAL still routes by
-    # ThirdArgAfterKeyCount and SCRIPT LOAD still broadcasts to all nodes), but
-    # OpenTelemetry spans are named "CustomCommand" instead of the command.
-    # Once glide-core gains those arms, these can revert to typed dispatch -
-    # EVAL_RO / EVALSHA_RO already have arms and could use it today; they go
-    # through #call only to keep the family's behavior uniform.
-    #
     # @see https://valkey.io/commands/#scripting
     #
     module ScriptingCommands
@@ -271,15 +259,6 @@ class Valkey
         call("EVALSHA_RO", sha, keys.size, *keys, *args)
       end
 
-      # Execute a cached script via the glide-ffi `invoke_script` entry point.
-      #
-      # No longer used by eval/evalsha - they dispatch real wire commands now.
-      # Retained as the FFI seam for the `Script` object proposed in #206, and
-      # still exercised by the scripting tests. Note that its glide-core
-      # NOSCRIPT self-heal relies on the client-side script container that
-      # `script_load` no longer populates, so a SHA this client never stored
-      # will surface a NOSCRIPT CommandError rather than being re-uploaded.
-      # Emits no OpenTelemetry span (span_ptr is hardcoded to 0 below).
       def invoke_script(script, args: [], keys: [])
         # Must hold onto the returned buffers (_arg_bufs/_keys_bufs) for the
         # lifetime of this method - they back arg_ptrs/keys_ptrs, and letting

--- a/lib/valkey/pipeline.rb
+++ b/lib/valkey/pipeline.rb
@@ -14,15 +14,16 @@ class Valkey
       @in_multi = false
     end
 
-    # `route:` is accepted and ignored. Routing is not supported for Pipeline yet.
-    # rubocop:disable Lint/UnusedMethodArgument
-    def send_command(command_type, command_args = [], route: nil, &block)
+    # `route:` is accepted and ignored. It exists for signature parity with
+    # Valkey#send_command, since any command reaching a pipeline through #call
+    # passes it, but a batch is dispatched as one unit so a per-command route
+    # cannot be honored. Batch-level routing is tracked in issue #137.
+    def send_command(command_type, command_args = [], route: nil, &block) # rubocop:disable Lint/UnusedMethodArgument
       @commands << [command_type, command_args, block]
       future = Future.new(command_type, command_args)
       @futures << future
       future
     end
-    # rubocop:enable Lint/UnusedMethodArgument
 
     # @api private - called by Valkey#pipelined / the block form of #multi
     # once send_batch_commands' final results are available. Purely

--- a/test/lint/scripting_commands.rb
+++ b/test/lint/scripting_commands.rb
@@ -175,14 +175,18 @@ module Lint
     # eval_ro tests
 
     def test_eval_ro_basic
-      result = r.eval_ro("return 42")
-      assert_equal 42, result
+      target_version "7.0" do
+        result = r.eval_ro("return 42")
+        assert_equal 42, result
+      end
     end
 
     def test_eval_ro_with_keys_and_args
-      r.set("mykey", "hello")
-      result = r.eval_ro("return redis.call('get', KEYS[1])", keys: ["mykey"])
-      assert_equal "hello", result
+      target_version "7.0" do
+        r.set("mykey", "hello")
+        result = r.eval_ro("return redis.call('get', KEYS[1])", keys: ["mykey"])
+        assert_equal "hello", result
+      end
     end
 
     def test_eval_ro_empty_script
@@ -191,27 +195,33 @@ module Lint
     end
 
     def test_eval_ro_consistency_with_eval
-      script = "return 42"
-      eval_result = r.eval(script)
-      eval_ro_result = r.eval_ro(script)
-      assert_equal eval_result, eval_ro_result
+      target_version "7.0" do
+        script = "return 42"
+        eval_result = r.eval(script)
+        eval_ro_result = r.eval_ro(script)
+        assert_equal eval_result, eval_ro_result
+      end
     end
 
     # evalsha_ro tests
 
     def test_evalsha_ro_basic
-      script = "return 42"
-      sha = r.script_load(script)
-      result = r.evalsha_ro(sha)
-      assert_equal 42, result
+      target_version "7.0" do
+        script = "return 42"
+        sha = r.script_load(script)
+        result = r.evalsha_ro(sha)
+        assert_equal 42, result
+      end
     end
 
     def test_evalsha_ro_with_keys
-      r.set("mykey", "world")
-      script = "return redis.call('get', KEYS[1])"
-      sha = r.script_load(script)
-      result = r.evalsha_ro(sha, keys: ["mykey"])
-      assert_equal "world", result
+      target_version "7.0" do
+        r.set("mykey", "world")
+        script = "return redis.call('get', KEYS[1])"
+        sha = r.script_load(script)
+        result = r.evalsha_ro(sha, keys: ["mykey"])
+        assert_equal "world", result
+      end
     end
 
     def test_evalsha_ro_invalid_sha
@@ -225,11 +235,13 @@ module Lint
     end
 
     def test_evalsha_ro_consistency_with_evalsha
-      script = "return 'hello'"
-      sha = r.script_load(script)
-      evalsha_result = r.evalsha(sha)
-      evalsha_ro_result = r.evalsha_ro(sha)
-      assert_equal evalsha_result, evalsha_ro_result
+      target_version "7.0" do
+        script = "return 'hello'"
+        sha = r.script_load(script)
+        evalsha_result = r.evalsha(sha)
+        evalsha_ro_result = r.evalsha_ro(sha)
+        assert_equal evalsha_result, evalsha_ro_result
+      end
     end
 
     # script_debug tests
@@ -263,9 +275,11 @@ module Lint
       assert_equal ["a1"], r.eval("return {ARGV[1]}", 0, "a1")
     end
 
+    # Both keys must live in one slot: in cluster mode EVAL routes by its keys
+    # and a multi-key script spanning slots is rejected with CROSSSLOT.
     def test_eval_with_integer_numkeys_multiple_keys_and_args
-      assert_equal %w[k1 k2 a1],
-                   r.eval("return {KEYS[1], KEYS[2], ARGV[1]}", 2, "k1", "k2", "a1")
+      assert_equal %w[{1}k1 {1}k2 a1],
+                   r.eval("return {KEYS[1], KEYS[2], ARGV[1]}", 2, "{1}k1", "{1}k2", "a1")
     end
 
     def test_eval_with_numkeys_exceeding_args_raises
@@ -334,14 +348,18 @@ module Lint
     end
 
     def test_eval_ro_with_integer_numkeys
-      assert_equal %w[mykey myarg],
-                   r.eval_ro("return {KEYS[1], ARGV[1]}", 1, "mykey", "myarg")
+      target_version "7.0" do
+        assert_equal %w[mykey myarg],
+                     r.eval_ro("return {KEYS[1], ARGV[1]}", 1, "mykey", "myarg")
+      end
     end
 
     def test_evalsha_ro_with_integer_numkeys
-      sha = r.script_load("return {KEYS[1], ARGV[1]}")
+      target_version "7.0" do
+        sha = r.script_load("return {KEYS[1], ARGV[1]}")
 
-      assert_equal %w[mykey myarg], r.evalsha_ro(sha, 1, "mykey", "myarg")
+        assert_equal %w[mykey myarg], r.evalsha_ro(sha, 1, "mykey", "myarg")
+      end
     end
 
     # the previously-supported forms must keep working unchanged
@@ -397,12 +415,22 @@ module Lint
       results = r.pipelined do |pipeline|
         pipeline.script_load("return 'from-pipeline'")
         pipeline.eval("return {KEYS[1], ARGV[1]}", 1, "pk", "pa")
-        pipeline.eval_ro("return 'ro'", 0)
       end
 
       assert_equal 40, results[0].length
       assert_equal %w[pk pa], results[1]
-      assert_equal "ro", results[2]
+    end
+
+    # split from the test above so the `route:` regression stays covered on
+    # servers predating EVAL_RO (added in 7.0)
+    def test_read_only_scripting_commands_work_inside_a_pipeline
+      target_version "7.0" do
+        results = r.pipelined do |pipeline|
+          pipeline.eval_ro("return 'ro'", 0)
+        end
+
+        assert_equal ["ro"], results
+      end
     end
 
     def test_eval_works_inside_a_transaction

--- a/test/lint/scripting_commands.rb
+++ b/test/lint/scripting_commands.rb
@@ -247,5 +247,203 @@ module Lint
       assert_equal "OK", r.script(:debug, "YES")
       assert_equal "OK", r.script(:debug, "NO")
     end
+
+    # integer key-count form - eval(script, numkeys, *keys, *args)
+    #
+    # This is the form used by the Valkey documentation and valkey-cli. It used
+    # to be misparsed: the count became KEYS[1], the real key shifted into
+    # ARGV[1], and any remaining arguments were dropped, all without raising.
+
+    def test_eval_with_integer_numkeys
+      assert_equal %w[mykey myarg],
+                   r.eval("return {KEYS[1], ARGV[1]}", 1, "mykey", "myarg")
+    end
+
+    def test_eval_with_integer_numkeys_zero
+      assert_equal ["a1"], r.eval("return {ARGV[1]}", 0, "a1")
+    end
+
+    def test_eval_with_integer_numkeys_multiple_keys_and_args
+      assert_equal %w[k1 k2 a1],
+                   r.eval("return {KEYS[1], KEYS[2], ARGV[1]}", 2, "k1", "k2", "a1")
+    end
+
+    def test_eval_with_numkeys_exceeding_args_raises
+      assert_raises(ArgumentError) { r.eval("return 1", 5, "only-one") }
+    end
+
+    def test_eval_with_negative_numkeys_raises
+      assert_raises(ArgumentError) { r.eval("return 1", -1) }
+    end
+
+    # A numeric-but-not-Integer key count used to fall through to the
+    # two-array branch, where the count itself became KEYS[1] and every
+    # remaining argument was silently dropped - the same silent misassignment
+    # the Integer form was fixed for. It must fail loudly instead.
+    def test_eval_with_non_integer_numeric_numkeys_raises
+      assert_raises(ArgumentError) { r.eval("return 1", 2.0, "k1", "k2") }
+      assert_raises(ArgumentError) { r.eval("return 1", Rational(2, 1), "k1", "k2") }
+    end
+
+    # More than (keys, argv) positionally is not a supported form; the extras
+    # used to be dropped without a word.
+    def test_eval_with_too_many_positional_arrays_raises
+      assert_raises(ArgumentError) do
+        r.eval("return 1", ["k1"], ["a1"], ["extra"])
+      end
+    end
+
+    def test_eval_integer_numkeys_mixed_with_keywords_raises
+      assert_raises(ArgumentError) do
+        r.eval("return 1", 1, "mykey", keys: ["other"])
+      end
+    end
+
+    def test_eval_integer_numkeys_writes_to_the_named_key
+      r.eval("redis.call('SET', KEYS[1], ARGV[1])", 1, "realkey", "realval")
+
+      assert_equal "realval", r.get("realkey")
+      assert_nil r.get("1")
+    end
+
+    def test_eval_integer_numkeys_releases_a_redlock_style_lock
+      r.set("lock:job", "token-abc")
+      unlock = "if redis.call('GET', KEYS[1]) == ARGV[1] then " \
+               "return redis.call('DEL', KEYS[1]) else return 0 end"
+
+      assert_equal 1, r.eval(unlock, 1, "lock:job", "token-abc")
+      assert_nil r.get("lock:job")
+    end
+
+    def test_evalsha_with_integer_numkeys
+      sha = r.script_load("return {KEYS[1], ARGV[1]}")
+
+      assert_equal %w[mykey myarg], r.evalsha(sha, 1, "mykey", "myarg")
+    end
+
+    def test_evalsha_with_integer_numkeys_zero
+      sha = r.script_load("return {ARGV[1]}")
+
+      assert_equal ["a1"], r.evalsha(sha, 0, "a1")
+    end
+
+    def test_evalsha_with_numkeys_exceeding_args_raises
+      sha = r.script_load("return 1")
+
+      assert_raises(ArgumentError) { r.evalsha(sha, 5, "only-one") }
+    end
+
+    def test_eval_ro_with_integer_numkeys
+      assert_equal %w[mykey myarg],
+                   r.eval_ro("return {KEYS[1], ARGV[1]}", 1, "mykey", "myarg")
+    end
+
+    def test_evalsha_ro_with_integer_numkeys
+      sha = r.script_load("return {KEYS[1], ARGV[1]}")
+
+      assert_equal %w[mykey myarg], r.evalsha_ro(sha, 1, "mykey", "myarg")
+    end
+
+    # the previously-supported forms must keep working unchanged
+
+    def test_eval_two_array_positional_form_still_works
+      assert_equal %w[mykey myarg],
+                   r.eval("return {KEYS[1], ARGV[1]}", ["mykey"], ["myarg"])
+    end
+
+    def test_eval_keyword_form_still_works
+      assert_equal %w[mykey myarg],
+                   r.eval("return {KEYS[1], ARGV[1]}", keys: ["mykey"], args: ["myarg"])
+    end
+
+    def test_evalsha_two_array_positional_form_still_works
+      sha = r.script_load("return {KEYS[1], ARGV[1]}")
+
+      assert_equal %w[mykey myarg], r.evalsha(sha, ["mykey"], ["myarg"])
+    end
+
+    # script cache lifecycle - script_load must reach the server
+
+    def test_script_load_makes_the_script_available_on_the_server
+      sha = r.script_load("return 'loaded-on-server'")
+
+      assert_equal true, r.script_exists(sha)
+      # no prior eval of this script - it is only usable if SCRIPT LOAD really
+      # reached the server
+      assert_equal "loaded-on-server", r.evalsha(sha)
+    end
+
+    def test_script_load_returns_the_server_computed_sha
+      script = "return 'sha-check'"
+      sha = r.script_load(script)
+
+      assert_equal 40, sha.length
+      assert_equal sha, r.script_load(script)
+    end
+
+    # script_load reaches the wire now, so a non-String would otherwise flatten
+    # into extra SCRIPT LOAD arguments and fail as a server arity error.
+    def test_script_load_rejects_a_non_string_script
+      assert_raises(ArgumentError) { r.script_load(42) }
+      assert_raises(ArgumentError) { r.script_load(nil) }
+      assert_raises(ArgumentError) { r.script_load("") }
+      assert_raises(ArgumentError) { r.script_load([]) }
+    end
+
+    # Every scripting command routes through #call, which forwards a `route:`
+    # keyword that Pipeline#send_command did not accept - queuing any of them
+    # raised ArgumentError instead of batching.
+    def test_scripting_commands_work_inside_a_pipeline
+      results = r.pipelined do |pipeline|
+        pipeline.script_load("return 'from-pipeline'")
+        pipeline.eval("return {KEYS[1], ARGV[1]}", 1, "pk", "pa")
+        pipeline.eval_ro("return 'ro'", 0)
+      end
+
+      assert_equal 40, results[0].length
+      assert_equal %w[pk pa], results[1]
+      assert_equal "ro", results[2]
+    end
+
+    def test_eval_works_inside_a_transaction
+      results = r.multi do |tx|
+        tx.eval("return {KEYS[1], ARGV[1]}", 1, "tk", "ta")
+      end
+
+      assert_equal [%w[tk ta]], results
+    end
+
+    def test_script_flush_really_invalidates_the_script
+      sha = r.script_load("return 'flushme'")
+      assert_equal "flushme", r.evalsha(sha)
+
+      assert_equal "OK", r.script_flush
+
+      assert_equal false, r.script_exists(sha)
+      # must not silently re-upload from a stale client-side container
+      assert_raises(Valkey::CommandError) { r.evalsha(sha) }
+      assert_equal false, r.script_exists(sha)
+    end
+
+    def test_evalsha_raises_for_a_never_loaded_sha
+      r.script_flush
+      never_loaded = "a" * 40
+
+      assert_raises(Valkey::CommandError) { r.evalsha(never_loaded) }
+    end
+
+    def test_script_loaded_by_one_client_is_usable_by_another
+      sha = r.script_load("return 'cross-client'")
+
+      # Deliberately NOT init()'d - init flushes the shared test database and
+      # would destroy the surrounding tests' keyspace. The script cache is
+      # server-wide, so a bare connection is all this needs.
+      other = _new_client
+      begin
+        assert_equal "cross-client", other.evalsha(sha)
+      ensure
+        other.close
+      end
+    end
   end
 end


### PR DESCRIPTION
### Summary

`eval`, `evalsha`, `eval_ro`, `evalsha_ro` and `script_load` never sent their
namesake commands to the server. They went through glide-core's client-side
`Script` container and `invoke_script`, which produced three distinct
user-visible defects. This PR dispatches real `EVAL` / `EVALSHA` / `EVAL_RO` /
`EVALSHA_RO` / `SCRIPT LOAD` over the wire, and adds the standard integer
key-count call form.

One root cause, three findings closed. **This PR contains two breaking
changes** — see below.

### Issue link

Closes #213

Also closes two findings from the #216 Group 1 rows (R2-12, R2-13), which were
not filed separately because they share this root cause.

### Features / Changes

#### The three findings

- **R3-4 — `KEYS`/`ARGV` misassignment on the integer key-count form.**
  `eval(script, 1, "mykey", "myarg")` — the form used by `valkey-cli` and every
  Valkey doc example — put the *count* in `KEYS[1]`, shifted the real key into
  `ARGV[1]`, and silently dropped everything after it. No error was raised.
- **R2-12 — `script_load` never sent `SCRIPT LOAD`.** It computed a SHA1 into a
  client-local container, so the server had never seen the script. The returned
  SHA was unusable by any other client or process, and `script_exists(sha)`
  returned `false` for a script that had just been "loaded".
- **R2-13 — `script_flush` was silently undone.** Because `evalsha` resolved
  through the client-side container, the next `evalsha` after a flush simply
  re-uploaded the script from the client and succeeded. Flushing the server
  cache had no observable effect.

#### Why wire dispatch instead of typed dispatch

`RequestType::Eval`, `RequestType::EvalSha` and `RequestType::ScriptLoad` have
enum values in glide-core but **no `get_command()` arm**, so typed
`send_command` fails outright with `Couldn't fetch command type`. To be precise:
this is 3 of the 5 methods. `EVAL_RO` and `EVALSHA_RO` *do* have arms
(glide-core `request_type.rs:1291-1292`) and would work with typed dispatch
today. All five are nonetheless routed through `call` to keep the family
uniform — a deliberate choice with a known cost, see *Known cost* below. The
rationale is recorded in a module comment so a future contributor can revert to
typed dispatch once glide-core gains the missing arms.

#### BREAKING: `evalsha` on a flushed/never-loaded SHA now raises

It raises **`Valkey::CommandError`** whose message contains `NoScriptError` —
**not** `Valkey::NoScriptError`. Callers must catch `Valkey::CommandError`.

`Valkey::NoScriptError` is defined at `lib/valkey/errors.rb:24` but is never
raised anywhere in `lib/`. The FFI exposes only four coarse `RequestErrorType`
values (`UNSPECIFIED` / `EXECABORT` / `TIMEOUT` / `DISCONNECT`), so `NOSCRIPT`
arrives as `UNSPECIFIED` and maps to `CommandError`. Verified live against a
real server.

Mapping the specific error subclasses is a **pre-existing gap out of scope for
this PR** — it equally affects `PermissionError`, `WrongTypeError` and
`OutOfMemoryError`, and deserves its own issue. Flagging it here so the
behavior is not mistaken for a regression introduced by this change.

#### BREAKING (smaller): ambiguous argument shapes now raise

Previously silent misparses now raise `ArgumentError`:

- Non-Integer numeric key counts (`Float`, `Rational`) — `eval(s, 2.0, "k1", "k2")`
  used to reproduce the exact bug this PR fixes, with no error at all.
- More than two positional arrays.
- `script_load` with a non-String script.

This follows the issue's own principle: proceeding with a silently different
meaning is precisely the thing to avoid. `Integer` and `Array` are disjoint in
the first positional slot, so recognizing the integer form is a strict superset
— it cannot change the meaning of any call that already worked.

#### A regression found during review, and fixed

Being honest about this one. Because every scripting method now goes through
`call`, which always forwards `route:`, and `Valkey::Pipeline#send_command` did
not accept `route:`, `pipelined { |p| p.script_load(...) }` **regressed from
returning `[]` to raising `ArgumentError: wrong number of arguments (given 3,
expected 1..2)`**.

Fixed by adding `route: nil` to `Pipeline#send_command`. The keyword is
**accepted and ignored**, matching the approach in #218 — batch-level routing
is a real feature but needs one route for the whole pipeline (see FFI
`BatchOptionsInfo.route_info`), not per-command routes. That work is tracked
in #137 and is out of scope here.

As a bonus, this also fixes a pre-existing case: `pipelined { |p| p.dbsize; p.info }`
used to raise `ArgumentError` on baseline because ~14 admin commands in
`server_commands.rb` forward `route:` unconditionally into `Pipeline#send_command`.
Verified: it now returns `[Integer, Hash]` cleanly. Non-block `MULTI` also
benefits — `eval` inside `multi { }` no longer executes outside the transaction.

Scope note: `eval`-in-pipeline was already broken before this branch
(`NoMethodError` on `build_command_args`), so that part is not a regression —
only `script_load` was. An earlier revision of this PR raised `ArgumentError`
when a route was supplied; changed to align with #218 after confirming no test
depends on either behavior.

#### Known cost — reviewer's call

OpenTelemetry spans for all five scripting methods are now named
`CustomCommand` rather than e.g. `EVAL_RO` (measured, not assumed).
`EVAL_RO` / `EVALSHA_RO` could retain real span names via typed dispatch today;
they were left uniform with the rest of the family and this is documented
in-code. Happy to split them out if maintainers prefer accurate span names over
family uniformity.

#### Tension with #206 — flagging, not resolving

#206 proposes a `Script` class; this PR moves away from the client-side
container. These are **not fundamentally in conflict** — `invoke_script` is
retained as the FFI seam. But #206 needs to know:

- `script_load` no longer populates glide-core's `scripts_container`, so
  `invoke_script`'s NOSCRIPT auto-reload path is now unreachable. A `Script`
  class must either call `store_script` itself, or be built on `EVALSHA` +
  `SCRIPT LOAD` fallback in Ruby.
- `Bindings.drop_script`, `Bindings.store_script`,
  `Bindings.free_script_hash_buffer` and `Bindings::ScriptHashBuffer` are now
  entirely unreferenced in `lib/` (`drop_script` was already dead before this
  branch). This PR enlarges the dead FFI surface. Left in place deliberately,
  since #206 may want it.

#### Cluster: reasoned, not locally tested

Routing is preserved because redis-rs derives it from the wire command name via
`Routable::command()` reading `arg_idx(0)`, and `CustomCommand` builds an empty
`Cmd` with args appended. So `EVAL` → `ThirdArgAfterKeyCount` (slot derived from
the key count this PR now sends correctly), `EVAL_RO` → replica-optional,
`SCRIPT LOAD` → `AllNodes` / `AllSucceeded`. Verified by reading glide-core
source. Actual cluster validation is deferred to CI — stating that plainly
rather than claiming coverage I don't have.

#### Files changed

| File | Change |
| --- | --- |
| `lib/valkey/commands/scripting_commands.rb` | Wire dispatch for all five methods; new `split_keys_and_args` helper handling all three call shapes; module comment recording the typed-dispatch constraint |
| `lib/valkey/pipeline.rb` | `send_command` accepts `route:` (raises if non-nil) — fixes the regression above |
| `test/lint/scripting_commands.rb` | 26 new tests |
| `CHANGELOG.md` | `## Pending` entry, including both breaking changes |

### Testing

**Lint** — `bundle exec rubocop lib/valkey/commands/scripting_commands.rb lib/valkey/pipeline.rb test/lint/scripting_commands.rb` → **0 offenses**.

**Standalone suite** — `CI=1 SKIP_TLS_TESTS=true VALKEY_PORT=6413 bundle exec rake test:standalone`
against a dedicated Valkey 8.1.3 instance:

| Run | Tests | Assertions | Failures |
| --- | --- | --- | --- |
| Baseline (pristine `fb2fa46`) | 840 | 4187 | 0 |
| With this change | **866** | 4207 | **0** |
| Repeat run | 866 | 4195 | 0 |

`test_cached_script_execution` — the known pre-existing flake (#167 / #124) —
passed in both final runs.

**The R2-12 / R2-13 tests assert real server state, not client-side echoes:**

- `test_script_load_makes_the_script_available_on_the_server`
- `test_script_loaded_by_one_client_is_usable_by_another` — cross-client, which
  is what actually proves the SHA reached the server
- `test_script_flush_really_invalidates_the_script` — asserts the raise **and**
  re-asserts `script_exists == false`, proving no client-side re-upload
- `test_evalsha_raises_for_a_never_loaded_sha`

All new tests live in the shared lint module, so they run in **both** the
standalone and cluster suites.

**Deferred:** `bundle exec rake test:cluster` — to CI (see *Cluster* above).

**Performance:** the warm path drops from 3 round trips to 1.

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] Documentation is updated (if applicable).
-   [x] Linters have been run (`bundle exec rubocop`) and pass.
-   [x] Destination branch is correct - main _(destination here is `release-1.0`, per the 1.0.0 GA release-blocker track)_

