### PR TITLE
Bump minimum ruby version to 3.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 3.0
   NewCops: enable
   Exclude:
     - 'vendor/**/*'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ This is the **Ruby client** for Valkey GLIDE, published as the `valkey-glide-rb`
 - Alpine Linux 3.18+ (x86_64, aarch64) — musl libc
 - macOS: 13.7+ (x86_64), 14.7+ (aarch64)
 
-**Ruby Versions:** 2.6, 2.7, 3.0, 3.1, 3.2, 3.3, 3.4, JRuby (CI matrix)
+**Ruby Versions:** 3.0, 3.1, 3.2, 3.3, 3.4, JRuby (CI matrix)
 
 **Gem name:** `valkey-glide-rb` on RubyGems
 
@@ -162,7 +162,7 @@ cargo fmt --manifest-path ./Cargo.toml --all
 
 ### Ruby-Specific Rules
 
-- **Ruby 2.6+ Required:** Minimum per `valkey.gemspec`
+- **Ruby 3.0+ Required:** Minimum per `valkey.gemspec`
 - **FFI dependency:** `ffi ~> 1.17.0` — do not break ABI without rebuilding native lib
 - **Synchronous only:** No async client in this repo; do not add EventMachine/async patterns without design review
 - **redis-rb conventions:** Prefer matching redis-rb method signatures and return types when implementing commands for familiarity.

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -54,7 +54,7 @@ valkey-glide-ruby/
 
 ### Software Dependencies
 
-- **Ruby** 2.6+ (3.x recommended for development)
+- **Ruby** 3.0+
 - **Bundler**
 - **git**
 - **Valkey** or Redis OSS (for integration tests)
@@ -352,8 +352,8 @@ GitHub Actions (`.github/workflows/ci.yml`):
 | Job | Matrix |
 |-----|--------|
 | `lint` | Ruby 3.3, RuboCop |
-| `standalone` | Ruby 2.6–3.4 + JRuby; Valkey 7.2, 8, 8.1 |
-| `cluster` | Ruby 2.6–3.4; grokzen/redis-cluster |
+| `standalone` | Ruby 3.0–3.4 + JRuby; Valkey 7.2, 8, 8.1 |
+| `cluster` | Ruby 3.0–3.4; grokzen/redis-cluster |
 
 ## Building the Gem Locally
 

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ source "https://rubygems.org"
 gemspec
 
 # irb dropped out of Ruby's default gems in 4.0; older rubies (down to the
-# gemspec's minimum of 2.6) already ship it and must not have a version pinned.
+# gemspec's minimum of 3.0) already ship it and must not have a version pinned.
 gem "irb" if RUBY_VERSION >= "4.0"
 
 gem "rake", "~> 13.0"

--- a/lib/valkey.rb
+++ b/lib/valkey.rb
@@ -46,7 +46,7 @@ class Valkey
     if options[:url]
       url_options = Utils.parse_redis_url(options[:url])
       # Merge URL options, but explicit options take precedence
-      options = url_options.merge(options.reject { |k, _v| k == :url })
+      options = url_options.merge(options.except(:url))
     end
 
     # Extract connection parameters

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -33,11 +33,11 @@ CLUSTER_NODES = 6.times.map do |i|
   { host: "127.0.0.1", port: 7000 + i }
 end
 
-Dir[File.expand_path("lint/**/*.rb", __dir__)].sort.each do |f|
+Dir[File.expand_path("lint/**/*.rb", __dir__)].each do |f|
   require f
 end
 
 # Load valkey shared test modules
-Dir[File.expand_path("valkey/**/*.rb", __dir__)].sort.each do |f|
+Dir[File.expand_path("valkey/**/*.rb", __dir__)].each do |f|
   require f
 end

--- a/valkey.gemspec
+++ b/valkey.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.summary = "A Ruby client library for Valkey"
   spec.description = "A Ruby client library for Valkey"
   spec.homepage = "https://github.com/valkey-io/valkey-glide-ruby"
-  spec.required_ruby_version = ">= 2.6.0"
+  spec.required_ruby_version = ">= 3.0.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage


### PR DESCRIPTION
### Summary
This PR updated the minimum gemspec to correctly reflects our minimum Ruby 3.0