### PR TITLE
fix(ci): build against glibc 2.17 and updated readme requirements.

### DIFF
--- a/.github/actions/install-zigbuild/action.yml
+++ b/.github/actions/install-zigbuild/action.yml
@@ -1,0 +1,38 @@
+name: Install zig and cargo-zigbuild
+description: >
+  Install pinned zig + cargo-zigbuild for cross-compiling the linux-gnu native
+  libraries against an glibc 2.17.
+
+  Assumes a Linux x86_64/aarch64 runner.
+
+inputs:
+  rust-target:
+    description: >
+      Optional Rust target triple to `rustup target add`.
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Install zig and cargo-zigbuild
+      shell: bash
+      env:
+        ZIG_VERSION: "0.13.0"
+        CARGO_ZIGBUILD_VERSION: "0.20.1"
+        RUST_TARGET: ${{ inputs.rust-target }}
+      run: |
+        set -euo pipefail
+        ARCH="$(uname -m)"
+        curl -fsSL "https://ziglang.org/download/${ZIG_VERSION}/zig-linux-${ARCH}-${ZIG_VERSION}.tar.xz" \
+          | sudo tar -xJ -C /usr/local
+        sudo ln -sf "/usr/local/zig-linux-${ARCH}-${ZIG_VERSION}/zig" /usr/local/bin/zig
+        curl -fsSL "https://github.com/rust-cross/cargo-zigbuild/releases/download/v${CARGO_ZIGBUILD_VERSION}/cargo-zigbuild-v${CARGO_ZIGBUILD_VERSION}.${ARCH}-unknown-linux-musl.tar.gz" \
+          | sudo tar -xz -C /usr/local/bin
+        if [[ -n "${RUST_TARGET}" ]]; then
+          rustup target add "${RUST_TARGET}"
+        fi
+        zig version
+        # `cargo zigbuild` dispatches to `cargo-zigbuild zigbuild`, whose
+        # subcommand has no --version flag; query the binary directly.
+        cargo-zigbuild --version

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -152,6 +152,7 @@ jobs:
           elif [[ "${{ matrix.host.TARGET }}" == *"linux-gnu"* ]]; then
             cargo zigbuild --release --target ${{ matrix.host.TARGET }}.2.17
           else
+            # macOS, pins to target MacOS 11+
             cargo build --release
           fi
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -134,6 +134,12 @@ jobs:
           linker = "musl-gcc-wrapper"
           EOF
 
+      - name: Install zig and cargo-zigbuild (linux-gnu)
+        if: contains(matrix.host.TARGET, 'linux-gnu')
+        uses: ./.github/actions/install-zigbuild
+        with:
+          rust-target: ${{ matrix.host.TARGET }}
+
       - name: Build native library
         working-directory: valkey-glide/ffi
         env:
@@ -143,6 +149,8 @@ jobs:
         run: |
           if [[ "${{ matrix.host.TARGET }}" == *"musl"* ]]; then
             cargo build --release --target ${{ matrix.host.TARGET }}
+          elif [[ "${{ matrix.host.TARGET }}" == *"linux-gnu"* ]]; then
+            cargo zigbuild --release --target ${{ matrix.host.TARGET }}.2.17
           else
             cargo build --release
           fi
@@ -151,7 +159,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: native-lib-${{ matrix.host.TARGET }}
-          path: valkey-glide/ffi/target/${{ contains(matrix.host.TARGET, 'musl') && format('{0}/release', matrix.host.TARGET) || 'release' }}/libglide_ffi.${{ matrix.host.OS == 'macos' && 'dylib' || 'so' }}
+          path: valkey-glide/ffi/target/${{ matrix.host.OS == 'macos' && 'release' || format('{0}/release', matrix.host.TARGET) }}/libglide_ffi.${{ matrix.host.OS == 'macos' && 'dylib' || 'so' }}
           if-no-files-found: error
 
   build-and-publish-gem:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,7 @@ jobs:
           if [[ "${{ matrix.host.TARGET }}" == *"linux-gnu"* ]]; then
             cargo zigbuild --release --target ${{ matrix.host.TARGET }}.2.17
           else
+            # macOS, pins to target MacOS 11+
             cargo build --release
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,18 +165,27 @@ jobs:
           restore-keys: |
             ${{ matrix.host.TARGET }}-cargo-
 
