### PR TITLE
fix(ruby): return stream entry fields as Hash to match redis-rb

### DIFF
--- a/lib/valkey/commands/stream_commands.rb
+++ b/lib/valkey/commands/stream_commands.rb
@@ -102,7 +102,7 @@ class Valkey
       #
       # @example Read from a single stream
       #   valkey.xread(["mystream"], ["0"])
-      #     # => { "mystream" => [["1234567890-0", ["field1", "value1"]]] }
+      #     # => { "mystream" => [["1234567890-0", {"field1" => "value1"}]] }
       # @example Read with count and block
       #   valkey.xread(["mystream"], ["0"], count: 10, block: 1000)
       #
@@ -177,10 +177,11 @@ class Valkey
       # @param [String] end_id end ID ("-" for beginning, "+" for end)
       # @param [Hash] options optional parameters
       #   - `:count => Integer`: maximum number of entries to return
-      # @return [Array] array of [id, [field, value, ...]] entries
+      # @return [Array<Array>] array of `[id, {field => value, ...}]` entries
       #
       # @example Get all entries
       #   valkey.xrange("mystream", "-", "+")
+      #     # => [["1234567890-0", {"field1" => "value1", "field2" => "value2"}]]
       # @example Get entries with count limit
       #   valkey.xrange("mystream", "-", "+", count: 10)
       #
@@ -200,7 +201,7 @@ class Valkey
       # @param [String] start start ID ("-" for beginning, "+" for end) - lower bound
       # @param [Hash] options optional parameters
       #   - `:count => Integer`: maximum number of entries to return
-      # @return [Array] array of [id, [field, value, ...]] entries in reverse order
+      # @return [Array<Array>] array of `[id, {field => value, ...}]` entries in reverse order
       #
       # @example Get last 10 entries
       #   valkey.xrevrange("mystream", "+", "-", count: 10)
@@ -501,7 +502,7 @@ class Valkey
       #
       # @example Auto-claim pending messages
       #   valkey.xautoclaim("mystream", "mygroup", "consumer2", 3600000, "0-0")
-      #     # => { 'next' => "1234567890-5", 'entries' => [["1234567890-0", ["field1", "value1"]]] }
+      #     # => { 'next' => "1234567890-5", 'entries' => [["1234567890-0", {"field1" => "value1"}]] }
       #
       # @see https://valkey.io/commands/xautoclaim/
       def xautoclaim(key, group, consumer, min_idle_time, start, **options)
@@ -519,6 +520,9 @@ class Valkey
           if options[:justid]
             Utils::HashifyStreamAutoclaimJustId.call(reply)
           else
+            # HashifyStreamAutoclaim handles both Array- and Hash-shaped
+            # `entries` slots; the earlier `!reply.is_a?(Array)` guard only
+            # rejects malformed top-level shapes.
             Utils::HashifyStreamAutoclaim.call(reply)
           end
         end

--- a/lib/valkey/utils.rb
+++ b/lib/valkey/utils.rb
@@ -101,61 +101,29 @@ class Valkey
     EMPTY_STREAM_RESPONSE = [nil].freeze
     private_constant :EMPTY_STREAM_RESPONSE
 
