### PR TITLE
docs: clean up docstrings and drop redis-rb compatibility mentions

### DIFF
--- a/.github/json_matrices/build-matrix.json
+++ b/.github/json_matrices/build-matrix.json
@@ -38,7 +38,7 @@
     {
         "OS": "macos",
         "NAMED_OS": "darwin",
-        "RUNNER": "macos-latest",
+        "RUNNER": "macos-14",
         "ARCH": "arm64",
         "TARGET": "aarch64-apple-darwin",
         "languages": ["ruby"]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides AI agents and developers with the minimum but sufficient cont
 
 ## Repository Overview
 
-This is the **Ruby client** for Valkey GLIDE, published as the `valkey-glide-rb` gem. It provides a synchronous, redis-rb-compatible API on top of the Rust GLIDE core via FFI.
+This is the **Ruby client** for Valkey GLIDE, published as the `valkey-glide-rb` gem. It provides a synchronous API on top of the Rust GLIDE core via FFI.
 
 **Primary Languages:** Ruby, Rust (FFI native library, built separately from [valkey-glide](https://github.com/valkey-io/valkey-glide))
 
@@ -20,7 +20,7 @@ This is the **Ruby client** for Valkey GLIDE, published as the `valkey-glide-rb`
 - `lib/valkey/opentelemetry.rb` — Native OTel configuration
 - `test/valkey/` — Standalone integration tests
 - `test/cluster/` — Cluster integration tests
-- `test/lint/` — redis-rb compatibility lint suites
+- `test/lint/` — Lint suites
 
 ## Architecture Quick Facts
 
@@ -28,7 +28,7 @@ This is the **Ruby client** for Valkey GLIDE, published as the `valkey-glide-rb`
 
 **Client Types:** `Valkey` — standalone or cluster (`cluster_mode: true`)
 
-**API Style:** Synchronous, blocking calls (redis-rb style)
+**API Style:** Synchronous, blocking calls.
 
 **Communication:** Direct FFI (`Bindings.command`, `Bindings.batch`)
 
@@ -165,7 +165,7 @@ cargo fmt --manifest-path ./Cargo.toml --all
 - **Ruby 2.6+ Required:** Minimum per `valkey.gemspec`
 - **FFI dependency:** `ffi ~> 1.17.0` — do not break ABI without rebuilding native lib
 - **Synchronous only:** No async client in this repo; do not add EventMachine/async patterns without design review
-- **redis-rb compatibility:** Prefer matching redis-rb method signatures and return types when implementing commands
+- **redis-rb conventions:** Prefer matching redis-rb method signatures and return types when implementing commands for familiarity.
 - **Command args:** All FFI args are strings; convert types in Ruby before `send_command`
 - **Pipeline transactions:** `MULTI`/`EXEC`/`DISCARD` in `pipelined` use sequential fallback — do not remove without fixing FFI batch stability
 - **OpenTelemetry:** Init once per process via `Valkey::OpenTelemetry.init`; spans created in FFI layer
@@ -220,10 +220,10 @@ valkey-glide-ruby/
 ## Quick Facts for Reasoners
 
 **Package:** `valkey-glide-rb` on RubyGems  
-**API Style:** Synchronous, redis-rb-compatible  
+**API Style:** Synchronous. 
 **Client:** `Valkey.new` — standalone or `cluster_mode: true`  
 **Key Features:** Pipelining, OpenTelemetry (native), statistics, TLS, URL parsing, cluster routing  
-**Testing:** Minitest + rake tasks; lint suites for redis-rb parity  
+**Testing:** Minitest + rake tasks; lint suites.
 **Core repo:** [valkey-glide](https://github.com/valkey-io/valkey-glide) (`ffi/`, `glide-core/`)  
 **This repo:** [valkey-glide-ruby](https://github.com/valkey-io/valkey-glide-ruby)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-Valkey GLIDE Ruby (`valkey-glide-rb`) is the official Ruby binding for Valkey and Redis OSS. It uses the shared Rust **glide-core** driver via the **glide-ffi** C library, with a redis-rb-compatible Ruby API. This repository is separate from the [valkey-glide](https://github.com/valkey-io/valkey-glide) mono-repo (Python, Java, Node, Go).
+Valkey GLIDE Ruby (`valkey-glide-rb`) is the official Ruby binding for Valkey and Redis OSS. It uses the shared Rust **glide-core** driver via the **glide-ffi** C library. This repository is separate from the [valkey-glide](https://github.com/valkey-io/valkey-glide) mono-repo (Python, Java, Node, Go).
 
 ## Hard Constraints (non-negotiable)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # Valkey GLIDE for Ruby
 
-Valkey General Language Independent Driver for the Enterprise (GLIDE) is the official open-source Valkey client library, proudly part of the [Valkey](https://valkey.io) organization. The Ruby gem (`valkey-glide-rb`) wraps [Valkey GLIDE Core](https://github.com/valkey-io/valkey-glide) with an interface similar to [redis-rb](https://github.com/redis/redis-rb), delivering GLIDE performance, reliability, and enterprise features.
+Valkey General Language Independent Driver for the Enterprise (GLIDE) is the official open-source Valkey client library, proudly part of the [Valkey](https://valkey.io) organization. The Ruby gem (`valkey-glide-rb`) wraps [Valkey GLIDE Core](https://github.com/valkey-io/valkey-glide), delivering GLIDE performance, reliability, and enterprise features.
 
 ## Why Choose Valkey GLIDE?
 
@@ -10,7 +10,6 @@ Valkey General Language Independent Driver for the Enterprise (GLIDE) is the off
 - **Performance**: Optimized for high performance and low latency via the Rust-based GLIDE core.
 - **High Availability**: Cluster-aware routing, reconnection, and fault tolerance.
 - **Cross-Language Consistency**: Same core driver as Python, Java, Node.js, and Go clients.
-- **Drop-in Replacement**: Familiar redis-rb-style API (`Valkey.new`, command methods, `pipelined`, URL parsing).
 - **Observability**: Native OpenTelemetry tracing and client statistics.
 
 ## Documentation
@@ -87,7 +86,7 @@ client.get("mykey")
 client.close
 ```
 
-### Standalone with URL (redis-rb compatible)
+### Standalone with URL
 
 Accepted URL schemes: `redis://`, `rediss://` (TLS), `valkey://`, `valkeys://` (TLS).
 
@@ -328,17 +327,17 @@ See https://github.com/valkey-io/valkey-glide-ruby/issues/135
 | `lib/valkey/pipeline.rb` | Pipeline command batching |
 | `test/valkey/` | Standalone integration tests |
 | `test/cluster/` | Cluster integration tests |
-| `test/lint/` | Shared lint tests (redis-rb compatibility patterns) |
+| `test/lint/` | Shared lint tests (redis-rb convention patterns) |
 
-## redis-rb Compatibility
+## API Conventions
 
-This client mirrors redis-rb conventions where possible:
+This client is **not** a drop-in replacement for redis-rb, but it follows familiar Ruby conventions to ease adoption:
 
 - `Valkey.new` with `url`, `host`, `port`, `db`, `ssl_params`
-- Command method names and argument ordering aligned with redis-rb
+- Conventional command method names and argument ordering
 - `pipelined`, `multi` / `exec`, `disconnect!` (alias of `close`)
 
-Not every redis-rb API is implemented yet. See the [command implementation wiki](https://github.com/valkey-io/valkey-glide-ruby/wiki/The-implementation-status-of-the-Valkey-commands) for coverage.
+APIs and behavior may differ from redis-rb; verify against your usage. See the [command implementation wiki](https://github.com/valkey-io/valkey-glide-ruby/wiki/The-implementation-status-of-the-Valkey-commands) for coverage.
 
 ## Building and Testing
 

--- a/README.md
+++ b/README.md
@@ -31,20 +31,17 @@ Valkey General Language Independent Driver for the Enterprise (GLIDE) is the off
 ### System Requirements
 
 - glibc 2.17+ or musl 1.2.3+
-- Ruby 2.6+
+- Ruby 3.0+
 
 #### Supported OS
 
-The following platforms have been tested:
-- Ubuntu 24
-- Alpine Linux 3
-- macOS 14 (Apple silicon / ARM)
+The following platforms are tested in CI:
+- Ubuntu 24 (x86_64 and arm64)
+- Alpine Linux 3 (x86_64 and arm64, via musl targets)
+- macOS 14+ (Apple silicon / arm64)
 
-**Notes:**
-* Other Linux distributions not mentioned here should work as long as they
-meet the glibc 2.17+ / musl 1.2.3+ requirement above.
-* Only Apple silicon (ARM) macOS is shipped, with a minimum of macOS 11. 
-Intel macOS users must build locally — see [build from source](./DEVELOPER.md).
+**Notes:** valkey-glide-rb gem only support ARM MacOS. For Intel Mac users
+you will need to build the client locally.
 
 ### Installation and Setup
 

--- a/lib/valkey/commands/connection_commands.rb
+++ b/lib/valkey/commands/connection_commands.rb
@@ -19,13 +19,13 @@ class Valkey
       # Ping the server.
       #
       # @param message [String, nil] optional message to echo back
-      # @param route [Valkey::Route, nil] cluster routing. When routed, may return a Hash of node => value.
-      # @return [String]
+      # @param route [Valkey::Route, nil] cluster routing.
+      # @return [String] `"PONG"`, or the echoed `message` if given.
       #
       # @example
-      #   ping             #=> "PONG"
-      #   ping("hello")    #=> "hello"
-      #   ping(route: Valkey::Route.all_nodes)  #=> Hash (multi-node)
+      #   ping                                  #=> "PONG"
+      #   ping("hello")                         #=> "hello"
+      #   ping(route: Valkey::Route.all_nodes)  #=> "PONG"
       def ping(message = nil, route: nil)
         send_command(RequestType::PING, [message].compact, route: route)
       end
@@ -33,8 +33,9 @@ class Valkey
       # Echo the given string.
       #
       # @param value [String]
-      # @param route [Valkey::Route, nil] cluster routing. When routed, may return a Hash of node => value.
-      # @return [String]
+      # @param route [Valkey::Route, nil] cluster routing. Default is a single random node.
+      #   A multi-node route returns a `Hash` of `"host:port" => reply`.
+      # @return [String, Hash{String => String}]
       def echo(value, route: nil)
         send_command(RequestType::ECHO, [value], route: route)
       end
@@ -87,8 +88,9 @@ class Valkey
 
       # Get the current client's ID.
       #
-      # @param route [Valkey::Route, nil] cluster routing. When routed, may return a Hash of node => value.
-      # @return [Integer]
+      # @param route [Valkey::Route, nil] cluster routing. Default is a single random node.
+      #   A multi-node route returns a `Hash` of `"host:port" => Integer`.
+      # @return [Integer, Hash{String => Integer}]
       def client_id(route: nil)
         send_command(RequestType::CLIENT_ID, [], route: route)
       end

--- a/lib/valkey/commands/function_commands.rb
+++ b/lib/valkey/commands/function_commands.rb
@@ -169,10 +169,10 @@ class Valkey
       #
       # @example Get function stats
       #   valkey.function_stats
-      #     # => {"running_script" => {...}, "engines" => {...}}
+      #     # => {"127.0.0.1:6379" => {"running_script" => nil, "engines" => {...}}}
       #
       # @param route [Valkey::Route, nil] cluster routing. When routed, may return a Hash of node => value.
-      # @return [Hash] function execution statistics
+      # @return [Hash{String => Hash}] a Hash keyed by `"host:port"`.
       #
       # @see https://valkey.io/commands/function-stats/
       def function_stats(route: nil)

--- a/lib/valkey/commands/list_commands.rb
+++ b/lib/valkey/commands/list_commands.rb
@@ -232,7 +232,8 @@ class Valkey
       #
       # @params timeout [Float] a float value specifying the maximum number of seconds to block) elapses.
       #   A timeout of zero can be used to block indefinitely.
-      # @params key [String, Array<String>] one or more keys with lists
+      # @params keys [String] one or more list keys, passed as separate arguments
+      #   (splat). To pass a pre-built array, splat it at the call site: `blmpop(1.0, *keys)`.
       # @params modifier [String]
       #  - when `"LEFT"` - the elements popped are those from the left of the list
       #  - when `"RIGHT"` - the elements popped are those from the right of the list
@@ -258,7 +259,8 @@ class Valkey
       #   valkey.lmpop('list', count: 2)
       #   #=> ['list', ['a', 'b']]
       #
-      # @params key [String, Array<String>] one or more keys with lists
+      # @params keys [String] one or more list keys, passed as separate arguments
+      #   (splat). To pass a pre-built array, splat it at the call site: `lmpop(*keys)`.
       # @params modifier [String]
       #  - when `"LEFT"` - the elements popped are those from the left of the list
       #  - when `"RIGHT"` - the elements popped are those from the right of the list
@@ -270,8 +272,6 @@ class Valkey
 
         args = [keys.size, *keys, modifier]
         args << "COUNT" << Integer(count) if count
-
-        # pp args
 
         send_command(RequestType::LMPOP, args)
       end

--- a/lib/valkey/commands/server_commands.rb
+++ b/lib/valkey/commands/server_commands.rb
@@ -37,8 +37,10 @@ class Valkey
       # Sends the CONFIG GET command with the given arguments.
       #
       # @param [Array<String>] args Configuration parameters to get
-      # @param route [Valkey::Route, nil] cluster routing. When routed, may return a Hash of node => value.
-      # @return [Hash, String]
+      # @param route [Valkey::Route, nil] cluster routing. Default is a single random node.
+      #   A multi-node route returns a `Hash` of `"host:port" => { parameter => value }`.
+      # @return [Hash] a flat `{ parameter => value }` Hash, or a per-node Hash under a
+      #   multi-node route.
       #
       # @example Get all configuration parameters
       #   config_get('*')
@@ -97,7 +99,8 @@ class Valkey
 
       # Return the number of keys in the selected database.
       #
-      # @param route [Valkey::Route, nil] cluster routing. When routed, may return a Hash of node => value.
+      # @param route [Valkey::Route, nil] cluster routing. Multi-node routes return the
+      #   aggregated sum across nodes, not a per-node Hash.
       # @return [Integer]
       def dbsize(route: nil)
         send_command(RequestType::DB_SIZE, [], route: route)
@@ -134,8 +137,11 @@ class Valkey
       # Get information and statistics about the server.
       #
       # @param cmd [String, Symbol, nil] section name (e.g. "commandstats")
-      # @param route [Valkey::Route, nil] cluster routing. When routed, may return a Hash of node => value.
-      # @return [Hash]
+      # @param route [Valkey::Route, nil] cluster routing. On cluster the default is all primaries,
+      #   so the reply is a per-node Hash even with no route. Standalone (or a single-node route)
+      #   returns a flat Hash.
+      # @return [Hash] a flat `{ field => value }` Hash, or a per-node
+      #   `{ "host:port" => { field => value } }` Hash under a multi-node route.
       def info(cmd = nil, route: nil)
         send_command(RequestType::INFO, [cmd].compact, route: route) do |reply|
           if reply.is_a?(Hash)
@@ -222,11 +228,14 @@ class Valkey
       # Return the server time.
       #
       # @example
-      #   r.time # => [ 1333093196, 606806 ]
+      #   r.time # => ["1333093196", "606806"]
       #
-      # @param route [Valkey::Route, nil] cluster routing. When routed, may return a Hash of node => value.
-      # @return [Array<Integer>] tuple of seconds since UNIX epoch and
-      #   microseconds in the current second
+      # @param route [Valkey::Route, nil] cluster routing. Default is a single random node.
+      #   A multi-node route returns a `Hash` of `"host:port" => [seconds, microseconds]`.
+      # @return [Array<String>, Hash{String => Array<String>}] a two-element array of
+      #   seconds since UNIX epoch and microseconds in the current second (both as
+      #   strings), or a per-node Hash under a multi-node route. Call `.map(&:to_i)` on
+      #   the array elements for arithmetic.
       def time(route: nil)
         send_command(RequestType::TIME, [], route: route)
       end

--- a/lib/valkey/commands/string_commands.rb
+++ b/lib/valkey/commands/string_commands.rb
@@ -83,13 +83,11 @@ class Valkey
       #   - `:xx => true`: Only set the key if it already exist.
       #   - `:keepttl => true`: Retain the time to live associated with the key.
       #   - `:get => true`: Return the old string stored at key, or nil if key did not exist.
-      # @return [String, Boolean] `"OK"` or true, false if `:nx => true` or `:xx => true`
+      # @return [String, nil] `"OK"` on write; `nil` when `:nx` or `:xx` skipped the write.
       def set(key, value, ex: nil, px: nil, exat: nil, pxat: nil, nx: nil, xx: nil, keepttl: nil, get: nil)
-        # value.to_s (matching redis-rb): a non-String value (e.g. an Array,
-        # in test_set_and_get_with_non_string_value) must become ONE opaque
-        # value here, not get flattened as if it were a multi-value list -
-        # see build_command_args's flat_map fix for why this must happen
-        # before command_args is built, not be left to that generic layer.
+        # A non-String value (e.g. an Array) must become ONE opaque value here, not
+        # get flattened as if it were a multi-value list -- see build_command_args's
+        # flat_map fix for why this must happen before command_args is built.
         args = [key, value.to_s]
         args << "EX" << Integer(ex) if ex
         args << "PX" << Integer(px) if px
@@ -101,11 +99,6 @@ class Valkey
         args << "GET" if get
 
         send_command(RequestType::SET, args)
-        # if nx || xx
-        #   send_command(RequestType::SET, &Utils::BoolifySet))
-        # else
-        #   send_command(RequestType::SET, args)
-        # end
       end
 
       # Set the time to live in seconds of a key.

--- a/lib/valkey/commands/transaction_commands.rb
+++ b/lib/valkey/commands/transaction_commands.rb
@@ -175,31 +175,17 @@ class Valkey
         @queued_commands = []
       end
 
-      # Commands whose reply is boolean when run standalone (via native return-type
-      # coercion server-side), but arrives as a raw 0/1 integer inside an EXEC array,
-      # since that coercion is keyed by the single command actually being run - which,
-      # for a queued command, is EXEC itself, not the original command.
+      # Commands the server coerces to boolean by name, but which arrive as raw 0/1
+      # inside an EXEC array (glide-core keys coercion on the executed command - EXEC -
+      # not the queued ones). Listed here so #reconvert_queued_replies can restore it.
       #
-      # This list mirrors glide-core's own Boolean-coercion table in
-      # `value_conversion.rs::expected_type_for_cmd` (HEXISTS, HSETNX, EXPIRE, EXPIREAT,
-      # PEXPIRE, PEXPIREAT, SISMEMBER, PERSIST, SMOVE, PFADD, RENAMENX, MOVE, COPY,
-      # MSETNX, XGROUP DESTROY, XGROUP CREATECONSUMER) MINUS the commands whose Ruby
-      # method already passes its own explicit conversion block (`hexists`/`hsetnx`
-      # use `&Utils::Boolify`; `xgroup_destroy`/`xgroup_createconsumer` use a custom
-      # bool->int block). Those are already handled correctly by the `if block`
-      # branch below, before this list is even consulted - listing them here too
-      # would be redundant, not wrong. Every RequestType below calls `send_command`
-      # with NO block at all, so this static list is the only place their boolean-ness
-      # is recorded.
+      # This is glide-core's boolean table (`value_conversion.rs::expected_type_for_cmd`)
+      # minus commands whose Ruby method passes its own conversion block - those are
+      # handled by the `if block` branch below. Only block-less RequestTypes belong here.
       #
-      # NOTE: SETNX is deliberately NOT in glide-core's coercion table (and so isn't
-      # here as a "no block" entry either) - it's `redis-rb`-style boolean-ness only,
-      # not something the server/`glide-core` treats as boolean, since coercion there
-      # is keyed by command name alone and can't distinguish this dedicated RequestType
-      # from a raw `customCommand(["SETNX", ...])` call, which other bindings' existing
-      # contracts expect to keep returning a plain integer. `setnx`'s own Ruby method
-      # passes `&Utils::Boolify` directly instead - see string_commands.rb - so it's
-      # already covered by the `if block` branch, same as hexists/hsetnx.
+      # SETNX is absent by design: glide-core doesn't treat it as boolean (name-keyed
+      # coercion can't distinguish it from a raw `customCommand(["SETNX", ...])`), so
+      # `setnx` passes `&Utils::Boolify` itself (string_commands.rb) - covered by `if block`.
       BOOLEAN_REQUEST_TYPES = [
         RequestType::EXPIRE, RequestType::EXPIRE_AT, RequestType::PEXPIRE, RequestType::PEXPIRE_AT,
         RequestType::PERSIST, RequestType::SISMEMBER, RequestType::S_MOVE, RequestType::PFADD,
@@ -208,11 +194,10 @@ class Valkey
 
       private
 
-      # Re-applies each queued command's own reply conversion (e.g. `&Utils::Boolify`)
-      # to EXEC's raw array, since redis-rb's Future-based design does the equivalent
-      # (a Future remembers its conversion and re-applies it once EXEC resolves), but
-      # queued commands here go through the plain single-command path with no such
-      # memory - see BOOLEAN_REQUEST_TYPES above for the case with no explicit block.
+      # Re-applies each queued command's reply conversion to EXEC's raw array: its own
+      # block if it had one, else Boolify for a BOOLEAN_REQUEST_TYPES command. Mirrors
+      # what redis-rb's Futures do (each remembers its conversion and re-applies it once
+      # EXEC resolves); glide's queued commands have no such memory, so we restore it here.
       def reconvert_queued_replies(result, queued_commands)
         return result unless result.size == queued_commands.size
 


### PR DESCRIPTION
## Description

Documentation-only cleanup ported to `release-1.0`, plus a small CI runner pin. No behavioral or API changes.

Cherry-picked from `alexl/agent/pubsub-client-privatize`:

- **doc: removed redis-rb compatibility mentions** — drop redis-rb parity framing from `AGENTS.md`, `CLAUDE.md`, and `README.md`.
- **fix: docstring function_stats** — correct the `function_stats` docstring in `function_commands.rb`.
- **updated docstrings** — clarify `route:` return-type behavior (single vs. multi-node `Hash`) and tidy examples across `connection_commands.rb`, `list_commands.rb`, `server_commands.rb`, `string_commands.rb`, and `transaction_commands.rb`.

Additional commit on this branch:

- **updated system requirements** —
  - README: bump documented minimum Ruby to 3.0+, expand Supported OS to reflect what CI actually covers (Ubuntu / Alpine x86_64 + arm64, macOS 14+ arm64), and simplify the Intel-Mac note.
  - CI: pin the macOS runner in `.github/json_matrices/build-matrix.json` from `macos-latest` to `macos-14` to match the documented tested platform and avoid surprise runner upgrades.

## Notes

- Doc/comment changes only, plus one CI matrix pin — no library logic touched.
- The `README.md` intro conflicted on cherry-pick; resolved to keep the redis-rb mention removed (the commit's intent).

## Testing

No runtime behavior changed; documentation and CI runner label only.