+      - name: Install zig and cargo-zigbuild (linux-gnu)
+        if: contains(matrix.host.TARGET, 'linux-gnu')
+        uses: ./.github/actions/install-zigbuild
+
       - name: Build native library
         working-directory: valkey-glide/ffi
         env:
           GLIDE_NAME: GlideRuby
           GLIDE_VERSION: ${{ github.ref_name }}
-        run: cargo build --release
+        run: |
+          if [[ "${{ matrix.host.TARGET }}" == *"linux-gnu"* ]]; then
+            cargo zigbuild --release --target ${{ matrix.host.TARGET }}.2.17
+          else
+            cargo build --release
+          fi
 
       - name: Upload native library
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: native-lib-${{ matrix.host.NAMED_OS }}-${{ matrix.host.ARCH }}
-          path: valkey-glide/ffi/target/release/libglide_ffi.${{ matrix.host.OS == 'macos' && 'dylib' || 'so' }}
+          path: valkey-glide/ffi/target/${{ contains(matrix.host.TARGET, 'linux-gnu') && format('{0}/release', matrix.host.TARGET) || 'release' }}/libglide_ffi.${{ matrix.host.OS == 'macos' && 'dylib' || 'so' }}
           if-no-files-found: error
 
   test-ruby:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,5 +4,6 @@
 
 ### Changes
 