+    # Normalizes the many shapes that stream-read replies can arrive in
+    # (Hash / [[id, pairs], ...] / flat [id, pairs, id, pairs] outer;
+    # Hash / [[k, v], ...] / flat [k, v, k, v] inner) into redis-rb's
+    # [[id, {field => value, ...}], ...] shape. Duplicate field names in one
+    # entry collapse to last-write-wins, same as redis-rb.
     HashifyStreamEntries = lambda { |reply|
-      return [] if reply.nil?
-
-      # In cluster mode, MAP responses come as Hash: {id => [fields], ...}
-      if reply.is_a?(Hash)
-        return reply.map { |entry_id, values| [entry_id, values.is_a?(Array) ? values.flatten : []] }
-      end
-
-      return [] if !reply.is_a?(Array) || reply.empty?
-
-      # Reply format: [[entry_id, [field1, value1, field2, value2, ...]], ...]
-      # Match redis-rb: return flat arrays [["id", ["field", "value", ...]], ...]
-      # Check if first element is a pair [entry_id, values_array]
-      first_elem = reply.first
-      if first_elem.is_a?(Array) && first_elem.length == 2
-        # Already in pair format: [[entry_id, [fields...]], ...]
-        reply.compact.map do |entry_id, values|
-          # Return flat array format like redis-rb, not hash
-          values_array = if values.nil?
-                           []
-                         elsif values.is_a?(Array)
-                           values
-                         else
-                           []
-                         end
-          [entry_id, values_array]
+      entries =
+        case reply
+        when Hash
+          reply
+        when Array
+          reply.first.is_a?(Array) ? reply : reply.each_slice(2)
+        else
+          return []
         end
-      else
-        # Flat array format: [entry_id1, [field1, value1, ...], entry_id2, [field2, value2, ...], ...]
-        reply.compact.each_slice(2).map do |entry_id, values|
-          # Return flat array format like redis-rb, not hash
-          values_array = if values.nil?
-                           []
-                         elsif values.is_a?(Array)
-                           values
-                         else
-                           []
-                         end
-          [entry_id, values_array]
-        end
-      end
+
+      entries.map { |entry_id, pairs| [entry_id, Hashify.call(pairs || [])] }
     }
 
     HashifyStreamAutoclaim = lambda { |reply|
       {
         'next' => reply[0],
-        'entries' => if reply[1].nil?
-                       []
-                     elsif reply[1].is_a?(Array)
-                       # Reply[1] is already an array of entries: [[id, [field, value, ...]], ...]
-                       # Use HashifyStreamEntries to convert them properly
-                       HashifyStreamEntries.call(reply[1])
-                     else
-                       []
-                     end
+        'entries' => HashifyStreamEntries.call(reply[1])
       }
     }
 

--- a/test/lint/stream_commands.rb
+++ b/test/lint/stream_commands.rb
@@ -77,11 +77,13 @@ module Lint
       r.xadd("mystream", { "field2" => "value2" }, id: "2000-0")
       r.xadd("mystream", { "field3" => "value3" }, id: "3000-0")
 
-      # Get all entries (redis-rb format: [id, [field, value, ...]])
+      # Get all entries (redis-rb format: [id, {field => value, ...}])
       entries = r.xrange("mystream", "-", "+")
       assert_equal 3, entries.length
       assert_equal id1, entries[0][0]
-      assert_kind_of Array, entries[0][1] # field-value array (redis-rb format)
+      assert_kind_of Hash, entries[0][1] # redis-rb format: field-value Hash
+      assert_equal "value1", entries[0][1]["field1"]
+      assert_equal "value2", entries[1][1]["field2"]
 
       # Get entries with count
       entries = r.xrange("mystream", "-", "+", count: 2)
@@ -102,11 +104,12 @@ module Lint
       r.xadd("mystream", { "field2" => "value2" }, id: "2000-0")
       id3 = r.xadd("mystream", { "field3" => "value3" }, id: "3000-0")
 
-      # Get all entries in reverse (redis-rb format: [id, [field, value, ...]])
+      # Get all entries in reverse (redis-rb format: [id, {field => value, ...}])
       entries = r.xrevrange("mystream")
       assert_equal 3, entries.length
       assert_equal id3, entries[0][0] # Last entry first
-      assert_kind_of Array, entries[0][1] # field-value array (redis-rb format)
+      assert_kind_of Hash, entries[0][1] # redis-rb format: field-value Hash
+      assert_equal "value3", entries[0][1]["field3"]
 
       # Get last entry
       entries = r.xrevrange("mystream", "+", "-", count: 1)
@@ -178,10 +181,11 @@ module Lint
       assert_kind_of Hash, result
       assert result.key?("mystream")
       assert_operator result["mystream"].length, :>=, 2
-      # Verify entries are in redis-rb format: [id, [field, value, ...]]
+      # Verify entries are in redis-rb format: [id, {field => value, ...}]
       assert_kind_of Array, result["mystream"][0]
       assert_equal 2, result["mystream"][0].length
