### PR TITLE
fix: remove route parameters from commands and pipeline API

### DIFF
--- a/lib/valkey/commands/cluster_commands.rb
+++ b/lib/valkey/commands/cluster_commands.rb
@@ -124,10 +124,9 @@ class Valkey
 
       # Get information about the cluster.
       #
-      # @param route [Valkey::Route, nil] cluster routing. When routed, may return a Hash of node => value.
       # @return [Hash<String, String>] cluster information
-      def cluster_info(route: nil)
-        send_command(RequestType::CLUSTER_INFO, [], route: route) do |reply|
+      def cluster_info
+        send_command(RequestType::CLUSTER_INFO, []) do |reply|
           if reply.is_a?(Hash)
             reply.transform_values { |v| Utils::HashifyInfo.call(v) }
           else
@@ -146,10 +145,9 @@ class Valkey
 
       # Get information about cluster links.
       #
-      # @param route [Valkey::Route, nil] cluster routing. When routed, may return a Hash of node => value.
       # @return [Array<Hash>] array of link information
-      def cluster_links(route: nil)
-        send_command(RequestType::CLUSTER_LINKS, [], route: route)
+      def cluster_links
+        send_command(RequestType::CLUSTER_LINKS, [])
       end
 
       # Meet another node in the cluster.
@@ -163,26 +161,23 @@ class Valkey
 
       # Get the ID of the current node.
       #
-      # @param route [Valkey::Route, nil] cluster routing. When routed, may return a Hash of node => value.
       # @return [String] node ID
-      def cluster_myid(route: nil)
-        send_command(RequestType::CLUSTER_MY_ID, [], route: route)
+      def cluster_myid
+        send_command(RequestType::CLUSTER_MY_ID, [])
       end
 
       # Get the shard ID of the current node.
       #
-      # @param route [Valkey::Route, nil] cluster routing. When routed, may return a Hash of node => value.
       # @return [String] shard ID
-      def cluster_myshardid(route: nil)
-        send_command(RequestType::CLUSTER_MY_SHARD_ID, [], route: route)
+      def cluster_myshardid
+        send_command(RequestType::CLUSTER_MY_SHARD_ID, [])
       end
 
       # Get information about all nodes in the cluster.
       #
-      # @param route [Valkey::Route, nil] cluster routing. When routed, may return a Hash of node => value.
       # @return [Array<Hash>] array of node information
-      def cluster_nodes(route: nil)
-        send_command(RequestType::CLUSTER_NODES, [], route: route) do |reply|
+      def cluster_nodes
+        send_command(RequestType::CLUSTER_NODES, []) do |reply|
           if reply.is_a?(Hash)
             reply.transform_values { |v| Utils::HashifyClusterNodes.call(v) }
           else
@@ -248,10 +243,9 @@ class Valkey
 
       # Get information about cluster shards.
       #
-      # @param route [Valkey::Route, nil] cluster routing. When routed, may return a Hash of node => value.
       # @return [Array<Hash>] array of shard information
-      def cluster_shards(route: nil)
-        send_command(RequestType::CLUSTER_SHARDS, [], route: route)
+      def cluster_shards
+        send_command(RequestType::CLUSTER_SHARDS, [])
       end
 
       # Get information about slave nodes (deprecated, use cluster_replicas).

--- a/lib/valkey/commands/function_commands.rb
+++ b/lib/valkey/commands/function_commands.rb
@@ -182,40 +182,38 @@ class Valkey
       # Invoke a function.
       #
       # @example Call a function
-      #   valkey.fcall("myfunc", keys: ["key1"], args: ["arg1"])
+      #   valkey.fcall("myfunc", keys: ["key1"], arguments: ["arg1"])
       #     # => <function result>
       # @example Call a function without keys
-      #   valkey.fcall("myfunc", args: ["arg1", "arg2"])
+      #   valkey.fcall("myfunc", arguments: ["arg1", "arg2"])
       #     # => <function result>
       #
       # @param [String] function the function name
       # @param [Array<String>] keys the keys to pass to the function
-      # @param [Array<String>] args the arguments to pass to the function
-      # @param route [Valkey::Route, nil] cluster routing. When routed, may return a Hash of node => value.
+      # @param [Array<String>] arguments the arguments to pass to the function
       # @return [Object] the function result
       #
       # @see https://valkey.io/commands/fcall/
-      def fcall(function, keys: [], args: [], route: nil)
-        command_args = [function, keys.size] + keys + args
-        send_command(RequestType::FCALL, command_args, route: route)
+      def fcall(function, keys: [], arguments: [])
+        command_args = [function, keys.size] + keys + arguments
+        send_command(RequestType::FCALL, command_args)
       end
 
       # Invoke a read-only function.
       #
       # @example Call a read-only function
