### PR TITLE
fix: remove pubsub public API and skip upstream client KILL bug

### DIFF
--- a/lib/valkey/commands.rb
+++ b/lib/valkey/commands.rb
@@ -47,7 +47,8 @@ class Valkey
     include SetCommands
     include ScriptingCommands
     include FunctionCommands
-    include PubSubCommands
+    # TODO: https://github.com/valkey-io/valkey-glide-ruby/issues/135
+    # include PubSubCommands
     include ClusterCommands
     include TransactionCommands
     include StreamCommands

--- a/lib/valkey/commands/connection_commands.rb
+++ b/lib/valkey/commands/connection_commands.rb
@@ -161,26 +161,6 @@ class Valkey
         send_command(RequestType::CLIENT_KILL_SIMPLE, [addr])
       end
 
-      private
-
-      def build_client_kill_args(addr, options)
-        args = []
-        args << "ADDR" << addr if addr
-        options.each do |key, value|
-          case key
-          when :id then args << "ID" << value.to_s
-          when :type then args << "TYPE" << value.to_s
-          when :user then args << "USER" << value.to_s
-          when :addr then args << "ADDR" << value.to_s
-          when :laddr then args << "LADDR" << value.to_s
-          when :skipme then args << "SKIPME" << (value ? "yes" : "no")
-          end
-        end
-        args
-      end
-
-      public
-
       # Pause client processing.
       #
       # @param [Integer] timeout Pause duration in milliseconds
@@ -270,6 +250,22 @@ class Valkey
       private :client_tracking, :client_caching, :client_tracking_info, :client_getredir
 
       private
+
+      def build_client_kill_args(addr, options)
+        args = []
+        args << "ADDR" << addr if addr
+        options.each do |key, value|
+          case key
+          when :id then args << "ID" << value.to_s
+          when :type then args << "TYPE" << value.to_s
+          when :user then args << "USER" << value.to_s
+          when :addr then args << "ADDR" << value.to_s
+          when :laddr then args << "LADDR" << value.to_s
+          when :skipme then args << "SKIPME" << (value ? "yes" : "no")
+          end
+        end
+        args
+      end
 
       def build_client_tracking_args(options)
         args = []

--- a/test/lint/server_commands.rb
+++ b/test/lint/server_commands.rb
@@ -233,12 +233,14 @@ module Lint
       sleep(0.5) # Ensure the new client created
 
       addr = extra_client.client(:info)[/addr=(\S+)/, 1]
+      skip("No client address found for extra client") unless addr
 
-      if addr
-        result = extra_client.client(:kill, addr)
-        assert_equal "OK", result
-      else
-        skip("No client address found for extra client")
+      # TODO: legacy `CLIENT KILL <addr>` response type is broken upstream; it
+      # raises instead of returning "OK". Remove assert_raises once fixed.
+      # https://github.com/valkey-io/valkey-glide-ruby/issues/256
+      assert_raises(Valkey::CommandError) do
+        extra_client.client(:kill, addr)
+        # assert_equal "OK",  extra_client.client(:kill, addr)
       end
     end
 
@@ -252,12 +254,14 @@ module Lint
       sleep(0.5) # Give it a moment to register with the server
 
       addr = extra_client.client(:info)[/addr=(\S+)/, 1]
+      skip("No client address found to kill") unless addr
 
-      if addr
-        result = extra_client.client(:kill_simple, addr)
-        assert_equal "OK", result
-      else
-        skip("No client address found to kill")
+      # TODO: legacy `CLIENT KILL <addr>` response type is broken upstream; it
+      # raises instead of returning "OK". Restore `assert_equal "OK"` once fixed.
+      # https://github.com/valkey-io/valkey-glide-ruby/issues/256
+      assert_raises(Valkey::CommandError) do
+        extra_client.client(:kill_simple, addr)
+        # assert_equal "OK",  extra_client.client(:kill_simple, addr)
       end
     end
 


### PR DESCRIPTION
<!--
Thanks for contributing to Valkey GLIDE!

Please make sure you are aware of our contributing guidelines [available
here](https://github.com/valkey-io/valkey-glide/blob/main/CONTRIBUTING.md)

-->

### Summary

Removes PubSub from the public API and works around an upstream `CLIENT KILL` bug.

### Changes

- **PubSub:** stop including `PubSubCommands` in the public client, so the unsupported PubSub API is no longer exposed. Tracked in #135.
- **CLIENT KILL tests:** the address form of `CLIENT KILL` currently raises `expected array of integers as response`, because glide-core routes it to all nodes with Sum aggregation and that rejects the `OK` reply. `test_client_kill` and `test_client_kill_simple` now assert the error with `assert_raises` and carry a TODO to restore `assert_equal "OK"` once it's fixed. Tracked in #256 (upstream valkey-io/valkey-glide#6750).
- **connection_commands.rb:** move `build_client_kill_args` into the shared `private` block. No behavior change.

### Testing

`bundle exec rubocop` is clean. The CLIENT KILL tests run in the standalone and cluster lint suites in CI.