-      assert_kind_of Array, result["mystream"][0][1]
+      assert_kind_of Hash, result["mystream"][0][1]
+      assert_equal "value1", result["mystream"][0][1]["field1"]
 
       # Read with count
       result = r.xread(["mystream"], ["0"], count: 1)
@@ -208,10 +212,11 @@ module Lint
       assert result.key?("mystream")
       # Entries are converted to [id, hash] format
       assert_operator result["mystream"].length, :>=, 2
-      # Verify entries are in redis-rb format: [id, [field, value, ...]]
+      # Verify entries are in redis-rb format: [id, {field => value, ...}]
       assert_kind_of Array, result["mystream"][0]
       assert_equal 2, result["mystream"][0].length
-      assert_kind_of Array, result["mystream"][0][1]
+      assert_kind_of Hash, result["mystream"][0][1]
+      assert_equal "value1", result["mystream"][0][1]["field1"]
 
       r.del "mystream"
     end
@@ -344,16 +349,17 @@ module Lint
       # Wait a bit for idle time
       sleep(0.1)
 
-      # Claim message for consumer2 (redis-rb format: [id, [field, value, ...]])
+      # Claim message for consumer2 (redis-rb format: [id, {field => value, ...}])
       claimed = r.xclaim("mystream", "mygroup", "consumer2", 100, [id1])
       assert_kind_of Array, claimed
       assert_operator claimed.length, :>=, 1 # Should claim at least 1 message
-      # Each entry should be [id, [field, value, ...]] format (redis-rb)
+      # Each entry should be [id, {field => value, ...}] format (redis-rb)
       claimed.each do |entry|
         assert_kind_of Array, entry
         assert_equal 2, entry.length
         assert_kind_of String, entry[0] # ID
-        assert_kind_of Array, entry[1] # field-value array (redis-rb format)
+        assert_kind_of Hash, entry[1] # redis-rb format: field-value Hash
+        assert_equal "value1", entry[1]["field1"]
       end
 
       r.del "mystream"
@@ -378,12 +384,16 @@ module Lint
       assert result.key?("next")
       assert result.key?("entries")
       assert_kind_of Array, result["entries"]
-      # Verify entries are in redis-rb format: [id, [field, value, ...]]
+      # Guard against the silent-drop regression: server transferred ownership,
+      # entries must not be empty.
+      assert_operator result["entries"].length, :>=, 1
+      # Verify entries are in redis-rb format: [id, {field => value, ...}]
       result["entries"].each do |entry|
         assert_kind_of Array, entry
         assert_equal 2, entry.length
         assert_kind_of String, entry[0] # ID
-        assert_kind_of Array, entry[1] # field-value array (redis-rb format)
+        assert_kind_of Hash, entry[1] # redis-rb format: field-value Hash
+        assert_equal "value1", entry[1]["field1"]
       end
 
       r.del "mystream"

--- a/test/valkey/utils_test.rb
+++ b/test/valkey/utils_test.rb
@@ -272,6 +272,22 @@ module ValkeyTests
       assert_equal [["0-1", {}]], result
     end
 
+    # Streams allow the same field name to repeat in one entry. redis-rb
+    # collapses to last-write-wins because it stores fields in a Hash; we do
+    # the same, and this test locks in the contract so nobody accidentally
+    # switches to a first-write-wins helper.
+    def test_hashify_stream_entries_duplicate_field_names_last_write_wins
+      # Flat inner (standalone-default shape)
+      flat = [["0-1", %w[name alice name bob]]]
+      assert_equal [["0-1", { "name" => "bob" }]],
+                   ::Valkey::Utils::HashifyStreamEntries.call(flat)
+
+      # Pair-of-pairs inner (cluster/RESP3 shape)
+      pairs = [["0-1", [%w[name alice], %w[name bob]]]]
+      assert_equal [["0-1", { "name" => "bob" }]],
+                   ::Valkey::Utils::HashifyStreamEntries.call(pairs)
+    end
+
     # --- HashifyStreamAutoclaim -----------------------------------------------
 
     def test_hashify_stream_autoclaim_array_entries