-      #   valkey.fcall_ro("myfunc", keys: ["key1"], args: ["arg1"])
+      #   valkey.fcall_ro("myfunc", keys: ["key1"], arguments: ["arg1"])
       #     # => <function result>
       #
       # @param [String] function the function name
       # @param [Array<String>] keys the keys to pass to the function
-      # @param [Array<String>] args the arguments to pass to the function
-      # @param route [Valkey::Route, nil] cluster routing. When routed, may return a Hash of node => value.
+      # @param [Array<String>] arguments the arguments to pass to the function
       # @return [Object] the function result
       #
       # @see https://valkey.io/commands/fcall_ro/
-      def fcall_ro(function, keys: [], args: [], route: nil)
-        command_args = [function, keys.size] + keys + args
-        send_command(RequestType::FCALL_READ_ONLY, command_args, route: route)
+      def fcall_ro(function, keys: [], arguments: [])
+        command_args = [function, keys.size] + keys + arguments
+        send_command(RequestType::FCALL_READ_ONLY, command_args)
       end
 
       # Control function registry (convenience method).

--- a/lib/valkey/pipeline.rb
+++ b/lib/valkey/pipeline.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Valkey
+  # TODO: Pipeline/Multi routing is to be implemented.
+  # See https://github.com/valkey-io/valkey-glide-ruby/issues/137
   class Pipeline
     include Commands
 
@@ -48,5 +50,140 @@ class Valkey
     def abort_futures!
       @futures.each(&:_abort!)
     end
+
+    # ---------------------------------------------------------------------
+    # Signature overrides that strip the `route:` kwarg from methods that
+    # carry it in the shared Commands module. Individual pipelined commands
+    # cannot be routed.
+    #
+    # TODO: Pipeline level routing to be added in the future.
+    # See https://github.com/valkey-io/valkey-glide-ruby/issues/137
+    # ---------------------------------------------------------------------
+
+    # rubocop:disable Lint/UselessMethodDefinition
+    # server_commands
+    def bgrewriteaof
+      super
+    end
+
+    def bgsave
+      super
+    end
+
+    def config_get(*args)
+      super
+    end
+
+    def config_set(*args)
+      super
+    end
+
+    def config_resetstat
+      super
+    end
+
+    def config_rewrite
+      super
+    end
+
+    def dbsize
+      super
+    end
+
+    def flushall(options = nil)
+      super
+    end
+
+    def flushdb(options = nil)
+      super
+    end
+
+    def info(cmd = nil)
+      super
+    end
+
+    def lastsave
+      super
+    end
+
+    def save
+      super
+    end
+
+    def time
+      super
+    end
+
+    def lolwut(version = nil)
+      super
+    end
+
+    # function_commands
+    def function_delete(library_name)
+      super
+    end
+
+    def function_dump
+      super
+    end
+
+    def function_flush(async: false, sync: false)
+      super
+    end
+
+    def function_kill
+      super
+    end
+
+    def function_list(library_name: nil, with_code: false)
+      super
+    end
+
+    def function_load(function_code, replace: false)
+      super
+    end
+
+    def function_restore(serialized_value, policy: nil)
+      super
+    end
+
+    def function_stats
+      super
+    end
+
+    # connection_commands
+    def ping(message = nil)
+      super
+    end
+
+    def echo(value)
+      super
+    end
+
+    def client_id
+      super
+    end
+
+    def client_unpause
+      super
+    end
+
+    # generic_commands
+    def randomkey
+      super
+    end
+
+    def call(*argv, **kwargs)
+      if kwargs.key?(:route)
+        raise ArgumentError, "Not supported: :route is not supported for individual pipelined commands"
+      end
+
+      super
+    end
+
+    def call_v(argv)
+      super
+    end
+    # rubocop:enable Lint/UselessMethodDefinition
   end
 end

--- a/test/cluster/cluster_routing_test.rb
+++ b/test/cluster/cluster_routing_test.rb
@@ -246,59 +246,6 @@ class TestClusterRouting < Minitest::Test
     assert result.key?("cluster_state")
   end
 
