### PR TITLE
fix(ci): version lock Rust and zigbuild

### DIFF
--- a/.github/actions/install-zigbuild/action.yml
+++ b/.github/actions/install-zigbuild/action.yml
@@ -1,38 +1,28 @@
 name: Install zig and cargo-zigbuild
 description: >
-  Install pinned zig + cargo-zigbuild for cross-compiling the linux-gnu native
-  libraries against an glibc 2.17.
+  Install pinned zig + cargo-zigbuild via pip for cross-compiling the linux-gnu
+  native libraries. Versions are locked here; bump them in this file.
 
-  Assumes a Linux x86_64/aarch64 runner.
-
-inputs:
-  rust-target:
-    description: >
-      Optional Rust target triple to `rustup target add`.
-    required: false
-    default: ""
+  cargo-zigbuild's PyPI package depends on ziglang, and cargo-zigbuild locates
+  zig through `python3 -m ziglang`, so no zig binary needs to be on PATH. The
+  caller gates this to linux-gnu targets, so python3 + pip are always present
+  (Ubuntu runners).
 
 runs:
   using: composite
   steps:
-    - name: Install zig and cargo-zigbuild
+    - name: Install zig and cargo-zigbuild (pinned, pip)
       shell: bash
       env:
-        ZIG_VERSION: "0.13.0"
-        CARGO_ZIGBUILD_VERSION: "0.20.1"
-        RUST_TARGET: ${{ inputs.rust-target }}
+        CARGO_ZIGBUILD_VERSION: "0.23.1"
+        ZIGLANG_VERSION: "0.13.0"
       run: |
         set -euo pipefail
-        ARCH="$(uname -m)"
-        curl -fsSL "https://ziglang.org/download/${ZIG_VERSION}/zig-linux-${ARCH}-${ZIG_VERSION}.tar.xz" \
-          | sudo tar -xJ -C /usr/local
-        sudo ln -sf "/usr/local/zig-linux-${ARCH}-${ZIG_VERSION}/zig" /usr/local/bin/zig
-        curl -fsSL "https://github.com/rust-cross/cargo-zigbuild/releases/download/v${CARGO_ZIGBUILD_VERSION}/cargo-zigbuild-v${CARGO_ZIGBUILD_VERSION}.${ARCH}-unknown-linux-musl.tar.gz" \
-          | sudo tar -xz -C /usr/local/bin
-        if [[ -n "${RUST_TARGET}" ]]; then
-          rustup target add "${RUST_TARGET}"
-        fi
-        zig version
-        # `cargo zigbuild` dispatches to `cargo-zigbuild zigbuild`, whose
-        # subcommand has no --version flag; query the binary directly.
+        python3 -m pip install "cargo-zigbuild==${CARGO_ZIGBUILD_VERSION}" "ziglang==${ZIGLANG_VERSION}"
+        # cargo-zigbuild's console script lands in the pip user bin; put it on
+        # PATH so later steps (cargo zigbuild) can find it.
+        USER_BIN="$(python3 -m site --user-base)/bin"
+        echo "${USER_BIN}" >> "$GITHUB_PATH"
+        export PATH="${USER_BIN}:${PATH}"
         cargo-zigbuild --version
+        python3 -m ziglang version

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,6 +12,7 @@ on:
       - lib/**
       - test/**
       - valkey-glide/ffi/**
+      - .github/actions/**
       - .github/workflows/**
       - .github/json_matrices/**
       - Gemfile
@@ -140,13 +141,14 @@ jobs:
         with:
           submodules: recursive
 
-      # Composite actions from the valkey-glide submodule use relative paths
-      # (vs reusable workflows which use org/repo/path@ref syntax)
-      - name: Install Rust
-        uses: ./valkey-glide/.github/actions/install-rust
+      - name: Install Rust (pinned)
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
-          target: ${{ matrix.host.TARGET }}
+          toolchain: "1.98.0"
+          targets: ${{ matrix.host.TARGET }}
 
+      # Composite action from the valkey-glide submodule uses a relative path
+      # (vs reusable workflows which use org/repo/path@ref syntax)
       - name: Install protoc
         uses: ./valkey-glide/.github/actions/install-protoc
         with:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -89,8 +89,11 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+      - name: Install Rust (pinned)
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: "1.98.0"
+          targets: ${{ matrix.host.TARGET }}
 
       - name: Install protoc (protobuf)
         uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
@@ -137,8 +140,6 @@ jobs:
       - name: Install zig and cargo-zigbuild (linux-gnu)
         if: contains(matrix.host.TARGET, 'linux-gnu')
         uses: ./.github/actions/install-zigbuild
-        with:
-          rust-target: ${{ matrix.host.TARGET }}
 
       - name: Build native library
         working-directory: valkey-glide/ffi


### PR DESCRIPTION
### Summary

Unpinned Rust hit 1.98.0, which emits `-Wl,--fix-cortex-a53-843419` on aarch64. Our pinned cargo-zigbuild 0.20.1 rejects it, so the arm64 link fails. Fix: pin Rust and the zig toolchain.

- Rust 1.98.0 (stable ~2026-08-18) added the arg (rust-lang/rust#155453); cargo-zigbuild 0.23.0+ filters it.
- arm64 only; macOS/musl use plain `cargo build`.
- CI-only, no CHANGELOG.

### Issue link

None. CI regression from Rust stable drift (rust-lang/rust#155453).

### Changes

- Pin Rust to `1.98.0` via `dtolnay/rust-toolchain` (ci.yml + cd.yml).
- Pin zig `0.13.0` + cargo-zigbuild `0.23.1` via pip in `install-zigbuild`.
- Add `.github/actions/**` to CI's `pull_request` paths so action changes trigger CI.

### Limitations

- Pinned versions bumped by hand (Dependabot can).
- musl test job + local dev still on unpinned rustup; a `rust-toolchain.toml` would cover them.

### Testing

- CI runs the previously-failing arm64 build.
- cd.yml is release-triggered, so this PR doesn't exercise it.

### Checklist

Before submitting the PR make sure the following are checked:

- [ ] This Pull Request is related to an issue.
- [x] Commit message describe your changes
- [x] Commits are signed off (`git commit -s`) per the DCO.
- [ ] Tests are added or updated.
- [ ] CHANGELOG.md and documentation files are updated.
- [x] Linters have been run (`bundle exec rubocop`) and pass.
- [x] Destination branch is correct - main.
