### PR TITLE
Support Ruby 2.7 (backport from v1.0.0)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -68,3 +68,12 @@ Metrics/ModuleLength:
     - 'lib/valkey/bindings.rb'
     - 'lib/valkey/opentelemetry.rb'
     - 'test/**/*.rb'
+
+# This gem is backported to run on Ruby 2.7 (see required_ruby_version in
+# valkey.gemspec), while TargetRubyVersion stays at 3.0 for general style.
+# The two cops below assume the gem's minimum Ruby is 3.0, which isn't true here.
+Style/HashExcept:
+  Enabled: false   # Hash#except is Ruby 3.0+; we use Hash#reject to stay 2.7-compatible
+
+Gemspec/RequiredRubyVersion:
+  Enabled: false   # required_ruby_version (>= 2.6) is intentionally below TargetRubyVersion

--- a/lib/valkey.rb
+++ b/lib/valkey.rb
@@ -45,8 +45,9 @@ class Valkey
     # Parse URL if provided
     if options[:url]
       url_options = Utils.parse_redis_url(options[:url])
-      # Merge URL options, but explicit options take precedence
-      options = url_options.merge(options.except(:url))
+      # Merge URL options, but explicit options take precedence.
+      # `reject` (not Hash#except, which is Ruby 3.0+) keeps this Ruby 2.7 compatible.
+      options = url_options.merge(options.reject { |k, _| k == :url })
     end
 
     # Extract connection parameters

--- a/valkey.gemspec
+++ b/valkey.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.summary = "A Ruby client library for Valkey"
   spec.description = "A Ruby client library for Valkey"
   spec.homepage = "https://github.com/valkey-io/valkey-glide-ruby"
-  spec.required_ruby_version = ">= 3.0.0"
+  spec.required_ruby_version = ">= 2.6.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage
@@ -29,5 +29,7 @@ Gem::Specification.new do |spec|
   end + Dir.glob("lib/valkey/native/**/*").reject { |f| File.directory?(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "ffi", "~> 1.17.0"
+  # ffi 1.17 dropped Ruby 2.7 (its required_ruby_version is >= 3.0), so 2.7
+  # installs resolve to ffi 1.16.x while 3.x installs pick up 1.17+ automatically.
+  spec.add_dependency "ffi", "~> 1.16"
 end


### PR DESCRIPTION
### Summary
Support for Ruby 2.7, from v1.0.0

### Issue link
Closes #221

### Features / Changes
- ffi gem 1.17.0 to 1.16 and updating required_ruby_version to 2.6.0
- Remove the usage of Hash#except

### Testing

### Checklist

Before submitting the PR make sure the following are checked:

-   [x] This Pull Request is related to one issue.
-   [x] Commit message has a detailed description of what changed and why.
-   [ ] Tests are added or updated.
-   [ ] Documentation is updated (if applicable).
-   [ ] Linters have been run (`bundle exec rubocop`) and pass.
-   [ ] Destination branch is correct - main