--- a/test/valkey/utils_test.rb
+++ b/test/valkey/utils_test.rb
@@ -203,5 +203,98 @@ module ValkeyTests
       refute_match(/p@ss/, error.message)
       assert_match(/REDACTED/, error.message)
     end
+
+    # --- HashifyStreamEntries -------------------------------------------------
+    # Stream replies arrive in several shapes depending on cluster mode, RESP
+    # protocol version, and where recursive Map-flattening lands. The lambda
+    # must always produce redis-rb's `[[id, {field => value, ...}], ...]`.
+
+    def test_hashify_stream_entries_nil_returns_empty
+      assert_equal [], ::Valkey::Utils::HashifyStreamEntries.call(nil)
+    end
+
+    def test_hashify_stream_entries_empty_array_returns_empty
+      assert_equal [], ::Valkey::Utils::HashifyStreamEntries.call([])
+    end
+
+    def test_hashify_stream_entries_non_stream_shape_returns_empty
+      assert_equal [], ::Valkey::Utils::HashifyStreamEntries.call("nope")
+      assert_equal [], ::Valkey::Utils::HashifyStreamEntries.call(42)
+    end
+
+    # Standalone default: MAP responses get recursively flattened at the FFI
+    # layer, so the entry values arrive as a flat `[k, v, k, v]` array.
+    def test_hashify_stream_entries_flat_pair_of_pairs
+      reply = [["0-1", %w[name alice age 30]], ["0-2", %w[name bob age 40]]]
+      result = ::Valkey::Utils::HashifyStreamEntries.call(reply)
+      assert_equal [["0-1", { "name" => "alice", "age" => "30" }],
+                    ["0-2", { "name" => "bob",   "age" => "40" }]], result
+    end
+
+    # Some responses arrive as fully-flat: [id, pairs, id, pairs, ...].
+    def test_hashify_stream_entries_fully_flat_array
+      reply = ["0-1", %w[name alice age 30], "0-2", %w[name bob age 40]]
+      result = ::Valkey::Utils::HashifyStreamEntries.call(reply)
+      assert_equal [["0-1", { "name" => "alice", "age" => "30" }],
+                    ["0-2", { "name" => "bob",   "age" => "40" }]], result
+    end
+
+    # Cluster mode / RESP3: the outer MAP stays a Hash, and glide-core's
+    # ArrayOfPairs is preserved as `[[k, v], [k, v]]`.
+    def test_hashify_stream_entries_hash_of_pair_of_pairs
+      reply = {
+        "0-1" => [%w[name alice], %w[age 30]],
+        "0-2" => [%w[name bob],   %w[age 40]]
+      }
+      result = ::Valkey::Utils::HashifyStreamEntries.call(reply)
+      # Hash key order is preserved in Ruby, so we can compare directly.
+      assert_equal [["0-1", { "name" => "alice", "age" => "30" }],
+                    ["0-2", { "name" => "bob",   "age" => "40" }]], result
+    end
+
+    # Array of `[id, [[k, v], [k, v]]]` — pair-of-pairs preserved by core.
+    def test_hashify_stream_entries_array_of_pair_of_pairs
+      reply = [["0-1", [%w[name alice], %w[age 30]]]]
+      result = ::Valkey::Utils::HashifyStreamEntries.call(reply)
+      assert_equal [["0-1", { "name" => "alice", "age" => "30" }]], result
+    end
+
+    # RESP3: the inner MAP is delivered as a Ruby Hash directly.
+    def test_hashify_stream_entries_hash_inner_value
+      reply = [["0-1", { "name" => "alice", "age" => "30" }]]
+      result = ::Valkey::Utils::HashifyStreamEntries.call(reply)
+      assert_equal [["0-1", { "name" => "alice", "age" => "30" }]], result
+    end
+
+    def test_hashify_stream_entries_nil_inner_value_yields_empty_hash
+      reply = [["0-1", nil]]
+      result = ::Valkey::Utils::HashifyStreamEntries.call(reply)
+      assert_equal [["0-1", {}]], result
+    end
+
+    # --- HashifyStreamAutoclaim -----------------------------------------------
+
+    def test_hashify_stream_autoclaim_array_entries
+      reply = ["1-1", [["0-1", %w[name alice]]], []]
+      result = ::Valkey::Utils::HashifyStreamAutoclaim.call(reply)
+      assert_equal "1-1", result["next"]
+      assert_equal [["0-1", { "name" => "alice" }]], result["entries"]
+    end
+
+    # Regression: cluster/RESP3 hands the entries slot as a Hash. The old
+    # `reply[1].is_a?(Array)` guard silently dropped every claimed entry.
+    def test_hashify_stream_autoclaim_hash_entries
+      reply = ["1-1", { "0-1" => [%w[name alice]] }, []]
+      result = ::Valkey::Utils::HashifyStreamAutoclaim.call(reply)
+      assert_equal "1-1", result["next"]
+      assert_equal [["0-1", { "name" => "alice" }]], result["entries"]
+    end
+
+    def test_hashify_stream_autoclaim_nil_entries
+      reply = ["0-0", nil, []]
+      result = ::Valkey::Utils::HashifyStreamAutoclaim.call(reply)
+      assert_equal "0-0", result["next"]
+      assert_equal [], result["entries"]
+    end
   end
 end