+* Ruby: fixed cd workflow to correctly build the ffi with **glibc 2.17** ([#223](https://github.com/valkey-io/valkey-glide-ruby/issues/223))
 * Ruby: Add Alpine Linux (musl libc) support for x86_64 and aarch64 — runtime detection of musl libc, CI/CD pipeline for native builds, and prebuilt `libglide_ffi.so` for musl targets ([#143](https://github.com/valkey-io/valkey-glide-ruby/pull/143))
 * Ruby: Add distributed tracing support — `Valkey::OpenTelemetry.set_parent_span_context_provider` (and `init(parent_span_context_provider:)`) let an app propagate its current W3C trace context into command/pipeline spans, so they become children of the app's trace instead of independent root spans, matching the Node.js client's `parentSpanContextProvider` behavior.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Valkey General Language Independent Driver for the Enterprise (GLIDE) is the off
 ### System Requirements
 
 - glibc 2.17+ or musl 1.2.3+
-- Ruby 2.6+
+- Ruby 3.0+
 
 #### Supported OS
 
@@ -46,16 +46,6 @@ The following platforms have been tested:
 meet the glibc 2.17+ / musl 1.2.3+ requirement above.
 * Only Apple silicon (ARM) macOS is shipped, with a minimum of macOS 11. 
 Intel macOS users must build locally — see [build from source](./DEVELOPER.md).
-
-### Ruby Supported Versions
-
-| Ruby Version | MRI | JRuby |
-|--------------|-----|-------|
-| 2.6          | ✓   | -     |
-| 2.7          | ✓   | -     |
-| 3.0 – 3.4    | ✓   | ✓     |
-
-Minimum Ruby version: **2.6.0** (see `valkey.gemspec`).
 
 ### Installation and Setup
 

--- a/README.md
+++ b/README.md
@@ -36,15 +36,16 @@ Valkey General Language Independent Driver for the Enterprise (GLIDE) is the off
 
 #### Supported OS
 
-The following platforms are have been tested:
+The following platforms have been tested:
 - Ubuntu 24
 - Alpine Linux 3
-- macOS 14+ ARM
+- macOS 14 (Apple silicon / ARM)
 
 **Notes:**
 * Other Linux distributions not mentioned here should work as long as they
 meet the glibc 2.17+ / musl 1.2.3+ requirement above.
-* Intel macOS users must build locally. See [build from source](./DEVELOPER.md).
+* Only Apple silicon (ARM) macOS is shipped, with a minimum of macOS 11. 
+Intel macOS users must build locally — see [build from source](./DEVELOPER.md).
 
 ### Ruby Supported Versions
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
+
 # Valkey GLIDE for Ruby
 
-Valkey General Language Independent Driver for the Enterprise (GLIDE) is the official open-source Valkey client library, proudly part of the [Valkey](https://valkey.io) organization. The Ruby gem (`valkey-glide-rb`) wraps [Valkey GLIDE Core](https://github.com/valkey-io/valkey-glide) with an interface similar to [redis-rb](https://github.com/redis/redis-rb)**, delivering GLIDE performance, reliability, and enterprise features.
+Valkey General Language Independent Driver for the Enterprise (GLIDE) is the official open-source Valkey client library, proudly part of the [Valkey](https://valkey.io) organization. The Ruby gem (`valkey-glide-rb`) wraps [Valkey GLIDE Core](https://github.com/valkey-io/valkey-glide) with an interface similar to [redis-rb](https://github.com/redis/redis-rb), delivering GLIDE performance, reliability, and enterprise features.
 
 ## Why Choose Valkey GLIDE?
 
@@ -30,18 +31,20 @@ Valkey General Language Independent Driver for the Enterprise (GLIDE) is the off
 
 ### System Requirements
 
-The release of Valkey GLIDE Ruby was tested on the following platforms:
+- glibc 2.17+ or musl 1.2.3+
+- Ruby 2.6+
 
-**Linux:**
+#### Supported OS
 
-- Ubuntu 20+ (x86_64/amd64 and arm64/aarch64)
-- Amazon Linux 2 (AL2) and 2023 (AL2023) (x86_64)
-- Alpine Linux 3.18+ (x86_64 and arm64/aarch64) — musl libc
+The following platforms are have been tested:
+- Ubuntu 24
+- Alpine Linux 3
+- macOS 14+ ARM
 
-**macOS:**
-
-- macOS 14.7+ (Apple silicon / aarch64)
-- macOS 13.7+ (x86_64 / amd64)
+**Notes:**
+* Other Linux distributions not mentioned here should work as long as they
+meet the glibc 2.17+ / musl 1.2.3+ requirement above.
+* Intel macOS users must build locally. See [build from source](./DEVELOPER.md).
 
 ### Ruby Supported Versions
 


### PR DESCRIPTION
## Summary

This PR fixes the published gem's prebuilt `libglide_ffi.so` to compile against glibc 2.17. We also updated the Readme to reflect the current Ruby version support. 

#### README / documentation changes

This PR also corrects the **System Requirements** section, which previously claimed platforms that were never tested and, in some cases, cannot work.

Notably, we removed the JRuby support from documentations. Added #235 as a followup to verify our support level.

## Issue

Close #223  

## Changes

Build the two `linux-gnu` targets with `cargo zigbuild --target <triple>.2.17` to pin glibc to **2.17**. This matches how the upstream Java client builds its native artifacts

- New composite action `.github/actions/install-zigbuild` installs pinned zig + cargo-zigbuild (versions kept internal, not exposed as inputs). Used by both `cd.yml` and `ci.yml`.
- Artifact upload paths updated: an explicit `--target` moves cargo output to `target/<triple>/release/`.
- README System Requirements reworked to separate *tested* platforms from *compatible-by-glibc-floor* platforms, and to correct the macOS claim (only `aarch64-apple-darwin` ships).
- CHANGELOG entry.


## Verification

**Build:** CD run on this branch built both `linux-gnu` targets successfully — `aws-lc-sys`/`ring` compile cleanly through `zig cc`.

**glibc floor:** `objdump -T` on the shipped `libglide_ffi.so` tops out at `GLIBC_2.17` on both x86_64 and aarch64. Pre-fix baseline was `GLIBC_2.39`.

**Functional (native, not emulated):** the fixed gem was installed and exercised on a native x86_64 EC2 instance (glibc 2.31) inside Docker containers for both distros from the issue report:

| OS | glibc | objdump max | `require` + PING/SET/GET |
|----|-------|-------------|--------------------------|
| Debian 11 | 2.31 | `GLIBC_2.17` | ✅ pass (stock Ruby 2.7.4) |
| Ubuntu 20.04 | 2.31 | `GLIBC_2.17` | ✅ pass (Ruby ≥ 3.0) |

The native run confirms the fix end-to-end for the exact environments reported in #223. (Ubuntu 20.04's stock Ruby 2.7.0 cannot install the gem — the `ffi ~> 1.17` dependency requires Ruby ≥ 3.0 — but that is a separate, non-glibc packaging constraint, not a regression of this fix; verified with Ruby 3.2 in the same glibc-2.31 container.)