-  def test_cluster_info_random_route
-    result = r.cluster_info(route: Valkey::Route.random)
-
-    assert_kind_of Hash, result
-  end
-
-  def test_cluster_info_all_nodes_route
-    result = r.cluster_info(route: Valkey::Route.all_nodes)
-
-    assert_kind_of Hash, result
-    result.each_value do |v|
-      assert_kind_of Hash, v
-      assert v.key?("cluster_state")
-    end
-  end
-
-  # --- cluster_nodes ---
-
-  def test_cluster_nodes_random_route
-    result = r.cluster_nodes(route: Valkey::Route.random)
-
-    assert_kind_of Array, result
-    assert_operator result.size, :>, 0
-  end
-
-  def test_cluster_nodes_all_nodes_route
-    result = r.cluster_nodes(route: Valkey::Route.all_nodes)
-
-    assert_kind_of Hash, result
-    result.each_value do |v|
-      refute_nil v
-    end
-  end
-
-  # --- cluster_myid ---
-
-  def test_cluster_myid_all_primaries_route
-    result = r.cluster_myid(route: Valkey::Route.all_primaries)
-
-    assert_kind_of Hash, result
-    result.each_value do |id|
-      assert_kind_of String, id
-      refute_empty id
-    end
-  end
-
-  def test_cluster_myid_random_route
-    result = r.cluster_myid(route: Valkey::Route.random)
-
-    assert_kind_of String, result
-    refute_empty result
-  end
-
   # --- randomkey ---
 
   def test_randomkey_with_route

--- a/test/lint/function_commands.rb
+++ b/test/lint/function_commands.rb
@@ -187,7 +187,7 @@ module Lint
         LUA
 
         r.function_load(code)
-        result = r.fcall("fcallfunc", keys: [], args: ["test"])
+        result = r.fcall("fcallfunc", keys: [], arguments: ["test"])
         assert_equal "test", result
       rescue Valkey::CommandError => e
         # In cluster mode, function may be loaded on different node than execution
@@ -207,7 +207,7 @@ module Lint
         LUA
 
         r.function_load(code)
-        result = r.fcall("keysfunc", keys: ["mykey"], args: [])
+        result = r.fcall("keysfunc", keys: ["mykey"], arguments: [])
         assert_equal "mykey", result
       rescue Valkey::CommandError => e
         # In cluster mode, function may be loaded on different node than execution
@@ -238,7 +238,7 @@ module Lint
         end
 
         r.function_load(code)
-        result = r.fcall_ro("rofunc", keys: [], args: ["readonly"])
+        result = r.fcall_ro("rofunc", keys: [], arguments: ["readonly"])
         assert_equal "readonly", result
       rescue Valkey::CommandError => e
         # In cluster mode, function may be loaded on different node than execution


### PR DESCRIPTION
## Summary
Two coordinated cleanups so Ruby's cluster/function routing surface matches Python.

### Base `Commands` — 8 methods no longer accept `route:`
- `cluster_info`, `cluster_links`, `cluster_myid`, `cluster_myshardid`, `cluster_nodes`, `cluster_shards` — Python's cluster client exposes no `route`-taking wrappers for these; users who need routing should use `call("CLUSTER", "<subcommand>", route: …)`.
- `fcall`, `fcall_ro` — Python's keyed `fcall`/`fcall_ro` do not take a route (only the keyless `fcall_route`/`fcall_ro_route` variants do). The `args:` kwarg is also renamed to `arguments:` for Python parity. Route support here is tracked in #249.
### Pipeline — `route:` stripped from method signatures via override adapters
The shared `Commands` module carries `route:` on ~29 remaining methods (bgsave, info, dbsize, ping, function_*, call, etc.) so callers of the base `Valkey` client can route those commands to a specific cluster node. Because `Pipeline` mixes in the same module, IDE autocomplete on a pipeline object advertises `route:` on all of those commands — where passing it does nothing. Batch-level routing is separately tracked in #137.
This PR adds signature adapters on `Pipeline` that strip the `route:` kwarg so `Pipeline.instance_method(:bgsave).parameters` no longer advertises it. Each adapter forwards positionally to `super`, so all behavior comes from the shared `Commands` implementation — no duplicated logic.
## Behavior change
- Passing `route:` inside a `pipelined { |p| ... }` or `multi { |m| ... }` block now **raises `ArgumentError`** instead of being silently ignored. Pre-GA is the correct window for this change; the previous behavior was a footgun (no signal that the kwarg didn't work).
- `Valkey#cluster_info(route: …)` and the other 5 `cluster_*` methods now raise `ArgumentError`. Use `call("CLUSTER", "<subcommand>", route: …)` instead.
- `Valkey#fcall(function, keys: […], args: […])` — the `args:` kwarg is renamed to `arguments:`. `route:` is no longer accepted; route support tracked in #249.
## Non-goals
- Does not implement batch-level `route:` on `pipelined`/`multi` — that's #137, and matches the peer clients' design (Python `ClusterBatchOptions.route`, Node `ClusterBatchOptions.route`, Java `ClusterBatchOptions.route`, Go `ClusterBatchOptions.WithRoute`).
- Does not touch the base `Valkey` client's `route:` support on methods where Python legitimately exposes it — those 29 methods still accept `route:` on the non-batch path.
- `Pipeline#send_command` still accepts `route:` because that path is internal — the underlying `Commands` methods forward `route:` to `send_command` unconditionally, and the adapters guarantee it always arrives as `nil` from user-facing entry points.