### PR DESCRIPTION
### Summary

Every stream-read command (`xrange`, `xrevrange`, `xread`, `xreadgroup`, `xclaim`) returned each entry's field-value pairs as a flat `Array` (`["name", "alice", "age", "30"]`) instead of the `Hash` (`{"name"=>"alice","age"=>"30"}`) that redis-rb 5.4.1 returns. By-name access (`entry[1]["name"]`) raised `TypeError`, and pair-iteration silently produced `nil` on odd-length data. The same root cause silently dropped every claimed entry from `xautoclaim` when the server had already transferred ownership.

### Issue link

Closes #240

### Features / Changes

- `lib/valkey/utils.rb` — `HashifyStreamEntries` rewritten to accept every input shape the FFI/RESP layer can produce (`Hash{id => pairs}`, `[[id, pairs], ...]`, or flat `[id, pairs, id, pairs, ...]`; and inner `pairs` as `Hash{k=>v}`, `[[k,v], [k,v]]`, or flat `[k,v,k,v]`) and normalize to redis-rb's `[[id, {field => value, ...}], ...]`. Inner conversion delegates to the existing `Utils::Hashify` helper. Duplicate field names in one entry collapse to last-write-wins, same as redis-rb.
- `lib/valkey/utils.rb` — `HashifyStreamAutoclaim` no longer discards a `Hash`-shaped `entries` slot (cluster mode / RESP3 path); it delegates to `HashifyStreamEntries`, which handles all shapes uniformly.
- `lib/valkey/commands/stream_commands.rb` — YARD docstrings updated to reflect the Hash return shape.
- `test/lint/stream_commands.rb` — every `assert_kind_of Array, entries[0][1]` flipped to `Hash` and augmented with positive by-name-access assertions (`entry[1]["field1"] == "value1"`). `xautoclaim` gains a `length >= 1` guard against the silent-drop regression.
- `test/valkey/utils_test.rb` — 12 new server-independent unit tests covering every input shape for both lambdas.

### Testing

Ran locally against a Valkey 8 standalone server on `127.0.0.1:6379`:

- `bundle exec rubocop` — clean (99 files)
- `bundle exec rake test:standalone TESTOPTS="--name=/hashify_stream/"` — 12 tests / 16 assertions / 0 failures
- `bundle exec rake test:standalone TESTOPTS="--name=/test_x/"` — 24 tests / 97 assertions / 0 failures
- Reporter's exact repro from the issue now returns `[["...", {"name"=>"alice", "age"=>"30"}], ...]` and `entries.first[1]["name"] == "alice"` — parity with redis-rb 5.4.1 confirmed live.

Cluster suite (`bundle exec rake test:cluster`) was not run locally — the same shared lint suite runs there, and no code path is cluster-specific to this change.

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [x] Tests are added or updated.
-   [x] Documentation is updated (if applicable).
-   [x] Linters have been run (`bundle exec rubocop`) and pass.
-   [x] Destination branch is correct - `release-1.0` (RC3 bug bash target).