### PR TITLE
docs: correct Ruby minimum version to 2.6+

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Valkey General Language Independent Driver for the Enterprise (GLIDE) is the off
 ### System Requirements
 
 - glibc 2.17+ or musl 1.2.3+
-- Ruby 3.0+
+- Ruby 2.6+
 
 #### Supported OS
 


### PR DESCRIPTION
## Summary
- README listed `Ruby 3.0+` under System Requirements, but the gem's declared floor is `>= 2.6.0`.
- Corrects the line to match `valkey.gemspec` and RubyGems metadata (unchanged from 0.9.0 through 1.0.0-rc5).

## Evidence
- `valkey.gemspec:13` — `spec.required_ruby_version = ">= 2.6.0"`
- RubyGems reports `ruby_version=">= 2.6.0"` for every published version incl. `1.0.0.pre.rc5`.

## Test plan
- [ ] Docs-only change; visual verify the rendered README line reads `Ruby 2.6+`.