### PR TITLE
fix: short-circuit `scan`/`scan_each` to empty in cluster mode

### DIFF
--- a/lib/valkey/commands/generic_commands.rb
+++ b/lib/valkey/commands/generic_commands.rb
@@ -9,10 +9,10 @@ class Valkey
     module GenericCommands
       # Scan the keyspace
       #
-      # @note Standalone mode only. glide-core has no defined default route for
-      #   SCAN in cluster mode, so each call may land on a different node with
-      #   no cursor continuity between them — results are undefined (missed or
-      #   duplicated keys) rather than merely partial.
+      # @note Standalone mode only. In cluster mode this returns `["0", []]`
+      #   (a finished cursor and no keys) rather than iterating a single shard
+      #   with an undefined route. A cluster-aware scan API is tracked in
+      #   TODO: https://github.com/valkey-io/valkey-glide-ruby/issues/133
       #
       # @example Retrieve the first batch of keys
       #   valkey.scan(0)
@@ -33,13 +33,16 @@ class Valkey
       # @return [String, Array<String>] the next cursor and all found keys
       #
       def scan(cursor, **options)
+        return ["0", []] if @cluster_mode
+
         _scan(RequestType::SCAN, cursor, [], **options)
       end
 
       # Scan the keyspace
       #
-      # @note Standalone mode only. Built on {#scan}, which has undefined
-      #   routing behavior in cluster mode (see its note).
+      # @note Standalone mode only. In cluster mode this yields nothing and
+      #   returns immediately, matching {#scan}'s cluster behavior. See
+      #   TODO: https://github.com/valkey-io/valkey-glide-ruby/issues/133
       #
       # @example Retrieve all of the keys (with possible duplicates)
       #   valkey.scan_each.to_a
@@ -62,6 +65,7 @@ class Valkey
       #
       def scan_each(**options, &block)
         return to_enum(:scan_each, **options) unless block_given?
+        return if @cluster_mode
 
         cursor = 0
         loop do

--- a/test/lint/generic_commands.rb
+++ b/test/lint/generic_commands.rb
@@ -349,11 +349,14 @@ module Lint
     end
 
     def test_scan
-      # The set_some_keys method sets both tagged and untagged keys
-      # In cluster mode, scan only sees keys on the node being scanned
-      skip("SCAN with match pattern may not see all keys in cluster mode") if cluster_mode?
-
       set_some_keys
+
+      # scan is standalone only.
+      # For cluster support, see https://github.com/valkey-io/valkey-glide-ruby/issues/133
+      if cluster_mode?
+        assert_equal ["0", []], valkey.scan(0, match: '{key}*')
+        return
+      end
 
       cursor = 0
       all_keys = []
@@ -367,9 +370,14 @@ module Lint
     end
 
     def test_scan_each
-      skip("SCAN with match pattern may not see all keys in cluster mode") if cluster_mode?
-
       set_some_keys
+
+      # scan_each is standalone only.
+      # For cluster support, see https://github.com/valkey-io/valkey-glide-ruby/issues/133
+      if cluster_mode?
+        assert_empty valkey.scan_each(match: '{key}*').to_a
+        return
+      end
 
       all_keys = valkey.scan_each(match: '{key}*').to_a
 


### PR DESCRIPTION
## Summary
`scan` and `scan_each` are standalone mode only. This PR adds additional comments clarifications. It also return empty results if scan is used on `cluster_mode`. 

Cluster support to be added in https://github.com/valkey-io/valkey-glide-ruby/issues/133

## Test plan

- [x] `bundle exec rubocop lib/valkey/commands/generic_commands.rb test/lint/generic_commands.rb` — clean
- [x] `ruby -c` on both files — syntax OK
- [ ] `bundle exec rake test:standalone` — deferred (no local standalone server up at the time of push); please verify in CI
- [ ] `bundle exec rake test:cluster` — deferred (no local cluster up at the time of push); the new `cluster_mode?` branches in `test_scan` / `test_scan_each` are what exercises the guard, so CI is the load-bearing check here