### PR TITLE
fix: remove monitor, shutdown, and debug commands

### DIFF
--- a/lib/valkey/commands/server_commands.rb
+++ b/lib/valkey/commands/server_commands.rb
@@ -173,40 +173,12 @@ class Valkey
         send_command(RequestType::LAST_SAVE, [], route: route)
       end
 
-      # Listen for all requests received by the server in real time.
-      #
-      # There is no way to interrupt this command.
-      #
-      # @yield a block to be called for every line of output
-      # @yieldparam [String] line timestamp and command that was executed
-      def monitor
-        synchronize do |client|
-          client = client.pubsub
-          client.call_v([:monitor])
-          loop do
-            yield client.next_event
-          end
-        end
-      end
-
       # Synchronously save the dataset to disk.
       #
       # @param route [Valkey::Route, nil] cluster routing.
       # @return [String]
       def save(route: nil)
         send_command(RequestType::SAVE, [], route: route)
-      end
-
-      # Synchronously save the dataset to disk and then shut down the server.
-      def shutdown
-        synchronize do |client|
-          client.disable_reconnection do
-            client.call_v([:shutdown])
-          rescue ConnectionError
-            # This means Redis has probably exited.
-            nil
-          end
-        end
       end
 
       # Make the server a slave of another instance, or promote it as master.
@@ -257,11 +229,6 @@ class Valkey
       #   microseconds in the current second
       def time(route: nil)
         send_command(RequestType::TIME, [], route: route)
-      end
-
-      # RequestType::DEBUG not exist
-      def debug(*args)
-        send_command(RequestType::DEBUG, args)
       end
 
       # ACL Commands - Access Control List management

--- a/test/lint/server_commands.rb
+++ b/test/lint/server_commands.rb
@@ -147,14 +147,6 @@ module Lint
       assert response.nil? || response.is_a?(String), "Expected sync to return nil or a String"
     end
 
-    def test_debug
-      skip("DEBUG command not implemented in backend yet")
-
-      r.set("somekey", "somevalue") # Ensure key exists
-      response = r.debug("OBJECT", "somekey")
-      assert response.is_a?(String), "Expected debug to return a String response"
-    end
-
     def test_config_set
       response = r.config(:set, "maxmemory", "100mb")
       assert_equal "OK", response


### PR DESCRIPTION
Remove three `Valkey` server-command methods that either dispatch to undefined helpers or expose a server surface that no glide-family client supports.

## Summary

- **`monitor`**: Monitor is supported as a separate API. See https://glide.valkey.io/how-to/monitoring/monitor-command/. 
- **`shutdown`**:  Dangerous command not implemented by other GLIDE clients.
- **`debug`**: Potentially dangerous development command. Not intended for public usage and not implemented by other GLIDE clients.
## Test plan

- [x] `rubocop` clean on touched files
- [x] Skipped `test_debug` case in `test/lint/server_commands.rb` removed
- [x] Live probes confirm `v.monitor` / `v.shutdown` / `v.debug` now raise plain `NoMethodError: undefined method '<name>' for an instance of Valkey` (not the previous `NoMethodError: synchronize` or `NameError`)
- [x] Remaining `server_commands` lint suite passes on standalone
