### PR TITLE
fix(ruby): default `xtrim` to exact trimming and support `LIMIT`

### DIFF
--- a/lib/valkey/commands/stream_commands.rb
+++ b/lib/valkey/commands/stream_commands.rb
@@ -220,19 +220,25 @@ class Valkey
       # @param [Integer] maxlen maximum length of the stream
       # @param [Hash] options trimming options
       #   - `:strategy => String`: trimming strategy (default: "MAXLEN")
-      #   - `:approximate => true`: use approximate trimming (default: true)
+      #   - `:approximate => Boolean`: use approximate trimming (default: false)
+      #   - `:limit => Integer`: cap trim work per call; only valid with `approximate: true`
       # @return [Integer] number of entries removed
       #
-      # @example Trim to maximum length
+      # @example Trim to maximum length (exact)
       #   valkey.xtrim("mystream", 1000)
-      # @example Trim with exact count
-      #   valkey.xtrim("mystream", 1000, approximate: false)
+      # @example Approximate trimming
+      #   valkey.xtrim("mystream", 1000, approximate: true)
+      # @example Approximate trimming with LIMIT
+      #   valkey.xtrim("mystream", 1000, approximate: true, limit: 100)
       #
       # @see https://valkey.io/commands/xtrim/
-      def xtrim(key, maxlen, strategy: "MAXLEN", approximate: true)
+      def xtrim(key, maxlen, strategy: "MAXLEN", approximate: false, limit: nil)
+        raise ArgumentError, "limit: requires approximate: true" if limit && !approximate
+
         args = [key, strategy]
         args << "~" if approximate
         args << maxlen.to_s
+        args << "LIMIT" << limit.to_s if limit
         send_command(RequestType::X_TRIM, args)
       end
 

--- a/test/lint/stream_commands.rb
+++ b/test/lint/stream_commands.rb
@@ -135,6 +135,36 @@ module Lint
       r.del "mystream"
     end
 
+    def test_xtrim_default_trims_small_streams
+      r.del "mystream"
+      10.times { |i| r.xadd("mystream", { "n" => i.to_s }) }
+
+      # Default form must actually trim on small streams — approximate should
+      # default to false so `MAXLEN ~ N` is not silently a no-op below the
+      # server's radix-tree node boundary.
+      removed = r.xtrim("mystream", 3)
+      assert_operator removed, :>=, 1
+      assert_equal 3, r.xlen("mystream")
+
+      r.del "mystream"
+    end
+
+    def test_xtrim_limit_requires_approximate
+      assert_raises(ArgumentError) { r.xtrim("mystream", 3, limit: 10) }
+    end
+
+    def test_xtrim_with_limit
+      r.del "mystream"
+      30.times { |i| r.xadd("mystream", { "n" => i.to_s }) }
+
+      # Should run without raising; exact removed count is server-dependent
+      # under `~` semantics, so only assert on the return type.
+      removed = r.xtrim("mystream", 5, approximate: true, limit: 100)
+      assert_kind_of Integer, removed
+
+      r.del "mystream"
+    end
+
     def test_xread
       # Clean up any existing stream first
       r.del "mystream"


### PR DESCRIPTION
### Summary

`Valkey#xtrim` currently defaults `approximate:` to `true`, so `xtrim(key, N)` sends `MAXLEN ~ N` — which is silently a no-op on small streams (below the server's radix-tree node boundary, ~100 entries). Flip the default to `false` for redis-rb parity and least-surprising behavior, and add a `limit:` kwarg (gated on `approximate: true`) so callers can send the standard production form `MAXLEN ~ N LIMIT M`.

### Issue link

Closes #228

### Features / Changes

- `lib/valkey/commands/stream_commands.rb` — `xtrim` signature changes from `approximate: true` to `approximate: false, limit: nil`. When `limit:` is set without `approximate: true`, raise `ArgumentError` — the server rejects `LIMIT` without `~`, so pre-empt with a clearer Ruby-side error. Append `LIMIT M` to args when set. YARD docs and examples updated.
- `test/lint/stream_commands.rb` — three new tests:
  - `test_xtrim_default_trims_small_streams` — bare `xtrim(key, N)` form actually trims a small stream (regression guard against the `~` default returning).
  - `test_xtrim_limit_requires_approximate` — `limit:` without `approximate: true` raises `ArgumentError`.
  - `test_xtrim_with_limit` — `xtrim(key, N, approximate: true, limit: M)` runs and returns an Integer.

**Behavioral note:** technically a breaking change for any caller relying on the current default *and* okay with silent no-ops on small streams — a combination that doesn't correspond to any real use case. Callers who explicitly wanted approximate trimming will have passed `approximate: true` and are unaffected.

### Testing

Ran against a local Valkey 8.1.3 standalone on `localhost:6379`:

- `bundle exec rubocop lib/valkey/commands/stream_commands.rb test/lint/stream_commands.rb` — 2 files inspected, no offenses.
- `bundle exec ruby -Itest test/standalone/commands_test.rb -n "/xtrim/"` — 4 tests, 7 assertions, 0 failures.
- Broader stream regression check with `-n "/xadd|xtrim|xlen|xdel|xrange|xrevrange/"` — 10 tests, 32 assertions, 0 failures.

Full `bundle exec rake test:standalone` and cluster tests deferred to CI.

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] Documentation is updated (if applicable).
-   [x] Linters have been run (`bundle exec rubocop`) and pass.
-   [x] Destination branch is correct - release-1.0